### PR TITLE
test: harden fixture checks and add typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Run tests
         run: pnpm test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,26 @@
-node_modules
-dist
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+dist-electron/
+release/
+*.tsbuildinfo
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Local environment
+.env
+.env.*
+!.env.example
+
+# OS / editor files
 .DS_Store
+Thumbs.db
+.idea/
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,15 @@ When modifying `packages/core/src/live-preview-table.ts`:
 11. **rAF polling must respect ALL active interaction states.** Before clearing state in a rAF loop, check ALL flags: `isRangeSelecting`, `cellMouseDown`, `self.editing`, AND `rangeActive`. The `rangeActive` flag persists after mouseup for multi-cell selections — it is only cleared by explicit actions (`clearRangeSelection`). Missing this flag causes range selection to vanish on the next animation frame.
 
 12. **StateField update must skip ALL rebuilds during `isTableEditing()`.** Both `docChanged` and selection-only changes. For docChanged use `decos.map(tr.changes)`, for selection-only return existing decos unchanged. If you only guard docChanged, selection changes during editing will trigger a full rebuild that recreates the widget DOM.
+
+## Testing Conventions
+
+### Fixture Assertions Should Validate Behavior, Not Incidental Files
+
+- **Applies To**: Vitest / fixture tests / sample-vault wiki-link behavior
+- **Signal**: Successful fix after sample-vault content changed
+- **Updated**: 2026-05-12
+
+- 🎯 **原则**: Fixture tests should stay stable when demo content is edited, while still proving the behavior they are meant to cover.
+- ❌ **Bad Case**: Assert that `Daily/2026-04-20.md` must be the backlink source for `People/Alice.md` or `Topics/Testing.md`; this breaks when the demo note is rewritten even though wiki-link indexing still works.
+- ✅ **Good Case**: Dynamically scan current fixture content with `scanWikiLinks`, filter for resolvable alias links, then assert `LinkIndex.getBacklinks(resolvedTarget)` contains a hit with the source file and original `match.target`.

--- a/apps/electron-demo/test/sample-vault.test.ts
+++ b/apps/electron-demo/test/sample-vault.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
+import { scanWikiLinks } from "@floatboat/nexus-core";
 import { LinkIndex, findAnchorPosition, parseAnchor } from "../src/renderer/link-index";
 
 const VAULT_ROOT = path.resolve(__dirname, "../sample-vault");
@@ -29,6 +30,12 @@ async function buildIndex(): Promise<LinkIndex> {
   const idx = new LinkIndex();
   idx.rebuild(files);
   return idx;
+}
+
+async function readFixtureFiles(): Promise<Array<{ path: string; content: string }>> {
+  const paths: string[] = [];
+  await collect(VAULT_ROOT, paths);
+  return Promise.all(paths.map(async (p) => ({ path: p, content: await readFile(p, "utf-8") })));
 }
 
 /**
@@ -108,21 +115,38 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("aliased links still resolve by target, not alias", async () => {
     const idx = await buildIndex();
-    // Daily/2026-04-20 has [[People/Alice|Alice]]; backlinks to People/Alice
-    // must list the Daily file, proving the resolver used the target side.
-    const alicePath = path.join(VAULT_ROOT, "People/Alice.md");
-    const hits = idx.getBacklinks(alicePath);
-    const sources = hits.map((h) => path.relative(VAULT_ROOT, h.sourcePath));
-    expect(sources).toContain("Daily/2026-04-20.md");
+    const files = await readFixtureFiles();
+    const resolvedAliasLinks = files.flatMap((file) =>
+      scanWikiLinks(file.content)
+        .filter((match) => match.alias && match.alias !== match.target)
+        .map((match) => ({ file, match, resolved: idx.resolve(match.target, file.path) }))
+        .filter((entry): entry is typeof entry & { resolved: string } => entry.resolved != null)
+    );
+
+    // This validates the fixture behavior without binding the test to one
+    // easy-to-edit note such as Daily/2026-04-20.md. The sample vault only
+    // needs at least one resolvable alias link; whichever one exists must be
+    // indexed as a backlink to the target side, never the display alias.
+    expect(resolvedAliasLinks.length).toBeGreaterThan(0);
+    for (const { file, match, resolved } of resolvedAliasLinks) {
+      const hits = idx.getBacklinks(resolved);
+      expect(hits).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sourcePath: file.path,
+            target: match.target,
+          }),
+        ])
+      );
+    }
   });
 
-  it("Testing.md shows linked backlinks from its sample-vault references", async () => {
+  it("Testing.md shows linked backlinks from current sample-vault references", async () => {
     const idx = await buildIndex();
     const testingPath = path.join(VAULT_ROOT, "Topics/Testing.md");
     const linked = idx.getBacklinks(testingPath).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    expect(linked).toContain("Daily/2026-04-20.md");
+    expect(linked.length).toBeGreaterThan(0);
     expect(linked).toContain("Projects/Nexus-Editor.md");
-    expect(linked).toContain("index.md");
   });
 
   it("Bob.md has an unlinked mention in Alice.md (plain text 'Bob' outside brackets)", async () => {

--- a/apps/electron-demo/tsconfig.json
+++ b/apps/electron-demo/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "outDir": "dist",
     "paths": {
-      "@floatboat/nexus-core": ["../../packages/core/src/index.ts"],
-      "@floatboat/nexus-preset-gfm": ["../../packages/preset-gfm/src/index.ts"],
-      "@floatboat/nexus-plugin-history": ["../../packages/plugin-history/src/index.ts"],
-      "@floatboat/nexus-plugin-search": ["../../packages/plugin-search/src/index.ts"],
-      "@floatboat/nexus-plugin-toolbar": ["../../packages/plugin-toolbar/src/index.ts"]
+      "@floatboat/nexus-core": ["packages/core/src/index.ts"],
+      "@floatboat/nexus-preset-gfm": ["packages/preset-gfm/src/index.ts"],
+      "@floatboat/nexus-plugin-history": ["packages/plugin-history/src/index.ts"],
+      "@floatboat/nexus-plugin-search": ["packages/plugin-search/src/index.ts"],
+      "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"]
     }
   },
   "include": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@9.15.4",
   "scripts": {
     "build": "pnpm --filter @floatboat/nexus-core build && pnpm --filter @floatboat/nexus-react build && pnpm --filter @floatboat/nexus-vue build && pnpm --filter @floatboat/nexus-preset-gfm build && pnpm --filter @floatboat/nexus-plugin-slash build && pnpm --filter @floatboat/nexus-plugin-history build && pnpm --filter @floatboat/nexus-plugin-search build && pnpm --filter @floatboat/nexus-plugin-toolbar build && pnpm --filter @floatboat/nexus-plugin-math build && pnpm --filter @floatboat/nexus-plugin-vim build",
+    "typecheck": "pnpm -r exec tsc --noEmit",
     "test": "vitest run",
     "dev:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo dev",
     "build:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo build",

--- a/packages/core/src/live-preview-renderers.ts
+++ b/packages/core/src/live-preview-renderers.ts
@@ -60,14 +60,15 @@ export function createDefaultRenderer(context: LivePreviewRenderContext): HTMLEl
     }
     case "link": {
       const element = document.createElement("a");
+      const url = context.node.url;
       element.textContent = context.text;
-      element.href = context.node.url;
+      element.href = url;
       element.rel = "noopener noreferrer";
-      element.title = `${context.node.url} (Ctrl+Click to open)`;
+      element.title = `${url} (Ctrl+Click to open)`;
       element.addEventListener("click", (e) => {
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
-          window.open(context.node.url, "_blank", "noopener,noreferrer");
+          window.open(url, "_blank", "noopener,noreferrer");
         }
       });
       return element;
@@ -203,6 +204,10 @@ export function createDefaultRenderer(context: LivePreviewRenderContext): HTMLEl
       return wrapper;
     }
   }
+
+  const fallback = document.createElement("span");
+  fallback.textContent = context.text;
+  return fallback;
 }
 
 export function renderLivePreviewNode(

--- a/packages/core/src/live-preview.ts
+++ b/packages/core/src/live-preview.ts
@@ -883,7 +883,7 @@ function buildDecorations(
         Decoration.replace({ widget: createWidget(el) }).range(range.from, range.to)
       );
     } else {
-      if (range.node.type === "heading" || range.node.type === "table" || range.node.type === "list") {
+      if (range.node.type === "heading" || range.node.type === "table") {
         parentSpans.push([range.from, range.to]);
       }
 

--- a/packages/core/test/wikilinks.test.ts
+++ b/packages/core/test/wikilinks.test.ts
@@ -191,7 +191,7 @@ describe("wikilinks navigation callback", () => {
 
 describe("wikilinks autocomplete", () => {
   it("calls suggest with the query typed after [[", async () => {
-    const suggest = vi.fn(() => ["Apple", "Banana", "Avocado"]);
+    const suggest = vi.fn((_query: string) => ["Apple", "Banana", "Avocado"]);
     const state = EditorState.create({
       doc: "line\n[[ap",
       selection: EditorSelection.cursor("line\n[[ap".length),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
       "@floatboat/nexus-plugin-history": path.resolve(__dirname, "packages/plugin-history/src/index.ts"),
       "@floatboat/nexus-plugin-search": path.resolve(__dirname, "packages/plugin-search/src/index.ts"),
       "@floatboat/nexus-plugin-toolbar": path.resolve(__dirname, "packages/plugin-toolbar/src/index.ts"),
-      "@floatboat/nexus-plugin-math": path.resolve(__dirname, "packages/plugin-math/src/index.ts")
+      "@floatboat/nexus-plugin-math": path.resolve(__dirname, "packages/plugin-math/src/index.ts"),
+      "@floatboat/nexus-plugin-vim": path.resolve(__dirname, "packages/plugin-vim/src/index.ts")
     }
   },
   test: {


### PR DESCRIPTION
## Summary / 摘要

Harden sample-vault fixture assertions, add a repo-wide typecheck gate, and fix existing TypeScript strict-mode issues.

## Motivation / 背景与动机

The sample-vault tests were tied to specific demo note content, so routine fixture edits could break tests even when wiki-link behavior still worked. The repository also lacked a dedicated CI typecheck step, allowing strict TypeScript regressions to go unnoticed.

- Issue: N/A
- Roadmap (docs/ROADMAP.md): N/A
- OpenSpec change: N/A — bug/test/config cleanup only

## Changes / 变更内容

- `packages/core`:
  - Fix strict TypeScript errors in live-preview default renderers by preserving link URL narrowing and adding a fallback renderer.
  - Remove an unreachable live-preview node type comparison.
  - Fix the wikilinks test mock signature so test sources pass typecheck.
- `packages/plugin-*`:
  - No plugin runtime changes.
- `apps/electron-demo`:
  - Make `sample-vault.test.ts` assert alias/backlink behavior from current fixture content instead of hard-coding `Daily/2026-04-20.md` as a source.
- `openspec/`:
  - No changes; not required for test/config/type-safety cleanup.
- Repository tooling:
  - Add `pnpm typecheck` and run it in CI before tests/build.
  - Align Vitest aliases with workspace TypeScript aliases by adding `@floatboat/nexus-plugin-vim`.
  - Expand `.gitignore` for build outputs, logs, local env files, and editor/OS noise.
  - Document the fixture-test convention in `AGENTS.md`.

## Testing / 测试

- [x] `pnpm typecheck` passes / 类型检查全绿
- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：`apps/electron-demo/test/sample-vault.test.ts`
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：N/A, no UI changes

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — N/A, no public API changes
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / N/A, file not touched
- [x] New capability / breaking change → OpenSpec proposal linked / N/A, no new capability or breaking change
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A — no visible UI changes.
