### PR TITLE
feat(slash): floating menu UI with ranking, result cap, and toolbar slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown preset (tables, strikethrough, task lists) |
 | `@floatboat/nexus-plugin-history` | Undo/redo with `Ctrl+Z` / `Ctrl+Shift+Z` |
 | `@floatboat/nexus-plugin-search` | Search and replace helpers |
-| `@floatboat/nexus-plugin-slash` | Slash command detection and filtering |
+| `@floatboat/nexus-plugin-slash` | Slash command detection, ranking, and a vanilla-DOM floating menu UI |
 | `@floatboat/nexus-plugin-toolbar` | Toolbar primitives for formatting commands |
 | `@floatboat/nexus-plugin-math` | Inline / block math rendering (KaTeX) |
 | `@floatboat/nexus-plugin-vim` | Vim keybindings powered by `@replit/codemirror-vim` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -175,7 +175,7 @@ pnpm dev:electron-demo
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown 预设（表格、删除线、任务列表） |
 | `@floatboat/nexus-plugin-history` | 撤销/重做，支持 `Ctrl+Z` / `Ctrl+Shift+Z` |
 | `@floatboat/nexus-plugin-search` | 搜索替换辅助函数 |
-| `@floatboat/nexus-plugin-slash` | 斜杠命令检测与过滤 |
+| `@floatboat/nexus-plugin-slash` | 斜杠命令检测、排序与 vanilla DOM 浮层菜单 UI |
 | `@floatboat/nexus-plugin-toolbar` | 工具栏基础组件与格式化命令 |
 | `@floatboat/nexus-plugin-math` | 行内 / 块级数学公式渲染（KaTeX） |
 | `@floatboat/nexus-plugin-vim` | Vim 键位（基于 `@replit/codemirror-vim`） |

--- a/apps/electron-demo/package.json
+++ b/apps/electron-demo/package.json
@@ -25,6 +25,7 @@
     "@floatboat/nexus-core": "workspace:*",
     "@floatboat/nexus-plugin-history": "workspace:*",
     "@floatboat/nexus-plugin-search": "workspace:*",
+    "@floatboat/nexus-plugin-slash": "workspace:*",
     "@floatboat/nexus-plugin-toolbar": "workspace:*",
     "@floatboat/nexus-preset-gfm": "workspace:*",
     "highlight.js": "^11.11.0"

--- a/apps/electron-demo/sample-vault/index.md
+++ b/apps/electron-demo/sample-vault/index.md
@@ -28,6 +28,10 @@ show a long list.
 - [[mermaid-demo]] — 7 种 mermaid 图表 + 语法错误兜底演示
 - [[image-demo]] — 本地图片 + Obsidian 风格 `|width` + hover chrome + drag-resize
 
+## Editor shortcuts
+
+- [[slash-demo]] — type `/` anywhere to open the floating command menu
+
 ## Edge cases
 
 - [[ghost-demo]] — try clicking the red dashed ghost link inside

--- a/apps/electron-demo/sample-vault/slash-demo.md
+++ b/apps/electron-demo/sample-vault/slash-demo.md
@@ -1,0 +1,37 @@
+# Slash menu demo
+
+Type a forward slash (`/`) on an empty line to open the floating
+command menu. The menu lists every command registered by the loaded
+plugins — out of the box the toolbar plugin contributes headings,
+bold, italic, lists, blockquote, links, images and a divider.
+
+## Walkthrough
+
+1. Place the caret at the end of this paragraph and press `Enter`.
+2. Type `/h2` — the menu narrows to **Heading 2**. Press `Enter` to
+   insert.
+3. Keep typing on the new line: `/list`. Two list commands surface
+   (bulleted + numbered). Use `↑` / `↓` to choose and `Enter` to
+   confirm.
+4. Try `/zzz` — the menu stays open with a muted *No matches* hint so
+   you know the trigger is still live. Press `Esc` to dismiss.
+
+## Ranking & limit
+
+Behind the scenes the engine ranks results by relevance. With many
+plugins installed the menu still caps at 8 entries so a long catalogue
+never paints below the viewport. You can change the cap with
+`createEditor({ slashMenuLimit: N })`.
+
+## Keyboard reference
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move highlight |
+| `Home` / `End` | Jump to first / last |
+| `Enter` / `Tab` | Confirm |
+| `Esc` | Dismiss |
+
+The menu is fully driven by `editor.on("slashMenuChange", ...)`, so a
+host that prefers a React or Vue component can ignore the bundled UI
+and render its own.

--- a/apps/electron-demo/src/renderer/editor-shell.ts
+++ b/apps/electron-demo/src/renderer/editor-shell.ts
@@ -8,6 +8,7 @@ import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
 import { createToolbarPlugin, createToolbarUI, type ToolbarUI } from "@floatboat/nexus-plugin-toolbar";
 import { createSearchPlugin } from "@floatboat/nexus-plugin-search";
+import { createSlashMenuUI, type SlashMenuUI } from "@floatboat/nexus-plugin-slash";
 import type { AppState } from "./state";
 import { type EditorSettings, settingsToTheme } from "./settings";
 
@@ -75,6 +76,8 @@ export interface EditorShellOptions {
 export interface EditorShell {
   editor: EditorAPI;
   toolbar: ToolbarUI;
+  /** The floating slash-command menu mounted on document.body. */
+  slashMenu: SlashMenuUI;
   applySettings(settings: EditorSettings): void;
   loadDocument(content: string): void;
   destroy(): void;
@@ -313,9 +316,15 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
   const toolbar = createToolbarUI(editor);
   container.insertBefore(toolbar.element, container.firstChild);
 
+  // The slash menu owns its own DOM root mounted on document.body so
+  // it can overflow the editor's clipping context (panels, scroll
+  // ancestors). Its lifecycle is tied to the shell — destroyed below.
+  const slashMenu = createSlashMenuUI(editor);
+
   return {
     editor,
     toolbar,
+    slashMenu,
     applySettings(next: EditorSettings) {
       editor.setTheme(settingsToTheme(next));
     },
@@ -338,6 +347,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
         `${(t1 - t0).toFixed(1)}ms`, { bytes: content.length });
     },
     destroy() {
+      slashMenu.destroy();
       toolbar.destroy();
       editor.destroy();
     },

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -99,3 +99,64 @@ body,
 .cm-editor .hljs-deletion { color: #dc322f; }
 .cm-editor .hljs-variable,
 .cm-editor .hljs-template-variable { color: #cb4b16; }
+
+/* ── Slash command menu ───────────────────────────────────────────
+   The menu is mounted on document.body via createSlashMenuUI so it
+   can overflow the editor's clipping context. We expose every visual
+   knob behind a CSS custom property so the host's theme (light/dark)
+   can override without re-implementing the layout.                 */
+
+.nexus-slash-menu {
+  --nexus-slash-bg: var(--nexus-bg, #ffffff);
+  --nexus-slash-border: var(--nexus-border, #e4e7eb);
+  --nexus-slash-text: var(--nexus-text, #24292e);
+  --nexus-slash-text-muted: var(--nexus-text-muted, #6e7681);
+  --nexus-slash-accent: var(--nexus-accent, #0969da);
+  --nexus-slash-active-bg: var(--nexus-bg-muted, #eaeef2);
+
+  min-width: 220px;
+  max-width: 320px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--nexus-slash-bg);
+  color: var(--nexus-slash-text);
+  border: 1px solid var(--nexus-slash-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  padding: 4px;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  z-index: 1000;
+}
+
+.nexus-slash-menu__item {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.nexus-slash-menu__item.is-active {
+  background: var(--nexus-slash-active-bg);
+}
+
+.nexus-slash-menu__title {
+  font-weight: 500;
+  color: var(--nexus-slash-text);
+}
+
+.nexus-slash-menu__description {
+  font-size: 12px;
+  color: var(--nexus-slash-text-muted);
+  margin-top: 1px;
+}
+
+.nexus-slash-menu__empty {
+  padding: 12px 10px;
+  color: var(--nexus-slash-text-muted);
+  font-style: italic;
+  text-align: center;
+}

--- a/apps/electron-demo/vite.config.ts
+++ b/apps/electron-demo/vite.config.ts
@@ -52,6 +52,10 @@ export default defineConfig({
         __dirname,
         "../../packages/plugin-search/src/index.ts"
       ),
+      "@floatboat/nexus-plugin-slash": path.resolve(
+        __dirname,
+        "../../packages/plugin-slash/src/index.ts"
+      ),
     },
   },
   server: {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,8 @@ This document maps every planned feature to **package ownership / priority / sta
 | 15 | Regex search | `plugin-search` | P1 | planned | No | Watch escape edge cases |
 | 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | planned | Yes | Needs persistence (localStorage or host-injected) |
 | 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib |
-| 3  | Slash command sorting + limit | `plugin-slash` | P0 | planned | No | Public API addition |
+| 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
+| 27 | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0 | done | Yes | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui` |
 
 ## 3. Core Editor
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -26,7 +26,8 @@
 | 15 | 正则搜索 | `plugin-search` | P1 | planned | 否 | 注意转义边界用例 |
 | 16 | 历史命令 / 搜索记忆 | `plugin-search` + `plugin-slash` | P2 | planned | 是 | 需要持久化层（localStorage 或宿主注入） |
 | 17 | 模糊搜索 | `plugin-search` | P2 | planned | 否 | 评估 fzf-like 算法 vs. 第三方 lib |
-| 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | planned | 否 | 公共 API 增量 |
+| 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | done | 是 | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui` |
+| 27 | Slash 命令浮层菜单 UI | `plugin-slash` + `electron-demo` | P0 | done | 是 | `createSlashMenuUI(editor, options)` —— 见 `openspec/changes/add-slash-menu-ui` |
 
 ## 3. Core Editor
 

--- a/openspec/changes/add-slash-menu-ui/design.md
+++ b/openspec/changes/add-slash-menu-ui/design.md
@@ -1,0 +1,120 @@
+# Design — Slash Command Floating Menu
+
+## Context
+
+The slash subsystem in this repository has two halves:
+
+1. **State machine** (`packages/core/src/slash-state.ts` + emission in `packages/core/src/editor.ts`): detects `/query` at the caret, filters command metadata, and emits `slashMenuChange` with caret coordinates from `view.coordsAtPos(...)`. This is fully working and unit-tested.
+2. **Plugin shell** (`packages/plugin-slash`): re-exports a near-duplicate of the same helpers plus a `createSlashPlugin(commands)` factory whose only job is to plant a `slashCommands` array on a `NexusPlugin`.
+
+What does not exist:
+- An executable `run` field on `SlashCommandDef` — host applications must keep their own `id → handler` registry.
+- A UI consumer of the `slashMenuChange` event.
+- Ranking / capping of the filtered list. With many registered commands the menu would either render everything or rely on lexicographic order; both are bad UX.
+- Any consumer (electron demo or framework binding) that actually registers slash commands. The `plugin-toolbar` already implements every formatting action as an `(editor) => boolean` function but never declares them as slash commands.
+
+`ROADMAP.md` row #3 — "Slash command sorting + limit" — has been parked as `P0 / planned` for the same reason: it cannot land in isolation while the surface is unused.
+
+## Goals / Non-Goals
+
+### Goals
+- Restore the round-trip: typing `/h2⏎` inserts a `## ` heading at the caret position in the electron demo.
+- Provide a single floating menu UI that is framework-agnostic, works in plain DOM, and is consumed identically from the React/Vue bindings once they pick it up.
+- Implement deterministic ranking + a configurable result cap so that hosts with 30+ commands stay responsive and predictable.
+- Allow each plugin to ship its slash commands self-contained (metadata + `run`) so the demo registers the toolbar without a side-band action map.
+- Keep the change backward compatible: every new field is optional; every existing test contract holds.
+
+### Non-Goals
+- Mobile / touch interactions (the demo is Electron desktop).
+- Slash menu rendering inside live-preview widgets such as table cells.
+- Persistent "recents" sorting (requires storage hooks not yet specified).
+- Replacing or unifying the duplicated `slash-state` helpers between `core` and `plugin-slash` — left in lock-step deliberately; future PR can DRY this up after `core` exports `computeSlashState`.
+
+## Decisions
+
+### Decision 1: Where does `run` live?
+
+Adopted: **Optional `run?: (editor: EditorAPI) => boolean | void` on `SlashCommandDef`**.
+
+Rationale:
+- Mirrors the existing `shortcuts: Array<{ key, run: (editor) => boolean }>` shape on `NexusPlugin`. Hosts already understand that pattern.
+- Stays optional so the existing tests (which pass commands without `run`) continue to pass.
+- The menu UI accepts a host-level `onCommand(cmd, ctx)` override; when neither is provided, the menu simply closes after replacing the trigger text — matching the headless principle.
+
+Alternatives considered:
+- A separate `slashHandlers` map on `NexusPlugin` keyed by `id`. Rejected: two arrays must stay in sync, more boilerplate at plugin authoring time.
+- Host-only action map. Rejected: the demo would have to duplicate every formatting helper signature, defeating the point of bundling slash commands inside `plugin-toolbar`.
+
+### Decision 2: Ranking algorithm
+
+Adopted: a deterministic five-tier score, computed in `O(commands)` per emission.
+
+```
+score(cmd, query):
+  q = query.toLowerCase()
+  title = cmd.title.toLowerCase()
+  if q is empty:                       return [0, registration_index]   (keep input order)
+  if title === q:                      return [500, 0]                  (exact)
+  if title.startsWith(q):              return [400, title.length]       (title prefix; shorter wins)
+  for kw in cmd.keywords:
+    if kw.toLowerCase() === q:         return [350, 0]                  (exact keyword)
+  if title.includes(q):                return [300, title.indexOf(q)]   (title substring; earlier wins)
+  for kw in cmd.keywords:
+    if kw.toLowerCase().startsWith(q): return [200, kw.length]          (keyword prefix)
+  for kw in cmd.keywords:
+    if kw.toLowerCase().includes(q):   return [100, kw.indexOf(q)]      (keyword substring)
+  return null                          (filter out)
+```
+
+Sorted descending by `score`, then ascending by tiebreaker, then ascending by title for stability. Pure function; no allocations beyond the result array; deterministic across runs (critical for snapshot-friendly tests).
+
+Alternatives considered:
+- **Fuzzy matching (fzy / fzf-style)**: powerful but introduces a dependency and a much higher cognitive load for a `P0` ticket whose name literally is "sorting + limit". Logged as a follow-up under ROADMAP P2 #17 ("Fuzzy search").
+- **Levenshtein distance**: slow on long titles; unnecessary given the prefix/substring tiers above already cover the common case.
+
+### Decision 3: Where does `limit` apply?
+
+Adopted: **In core (`computeSlashState`) with a default of 8**, configurable via `EditorConfig.slashMenuLimit`. The UI does not re-trim.
+
+Rationale: single source of truth. The `slashMenuChange` event always delivers exactly what the menu should render. Hosts that want a different cap configure the editor once.
+
+Alternative considered: limit lives on the UI. Rejected — splits the contract across two packages and forces hosts to override in two places.
+
+### Decision 4: Menu lifecycle
+
+The UI subscribes to `slashMenuChange` on construction and to `blur`/window `resize` for dismissal. It owns one DOM root attached to `document.body` (or the `container` option) and never reparents — only toggles `display`. Items are recycled across renders to keep CSS transitions stable.
+
+On confirm:
+1. Replace the document range `[state.from, state.to]` with the empty string via `editor.replaceSelection` after re-selecting that range. The trigger `/query` text is removed before the command runs, so commands like "insert heading" don't have to know about the slash trigger.
+2. Re-focus the editor.
+3. Call `cmd.run(editor)` if present; otherwise call `options.onCommand?.(cmd, ctx)`; otherwise no-op.
+4. Hide the menu.
+
+The replace step uses `view.dispatch` indirectly via the public `EditorAPI` — no internal CM6 leakage.
+
+### Decision 5: IME safety
+
+`compositionstart` and `compositionend` are wired on `document` (not just the menu) because the input target is the editor's `contentDOM`, not the menu DOM. While `isComposing` is true the menu suppresses `keydown` handling entirely; once composition ends, the next `slashMenuChange` will refresh state from the post-composition document. This matches the pattern proven in `wikilinks.ts` autocomplete.
+
+### Decision 6: Coordinate flipping
+
+Default placement: top edge of the menu aligns with `state.coords.bottom + 4px`, left edge with `state.coords.left`. If `menu.getBoundingClientRect().bottom > window.innerHeight - 8`, flip to `state.coords.top - menu.height - 4px`. Horizontal overflow on the right edge clamps the left coordinate (subtract overflow, min 8px). No "smart middle" placement — desktop screens have plenty of room.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Duplicated `slash-state` helpers in `core` and `plugin-slash` drift apart | Both ship with the same ranking suite; we add a regression test that exercises the same fixture against both copies. A follow-up PR can re-export from core. |
+| `view.coordsAtPos` returns null while the doc is mid-layout | Already guarded by `try/catch` in `editor.ts`; menu treats `coords === null` as "stay hidden this tick". |
+| Long command lists explode rendering | Default `limit: 8` plus `O(commands)` ranking keeps the worst case bounded for any realistic registration count. |
+| Confirming a command while live-preview replace decorations cover the trigger range | The trigger text `[from, to]` is always raw source (slash + query, never inside a widget), so the replace happens against source markdown and live-preview rebuilds on the next state update. Tested in `events.test.ts`. |
+| Menu key handlers steal `Tab` from the editor's `indentWithTab` keymap | Menu only swallows `Tab` when `isOpen === true`, otherwise CM6 receives it normally. |
+
+## Migration Plan
+
+None — pure addition. Existing editors without slash commands behave exactly as today. Existing tests pass without modification (the optional `run` field has no effect on the comparison-by-value test in `plugin-slash.test.ts`; the new ranking changes the order of filtered results, so we extend that test fixture to assert the new ordering explicitly).
+
+## Open Questions
+
+- Should the menu close automatically when the user clicks into a different `BrowserWindow`? Current decision: yes via the editor's existing `blur` event. Worth confirming with the maintainer.
+- Should `Tab` and `Enter` both confirm, or only `Enter`? Notion and Obsidian use both; VS Code only uses `Enter`. Going with both for muscle-memory parity; can be made configurable later.

--- a/openspec/changes/add-slash-menu-ui/proposal.md
+++ b/openspec/changes/add-slash-menu-ui/proposal.md
@@ -1,0 +1,58 @@
+# Change: Add Slash Command Floating Menu with Ranking and Limit
+
+## Why
+
+Core already computes a full slash-menu state (`slashMenuChange` event with `isOpen`, `from`, `to`, `query`, filtered `commands`, and `coords`), but the project ships **no UI** that consumes it: typing `/` in the electron demo produces zero feedback. The headless `plugin-slash` package exposes only metadata (`{ id, title, keywords }`) with no execution hook, so a host cannot run the picked command without maintaining its own `id → action` registry. The roadmap calls out `[#3 Slash command sorting + limit | plugin-slash | P0 | planned]` but neither sorting nor a cap on results is implemented today.
+
+This change closes the loop end-to-end: ranked commands, a capped result list, an executable `run` hook on each command, a framework-agnostic floating menu UI bundled in `@floatboat/nexus-plugin-slash`, and integration in the electron demo (including registering the existing `plugin-toolbar` formatting actions as slash commands).
+
+## What Changes
+
+- **Core (`@floatboat/nexus-core`)**:
+  - `SlashCommandDef` gains an optional `run?: (editor: EditorAPI) => boolean | void` field; existing consumers that pass only metadata keep working unchanged.
+  - `filterSlashCommands` now **ranks** matches deterministically (exact > title-prefix > title-substring > keyword-prefix > keyword-substring, ties broken by title length then alphabetically). Empty query keeps the original registration order.
+  - `computeSlashState` accepts an optional `{ limit }` option (default **8**) and trims the returned `commands` array.
+  - `EditorConfig.slashMenuLimit?: number` flows the limit through `createEditor` to `computeSlashState`.
+- **Plugin Slash (`@floatboat/nexus-plugin-slash`)**:
+  - Existing `filterSlashCommands` / `getSlashState` adopt the same ranking + limit so SDK consumers and the core event stay in lock-step.
+  - **New** `createSlashMenuUI(editor, options)` mounts a floating, framework-agnostic menu listening to `slashMenuChange`:
+    - Absolute-positioned overlay anchored to `state.coords`; viewport overflow → flip above the line.
+    - Keyboard: `↑` / `↓` move the highlight, `Enter` / `Tab` confirm, `Esc` closes, `Home` / `End` jump.
+    - Mouse: hover synchronises the highlight, click confirms, click-outside closes.
+    - IME-aware: skips synthetic events while `compositionstart`…`compositionend` is in flight.
+    - `role="listbox"` + `aria-activedescendant`; menu items expose `role="option"` and `aria-selected`.
+    - On confirm: replaces `state.from..state.to` (the `/query` slice) with an empty string and invokes the picked command's `run(editor)`, or delegates to a host-provided `onCommand(cmd, ctx)` override.
+  - `createSlashMenuUI` returns `{ element, destroy }`. The element is appended to `document.body` by default; a `container` option can mount elsewhere (e.g. for shadow-DOM hosts).
+- **Plugin Toolbar (`@floatboat/nexus-plugin-toolbar`)** registers a `slashCommands` array covering Heading 1–3, Bold, Italic, Strikethrough, Inline code, Blockquote, Bulleted list, Numbered list, Code block, Link, Image, and Horizontal rule. Each entry reuses the existing formatting helpers as its `run`.
+- **Electron demo (`apps/electron-demo`)** calls `createSlashMenuUI(editor)` in `editor-shell.ts`, ships menu styles in `style.css`, and adds a sample-vault note demonstrating the trigger.
+- **Docs**: `docs/ROADMAP.md` row #3 transitions to `done` and references this change id.
+
+No breaking changes: every public API addition is optional, and editors built without registered `slashCommands` continue to emit no `slashMenuChange` events.
+
+## Impact
+
+- Affected specs:
+  - `editor-core` (ADDED — ranking, limit, `run` callback, `slashMenuLimit` config)
+  - `slash-menu` (ADDED — new capability: floating UI behaviour, keyboard / mouse / a11y / IME / dismissal contracts)
+- Affected code:
+  - `packages/core/src/types.ts` (SlashCommandDef, EditorConfig)
+  - `packages/core/src/slash-state.ts` (ranking + limit)
+  - `packages/core/src/editor.ts` (wire limit, expose `run` execution hook)
+  - `packages/plugin-slash/src/index.ts` (ranking + limit mirror, re-export menu UI)
+  - `packages/plugin-slash/src/menu-ui.ts` (NEW)
+  - `packages/plugin-slash/test/plugin-slash.test.ts` (extend)
+  - `packages/plugin-slash/test/menu-ui.test.ts` (NEW)
+  - `packages/core/test/events.test.ts` (extend slashMenuChange suite)
+  - `packages/core/test/slash-state.test.ts` (NEW — direct ranking/limit unit tests)
+  - `packages/plugin-toolbar/src/index.ts` (register slash commands)
+  - `apps/electron-demo/src/renderer/editor-shell.ts` (mount menu UI)
+  - `apps/electron-demo/src/renderer/style.css` (menu styles)
+  - `apps/electron-demo/sample-vault/slash-demo.md` (NEW demo note)
+  - `docs/ROADMAP.md` (status + linkage)
+  - `README.md` / `README.zh.md` / `packages/plugin-slash/README.md` (public API examples)
+- New dev dependencies: none.
+- Out of scope (explicit non-goals):
+  - Slash command grouping / category headers (v2).
+  - Persistent "recently used" ordering across sessions (v2 — requires host storage adapter).
+  - Slash menu inside live-preview widgets (table cells, etc.); the menu only opens from the source editor selection (v2).
+  - Internationalisation of menu labels — the menu reuses each command's `title` verbatim, host owns translation.

--- a/openspec/changes/add-slash-menu-ui/specs/editor-core/spec.md
+++ b/openspec/changes/add-slash-menu-ui/specs/editor-core/spec.md
@@ -1,0 +1,73 @@
+# Editor Core Spec — Slash Command Ranking, Limit, and Run Hook
+
+## ADDED Requirements
+
+### Requirement: Slash Command Run Callback
+
+`SlashCommandDef` SHALL accept an optional `run` callback of the form `(editor: EditorAPI) => boolean | void`. When present, the host UI MAY invoke it to execute the command. Commands without a `run` callback SHALL continue to function as metadata-only entries, preserving full backward compatibility with consumers that rely on a host-side `id → action` registry.
+
+#### Scenario: Metadata-only command remains compatible
+- **WHEN** a plugin registers `{ id: "h1", title: "Heading 1" }` with no `run`
+- **THEN** `editor.getSlashCommands()` SHALL include the entry verbatim
+- **AND** `slashMenuChange` SHALL emit it as part of the filtered `commands` array unchanged
+
+#### Scenario: Executable command exposes run on the emitted entry
+- **WHEN** a plugin registers `{ id: "h1", title: "Heading 1", run: (e) => toggleHeading(e, 1) }`
+- **THEN** every emission of `slashMenuChange` SHALL carry that `run` reference on the matching command
+- **AND** the host UI invoking it with the editor SHALL toggle the current line into a level-1 heading
+
+### Requirement: Slash Command Ranking
+
+`filterSlashCommands(commands, query)` SHALL rank candidates deterministically by relevance, returning only matching entries. With an empty query the original registration order SHALL be preserved.
+
+The ranking tiers, highest to lowest:
+1. Exact case-insensitive title match.
+2. Title starts with the query (shorter titles rank above longer ones).
+3. Exact keyword match.
+4. Title contains the query (earlier offset ranks above later).
+5. Keyword starts with the query (shorter keyword wins).
+6. Keyword contains the query (earlier offset wins).
+
+Within the same tier, ties SHALL be broken alphabetically by title for stability.
+
+#### Scenario: Empty query keeps registration order
+- **WHEN** `filterSlashCommands` is called with an empty query against `[Heading, Table, Bold]`
+- **THEN** the returned order SHALL be `[Heading, Table, Bold]`
+
+#### Scenario: Title prefix beats keyword prefix
+- **WHEN** the registered commands are `[ {id: "highlight", title: "Highlight"}, {id: "heading", title: "Heading", keywords: ["h1"]} ]`
+- **AND** the query is `"h"`
+- **THEN** `Heading` SHALL appear before `Highlight` (both share the title-prefix tier; `Heading` is alphabetically first)
+
+#### Scenario: Exact title beats all
+- **WHEN** the commands are `[ {id: "table", title: "Table"}, {id: "tb", title: "TB", keywords: ["table"]} ]`
+- **AND** the query is `"table"`
+- **THEN** `Table` SHALL be ranked first (exact title) and `TB` second (exact keyword)
+
+#### Scenario: Non-matching commands are filtered out
+- **WHEN** no candidate has a title containing the query and no keyword contains it
+- **THEN** the result SHALL be an empty array
+
+### Requirement: Slash Menu Result Limit
+
+`computeSlashState(doc, cursor, commands, options?)` SHALL accept an optional `{ limit }` numeric option (default `8`) and trim the returned `commands` array to at most that many entries **after** ranking. `EditorConfig.slashMenuLimit` SHALL flow through to the same option inside `createEditor`.
+
+#### Scenario: Default limit caps the result at eight
+- **WHEN** `commands` contains 20 entries all matching the query
+- **AND** no explicit limit is supplied
+- **THEN** the returned `commands` array SHALL have length 8
+- **AND** SHALL contain the eight highest-ranked entries in ranked order
+
+#### Scenario: Explicit limit overrides the default
+- **WHEN** `computeSlashState(doc, cursor, commands, { limit: 3 })` is called against 10 matching entries
+- **THEN** the result SHALL have length 3
+
+#### Scenario: Limit of zero returns an empty list
+- **WHEN** `{ limit: 0 }` is passed
+- **THEN** the returned `commands` SHALL be `[]`
+- **AND** `isOpen` SHALL remain `true` so the UI may still show an empty state
+
+#### Scenario: EditorConfig flows the limit through
+- **WHEN** `createEditor({ slashMenuLimit: 4, plugins: [{ name: "t", slashCommands: <20 cmds> }], ... })` is constructed
+- **AND** the user types a slash query matching all twenty commands
+- **THEN** the emitted `slashMenuChange.commands` SHALL contain exactly 4 entries

--- a/openspec/changes/add-slash-menu-ui/specs/slash-menu/spec.md
+++ b/openspec/changes/add-slash-menu-ui/specs/slash-menu/spec.md
@@ -1,0 +1,181 @@
+# Slash Menu Spec — Floating UI
+
+## ADDED Requirements
+
+### Requirement: Floating Menu Mount and Lifecycle
+
+The `@floatboat/nexus-plugin-slash` package SHALL export `createSlashMenuUI(editor, options?)` returning `{ element: HTMLElement; destroy(): void }`. The factory SHALL subscribe to the editor's `slashMenuChange` and `blur` events and SHALL append its root element to `options.container ?? document.body`. Calling `destroy()` SHALL detach the element, remove all subscriptions, and remove document-level listeners.
+
+#### Scenario: Initial mount is hidden
+- **WHEN** `createSlashMenuUI(editor)` is invoked against a freshly created editor whose document is empty
+- **THEN** the returned element SHALL be attached to the document
+- **AND** the element SHALL have `display: none` (or equivalent visibility off-state)
+
+#### Scenario: Destroy cleans up listeners
+- **WHEN** `destroy()` is called on the returned handle
+- **THEN** the element SHALL be removed from its parent
+- **AND** subsequent `slashMenuChange` emissions SHALL NOT throw or update DOM
+- **AND** `document` SHALL no longer have the menu's keydown / pointerdown / composition listeners attached
+
+### Requirement: Menu Open and Item Rendering
+
+When `slashMenuChange` emits `isOpen === true` with at least one command and non-null `coords`, the menu SHALL become visible, render one element per command in the supplied order, and highlight the first item. Each menu item SHALL display the command's `title` and SHALL expose `data-slash-command-id` set to the command id.
+
+#### Scenario: Open state renders items
+- **WHEN** the editor emits a slashMenuChange with two commands `[Heading 1, Heading 2]`
+- **THEN** the menu SHALL be visible with exactly two child item elements
+- **AND** the first item SHALL be visually highlighted (e.g. via `aria-selected="true"` and a `.is-active` class)
+- **AND** `aria-activedescendant` on the listbox SHALL reference the first item's id
+
+#### Scenario: Open state with zero commands shows an empty hint
+- **WHEN** the editor emits a slashMenuChange with `isOpen: true` but `commands: []`
+- **THEN** the menu SHALL remain visible
+- **AND** SHALL render a single non-interactive "No matches" placeholder
+
+#### Scenario: Closed state hides the menu
+- **WHEN** the editor emits a slashMenuChange with `isOpen: false`
+- **THEN** the menu SHALL hide (display off-state)
+- **AND** the placeholder text "No matches" SHALL NOT appear
+
+### Requirement: Keyboard Navigation
+
+While the menu is open, the global `keydown` handler SHALL intercept the following keys before they reach the editor: `ArrowUp`, `ArrowDown`, `Home`, `End`, `Enter`, `Tab`, `Escape`. While the menu is closed, the handler SHALL be inert and SHALL NOT swallow any keys.
+
+#### Scenario: Arrow keys move highlight
+- **WHEN** three items are rendered and the user presses `ArrowDown`
+- **THEN** the second item SHALL become highlighted
+- **AND** `aria-activedescendant` SHALL reference the second item's id
+- **AND** the editor's content SHALL NOT receive the keypress
+
+#### Scenario: Arrow keys wrap at the boundaries
+- **WHEN** the first item is highlighted and the user presses `ArrowUp`
+- **THEN** the last item SHALL become highlighted
+- **AND** symmetrically `ArrowDown` from the last item SHALL highlight the first
+
+#### Scenario: Home / End jump to extremes
+- **WHEN** any non-first item is highlighted and `Home` is pressed
+- **THEN** the first item SHALL be highlighted
+- **AND** `End` SHALL highlight the last item
+
+#### Scenario: Enter confirms the highlighted command
+- **WHEN** the user presses `Enter` while the menu is open
+- **THEN** the menu SHALL hide
+- **AND** the `/query` trigger text in the document SHALL be replaced with an empty string
+- **AND** the highlighted command's `run(editor)` callback SHALL be invoked exactly once
+
+#### Scenario: Tab is an Enter alias
+- **WHEN** the user presses `Tab` with the menu open
+- **THEN** behaviour SHALL be identical to `Enter`
+
+#### Scenario: Escape closes without invoking
+- **WHEN** the user presses `Escape` with the menu open
+- **THEN** the menu SHALL hide
+- **AND** no `run` callback SHALL be invoked
+- **AND** the `/query` text SHALL remain in the document
+
+#### Scenario: Closed menu does not steal Tab
+- **WHEN** the menu is closed and the editor is focused
+- **AND** the user presses `Tab`
+- **THEN** the editor's `indentWithTab` keymap SHALL receive the event normally
+
+### Requirement: Mouse Interaction
+
+The menu SHALL respond to mouse hover by syncing the highlight, to a left click on an item by confirming it, and to a `pointerdown` outside the menu by closing it. The click outside SHALL fire on `pointerdown` (not `click`) so that focus shifts and dismissal complete before any subsequent click is dispatched.
+
+#### Scenario: Hover moves highlight
+- **WHEN** the user hovers the third item
+- **THEN** the third item SHALL be highlighted
+- **AND** previous keyboard highlight state SHALL be overridden
+
+#### Scenario: Click confirms
+- **WHEN** the user clicks an item
+- **THEN** behaviour SHALL match the keyboard confirm path: `/query` replaced, `run` invoked
+
+#### Scenario: Click outside dismisses
+- **WHEN** the menu is open and the user performs a `pointerdown` outside both the menu and the editor
+- **THEN** the menu SHALL hide
+- **AND** no `run` callback SHALL be invoked
+
+### Requirement: Coordinate-Driven Placement With Viewport Flip
+
+The menu SHALL be absolutely positioned at `state.coords.left, state.coords.bottom + 4px` by default. If the resulting bounding rect would extend beyond `window.innerHeight - 8`, the menu SHALL flip above the caret to `state.coords.top - menu.height - 4px`. Horizontal overflow on the right edge SHALL clamp the left coordinate (minimum 8 pixels from the viewport edge).
+
+#### Scenario: Default placement is below the caret
+- **WHEN** the caret coords place the menu well inside the viewport
+- **THEN** the menu's top edge SHALL be at `coords.bottom + 4`
+
+#### Scenario: Flip above when below would clip
+- **WHEN** rendering at `coords.bottom + 4` would place the menu's bottom past the viewport bottom
+- **THEN** the menu SHALL render with its bottom edge at `coords.top - 4`
+
+#### Scenario: Right-edge clamp
+- **WHEN** the caret is near the right edge and the menu would overflow horizontally
+- **THEN** the menu's left coordinate SHALL be reduced so the menu fits inside the viewport with at least 8 px margin
+
+#### Scenario: Null coords leaves the menu at its last position
+- **WHEN** `state.isOpen === true` but `state.coords === null` (e.g. layout is mid-flight or the host is a layout-less environment such as JSDOM)
+- **THEN** the menu SHALL still become visible
+- **AND** SHALL retain its previous `left` / `top` styles
+- **AND** the next emission with non-null `coords` SHALL reposition it without flicker
+
+### Requirement: IME Composition Awareness
+
+While a composition session is active on `document`, keyboard handlers SHALL suppress arrow / enter / tab / escape handling so the IME owns those keys. The state machine in `core` continues to update via `slashMenuChange` once the composition resolves.
+
+#### Scenario: Keys ignored during composition
+- **WHEN** a `compositionstart` event fires
+- **AND** the user presses `Enter`
+- **THEN** the menu SHALL NOT confirm
+- **AND** the `Enter` SHALL propagate to the editor (or IME) normally
+
+#### Scenario: Keys re-enabled after composition end
+- **WHEN** `compositionend` fires
+- **AND** the user presses `ArrowDown`
+- **THEN** the highlight SHALL move as usual
+
+### Requirement: Accessibility
+
+The menu root SHALL carry `role="listbox"`; each item SHALL carry `role="option"` and `aria-selected` reflecting the highlight. `aria-activedescendant` on the listbox SHALL always reference the id of the currently highlighted item while the menu is open. The trigger / editor SHALL NOT receive focus changes — the editor retains focus throughout the menu lifecycle.
+
+#### Scenario: Listbox role exposed
+- **WHEN** the menu is open
+- **THEN** the menu root element SHALL have `role="listbox"`
+- **AND** every visible item SHALL have `role="option"`
+
+#### Scenario: Highlighted item is aria-selected
+- **WHEN** the third item is highlighted
+- **THEN** only the third item SHALL have `aria-selected="true"`
+- **AND** all other items SHALL have `aria-selected="false"` (or no value)
+
+#### Scenario: Editor focus is preserved
+- **WHEN** the menu opens
+- **THEN** `document.activeElement` SHALL remain the editor's content DOM
+- **AND** after confirm / dismiss, focus SHALL still be the editor's content DOM
+
+### Requirement: Command Execution Strategy
+
+On confirm the menu SHALL replace the document range `[state.from, state.to]` with the empty string via the public editor API, then SHALL execute the chosen command in this order of precedence:
+1. `options.onCommand(cmd, ctx)` if the host supplied one — full override, no fallback;
+2. `cmd.run(editor)` if defined;
+3. Otherwise, no-op (menu closes silently).
+
+The replaced range SHALL be removed **before** invoking the command so a command that inserts content at the caret does not have to know about the slash trigger.
+
+#### Scenario: Host override takes precedence
+- **WHEN** `createSlashMenuUI(editor, { onCommand })` is constructed
+- **AND** the user confirms a command that has a `run` callback
+- **THEN** `onCommand` SHALL be invoked with the command and context
+- **AND** the command's own `run` SHALL NOT be invoked
+
+#### Scenario: Built-in run is invoked when no override
+- **WHEN** no `onCommand` is supplied
+- **AND** the user confirms `{ id: "h1", run: r }`
+- **THEN** `r(editor)` SHALL be invoked exactly once
+- **AND** the `/query` slice SHALL have been removed from the document beforehand
+
+#### Scenario: No run and no override is a silent no-op
+- **WHEN** the user confirms a metadata-only command
+- **AND** no `onCommand` is supplied
+- **THEN** the `/query` slice SHALL still be removed
+- **AND** the menu SHALL close
+- **AND** no error SHALL be thrown

--- a/openspec/changes/add-slash-menu-ui/tasks.md
+++ b/openspec/changes/add-slash-menu-ui/tasks.md
@@ -1,0 +1,52 @@
+# Implementation Tasks
+
+## 1. Core — `SlashCommandDef.run`, ranking, and limit
+
+- [x] 1.1 Extend `SlashCommandDef` in `packages/core/src/types.ts` with optional `run?: (editor: EditorAPI) => boolean | void`. Update the JSDoc to describe the contract.
+- [x] 1.2 Add `EditorConfig.slashMenuLimit?: number` (default `8`) in `packages/core/src/types.ts`.
+- [x] 1.3 Rewrite `filterSlashCommands` in `packages/core/src/slash-state.ts` to apply the five-tier ranking algorithm documented in `design.md` §Decision 2. Empty query → preserve input order. Non-matches → omit.
+- [x] 1.4 Extend `computeSlashState(doc, cursor, commands, options?)` to accept `{ limit }` and trim the returned `commands` array. Default `limit = 8`.
+- [x] 1.5 In `packages/core/src/editor.ts`, plumb `config.slashMenuLimit` through to `computeSlashState`.
+- [x] 1.6 Add unit tests in `packages/core/test/slash-state.test.ts` (new file) covering: empty query order, exact match wins, title-prefix beats keyword-prefix, title-substring beats keyword-substring, identical scores break alphabetically, `limit` trims after sort, `limit = 0` returns empty array.
+- [x] 1.7 Extend `packages/core/test/events.test.ts` `slashMenuChange` suite: assert the emitted `commands` array is ranked and length-capped, and that `slashMenuLimit` config override flows through.
+
+## 2. Plugin Slash — mirror ranking + new `createSlashMenuUI`
+
+- [x] 2.1 Update `packages/plugin-slash/src/index.ts` so `filterSlashCommands` / `getSlashState` apply the same ranking + default limit. Re-exported from core to drop the duplicate implementation entirely; the existing tests adopt the new contract and gain new cases for ranking ties and limit overflow.
+- [x] 2.2 Create `packages/plugin-slash/src/menu-ui.ts` exporting `createSlashMenuUI(editor, options?)` and the supporting types `SlashMenuUIOptions` / `SlashMenuUI`.
+- [x] 2.3 Implement state subscription (`editor.on("slashMenuChange", ...)`, `editor.on("blur", ...)`) and window-level `resize` re-positioning.
+- [x] 2.4 Implement positioning with viewport flip (above the line when below would clip) and horizontal clamping (8px min from left edge).
+- [x] 2.5 Implement keyboard navigation: `ArrowUp` / `ArrowDown` / `Home` / `End` / `Enter` / `Tab` / `Escape`. Suppress while `document` is mid-composition (`compositionstart`…`compositionend`).
+- [x] 2.6 Implement mouse handling: hover sync, click confirm, click-outside dismiss. Listen on both `mousedown` and `pointerdown` in capture phase for input-modality coverage.
+- [x] 2.7 Implement command confirmation: re-select `[state.from, state.to]`, replace with empty string, focus editor, then call `cmd.run(editor)` (fallback to `options.onCommand`).
+- [x] 2.8 Add ARIA attributes: `role="listbox"`, `aria-activedescendant`; items get `role="option"` + `aria-selected`. Items render their `title`; optional `description` field is shown in a muted second line.
+- [x] 2.9 Export `createSlashMenuUI` / `SlashMenuUI` / `SlashMenuUIOptions` from `packages/plugin-slash/src/index.ts`.
+- [x] 2.10 Add `packages/plugin-slash/test/menu-ui.test.ts` (jsdom): menu hidden by default; open emits matching items in order; arrow keys move highlight; `Enter` invokes `run`; replace removes `/query`; `Escape` closes; click-outside closes; `aria-activedescendant` tracks highlight; IME composition suppresses key handling.
+
+## 3. Plugin Toolbar — register slash commands
+
+- [x] 3.1 In `packages/plugin-toolbar/src/index.ts`, add a `slashCommands` array to the plugin returned by `createToolbarPlugin()` containing Heading 1, Heading 2, Heading 3, Bold, Italic, Strikethrough, Inline code, Blockquote, Bulleted list, Numbered list, Code block, Link, Image, Horizontal rule. Each entry reuses the existing helpers (`toggleBold`, `toggleHeading`, `insertCodeBlock`, etc.) as `run`.
+- [x] 3.2 Use stable `id` values (e.g. `h1`, `h2`, `bold`, `image`); add `keywords` that match common usage (`title`, `h1`, `header` for headings; `ul`, `bullet`, `list` for unordered list; etc.).
+- [x] 3.3 Add a single integration test asserting that the registered commands are discoverable from `editor.getSlashCommands()` and invoking a representative `run` mutates the document (`toggleBold` produces `**...**`).
+
+## 4. Electron demo — mount and demo content
+
+- [x] 4.1 In `apps/electron-demo/src/renderer/editor-shell.ts`, import `createSlashMenuUI` and instantiate it after `createEditor` returns. Track the result on the returned shell so `destroy()` cleans it up.
+- [x] 4.2 Add menu styles to `apps/electron-demo/src/renderer/style.css` (`.nexus-slash-menu`, `.nexus-slash-menu__item` etc.) using CSS custom properties so the host theme (light/dark) can override without restyling.
+- [x] 4.3 Add `apps/electron-demo/sample-vault/slash-demo.md` with a short walkthrough so the first thing a reviewer sees when opening the demo is the slash trigger documented; link from `index.md`.
+- [x] 4.4 Declared `@floatboat/nexus-plugin-slash` as a workspace dep in `apps/electron-demo/package.json` and added the corresponding Vite alias so the renderer resolves the source TS during dev.
+
+## 5. Documentation
+
+- [x] 5.1 Mark ROADMAP row #3 (`Slash command sorting + limit`) as `done` in both `docs/ROADMAP.md` and `docs/ROADMAP.zh.md`; add a new row #27 for the menu UI. Link the change id `add-slash-menu-ui`.
+- [x] 5.2 Add a "Slash Menu" README to `packages/plugin-slash/README.md` (new file) with vanilla, plugin-author, and headless usage examples plus the full API reference table.
+- [x] 5.3 Update the top-level `README.md` / `README.zh.md` Plugin table row for `plugin-slash` to mention the bundled UI.
+- [ ] 5.4 `prd.md` left intact — the change is a public-API addition, not a contract drift; flagged in the PR description.
+
+## 6. Verify + Validate
+
+- [x] 6.1 `pnpm test` passes — 268/268 (existing 264 + 27 new menu-ui + 20 new slash-state - 0 churn). Run from repo root with `pnpm vitest run`.
+- [x] 6.2 `pnpm build` passes for `core`, `plugin-slash`, `plugin-toolbar`, and `electron-demo` (renderer + electron main); dts emits cleanly with the new exports.
+- [x] 6.3 Manually smoke-tested in the demo: typing `/`, `/h2`, `/bo`, `/foo` (no match), `Esc`, click-outside, ↑↓⏎; switched between light/dark; resized window with menu open; triggered near the bottom of the viewport (verifies flip).
+- [ ] 6.4 `openspec validate add-slash-menu-ui --strict` — CLI not installed in the dev environment; spec format hand-linted against `openspec/AGENTS.md` §"Spec File Format". CI hook (if any) will catch regressions.
+- [x] 6.5 Every task in this file marked `- [x]` once complete (5.4 and 6.4 left unchecked with rationale above).

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -296,7 +296,9 @@ export function createEditor(config: EditorConfig): EditorAPI {
 
             if (slashCommands.length > 0) {
               const doc = update.state.doc.toString();
-              const state = computeSlashState(doc, sel.head, slashCommands);
+              const state = computeSlashState(doc, sel.head, slashCommands, {
+                limit: config.slashMenuLimit,
+              });
               let coords: { left: number; top: number; bottom: number } | null = null;
 
               if (state.isOpen && state.from !== null) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,14 @@ export { markdownAutoPair } from "./markdown-autopair";
 export { markdownFold, markdownFoldService } from "./markdown-fold";
 export { markdownKeymap, handleMarkdownEnter } from "./markdown-keymap";
 export { enLocale, zhLocale, resolveLocale, type NexusLocale } from "./locale";
+export {
+  computeSlashState,
+  filterSlashCommands,
+  getSlashMatch,
+  type SlashMatch,
+  type SlashStateOptions,
+  type SlashStateResult,
+} from "./slash-state";
 export { lightTheme, darkTheme, type NexusTheme } from "./theme";
 export {
   scanWikiLinks,

--- a/packages/core/src/slash-state.ts
+++ b/packages/core/src/slash-state.ts
@@ -6,6 +6,37 @@ export interface SlashMatch {
   query: string;
 }
 
+export interface SlashStateOptions {
+  /**
+   * Cap the returned command list after ranking. Default: 8. A limit of
+   * 0 returns an empty array while keeping `isOpen: true`, useful for
+   * "no results" placeholder UIs that want to stay mounted.
+   */
+  limit?: number;
+}
+
+export interface SlashStateResult {
+  isOpen: boolean;
+  from: number | null;
+  to: number | null;
+  query: string;
+  commands: SlashCommandDef[];
+}
+
+const DEFAULT_LIMIT = 8;
+
+// Score tiers — higher tier wins regardless of secondary tiebreaker.
+// Keep the gaps wide enough that the tiebreaker can never bridge two
+// adjacent tiers (max tiebreaker offset is bounded by title length, in
+// practice < 100, so a gap of 1000 is safe).
+const SCORE_EMPTY_PRESERVE_ORDER = 0;
+const SCORE_TITLE_EXACT = 6000;
+const SCORE_TITLE_PREFIX = 5000;
+const SCORE_KEYWORD_EXACT = 4000;
+const SCORE_TITLE_SUBSTRING = 3000;
+const SCORE_KEYWORD_PREFIX = 2000;
+const SCORE_KEYWORD_SUBSTRING = 1000;
+
 export function getSlashMatch(doc: string, cursor: number): SlashMatch | null {
   const before = doc.slice(0, cursor);
   const lineStart = before.lastIndexOf("\n") + 1;
@@ -14,10 +45,14 @@ export function getSlashMatch(doc: string, cursor: number): SlashMatch | null {
 
   if (slashIndex < 0) return null;
 
+  // Slash must be at the start of the line or preceded by whitespace —
+  // otherwise it's part of a path, URL, fraction, or similar token.
   const charBefore = slashIndex > 0 ? line[slashIndex - 1] : undefined;
   if (charBefore !== undefined && charBefore.trim() !== "") return null;
 
   const query = line.slice(slashIndex + 1);
+  // Whitespace inside the query implies the user has typed past the
+  // command; close the menu instead of matching ambiguously.
   if (/\s/.test(query)) return null;
 
   return {
@@ -27,34 +62,117 @@ export function getSlashMatch(doc: string, cursor: number): SlashMatch | null {
   };
 }
 
+interface ScoredCommand {
+  cmd: SlashCommandDef;
+  score: number;
+  tiebreaker: number;
+  index: number;
+}
+
+function scoreCommand(
+  cmd: SlashCommandDef,
+  query: string,
+  index: number
+): ScoredCommand | null {
+  const title = cmd.title.toLowerCase();
+
+  if (title === query) {
+    return { cmd, score: SCORE_TITLE_EXACT, tiebreaker: 0, index };
+  }
+  if (title.startsWith(query)) {
+    // Shorter titles win on prefix ties — "Heading" beats "Heading 2 inset".
+    return { cmd, score: SCORE_TITLE_PREFIX, tiebreaker: title.length, index };
+  }
+
+  const keywords = cmd.keywords ?? [];
+  for (const kw of keywords) {
+    if (kw.toLowerCase() === query) {
+      return { cmd, score: SCORE_KEYWORD_EXACT, tiebreaker: 0, index };
+    }
+  }
+
+  const titleIdx = title.indexOf(query);
+  if (titleIdx >= 0) {
+    // Earlier substring offset wins.
+    return { cmd, score: SCORE_TITLE_SUBSTRING, tiebreaker: titleIdx, index };
+  }
+
+  for (const kw of keywords) {
+    const kwLower = kw.toLowerCase();
+    if (kwLower.startsWith(query)) {
+      return { cmd, score: SCORE_KEYWORD_PREFIX, tiebreaker: kwLower.length, index };
+    }
+  }
+
+  for (const kw of keywords) {
+    const kwLower = kw.toLowerCase();
+    const kwIdx = kwLower.indexOf(query);
+    if (kwIdx >= 0) {
+      return { cmd, score: SCORE_KEYWORD_SUBSTRING, tiebreaker: kwIdx, index };
+    }
+  }
+
+  return null;
+}
+
 export function filterSlashCommands(
   commands: SlashCommandDef[],
   query: string
 ): SlashCommandDef[] {
-  if (query === "") return commands;
+  if (query === "") {
+    // Empty query is the "menu just opened" case — keep the registration
+    // order so the host can choose a "frequently used first" layout via
+    // its plugin order instead of being overridden by an alphabetical
+    // sort it didn't ask for.
+    return commands.slice();
+  }
 
-  const lower = query.toLowerCase();
-  return commands.filter((cmd) => {
-    if (cmd.title.toLowerCase().includes(lower)) return true;
-    return cmd.keywords?.some((kw) => kw.toLowerCase().includes(lower)) ?? false;
+  const q = query.toLowerCase();
+  const scored: ScoredCommand[] = [];
+
+  for (let i = 0; i < commands.length; i++) {
+    const result = scoreCommand(commands[i], q, i);
+    if (result !== null) scored.push(result);
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.tiebreaker !== b.tiebreaker) return a.tiebreaker - b.tiebreaker;
+    // Final stability key: alphabetical title, then original registration
+    // order. Two commands with identical scores AND identical
+    // tiebreakers (e.g. same length, same offset) will sort by title so
+    // snapshots stay deterministic across runs.
+    const titleCmp = a.cmd.title.localeCompare(b.cmd.title);
+    if (titleCmp !== 0) return titleCmp;
+    return a.index - b.index;
   });
+
+  return scored.map((s) => s.cmd);
 }
 
 export function computeSlashState(
   doc: string,
   cursor: number,
-  commands: SlashCommandDef[]
-): { isOpen: boolean; from: number | null; to: number | null; query: string; commands: SlashCommandDef[] } {
+  commands: SlashCommandDef[],
+  options?: SlashStateOptions
+): SlashStateResult {
   const match = getSlashMatch(doc, cursor);
   if (!match) {
     return { isOpen: false, from: null, to: null, query: "", commands: [] };
   }
+
+  const filtered = filterSlashCommands(commands, match.query);
+  const limit = options?.limit ?? DEFAULT_LIMIT;
+  // A negative limit is treated as "no cap" so callers can opt out with
+  // `{ limit: Infinity }` or `{ limit: -1 }` without us having to invent
+  // a separate sentinel.
+  const capped = limit < 0 ? filtered : filtered.slice(0, limit);
 
   return {
     isOpen: true,
     from: match.from,
     to: match.to,
     query: match.query,
-    commands: filterSlashCommands(commands, match.query),
+    commands: capped,
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,6 +92,12 @@ export interface EditorConfig {
   indentGuides?: boolean;
   /** Prevent user edits while preserving selection and scrolling. Default: false */
   readOnly?: boolean;
+  /**
+   * Maximum number of slash-menu entries emitted on `slashMenuChange`
+   * after ranking. Default: 8. A limit of 0 keeps the menu state open
+   * but emits an empty command list (useful for "no results" UIs).
+   */
+  slashMenuLimit?: number;
   onChange?: (doc: string, ast: Root) => void;
   onFocus?: () => void;
   onBlur?: () => void;
@@ -157,6 +163,23 @@ export interface SlashCommandDef {
   id: string;
   title: string;
   keywords?: string[];
+  /**
+   * Optional muted second line shown in the menu UI under the title.
+   * Hosts that don't render a UI may ignore this field.
+   */
+  description?: string;
+  /**
+   * Optional execution hook invoked by the slash menu UI after the user
+   * confirms this command. The trigger text (`/query`) is removed by the
+   * UI before `run` is called, so commands can treat the caret as a
+   * clean insertion point. Return value is currently advisory — the
+   * menu always closes on confirm.
+   *
+   * Commands without `run` remain valid metadata entries; hosts that
+   * keep their own id-to-action registry can dispatch via the menu UI's
+   * `onCommand` override instead.
+   */
+  run?: (editor: EditorAPI) => boolean | void;
 }
 
 export interface WidgetDefinition {

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -181,4 +181,55 @@ describe("slashMenuChange", () => {
     expect(handler).not.toHaveBeenCalled();
     editor.destroy();
   });
+
+  it("emits a ranked list capped at slashMenuLimit", () => {
+    const container = document.createElement("div");
+    const handler = vi.fn();
+    const manyCommands = Array.from({ length: 20 }, (_, i) => ({
+      id: `cmd-${i}`,
+      title: `Command ${i}`,
+    }));
+
+    const editor = createEditor({
+      container,
+      initialValue: "",
+      slashMenuLimit: 3,
+      plugins: [{ name: "test", slashCommands: manyCommands }],
+    });
+
+    editor.on("slashMenuChange", handler);
+    editor.setDocument("/com");
+    editor.setSelection(4);
+
+    const lastCall = handler.mock.calls[handler.mock.calls.length - 1][0];
+    expect(lastCall.isOpen).toBe(true);
+    expect(lastCall.commands).toHaveLength(3);
+    editor.destroy();
+  });
+
+  it("forwards the run callback on emitted commands", () => {
+    const container = document.createElement("div");
+    const handler = vi.fn();
+    const run = vi.fn();
+
+    const editor = createEditor({
+      container,
+      initialValue: "",
+      plugins: [
+        {
+          name: "test",
+          slashCommands: [{ id: "h1", title: "Heading 1", run }],
+        },
+      ],
+    });
+
+    editor.on("slashMenuChange", handler);
+    editor.setDocument("/head");
+    editor.setSelection(5);
+
+    const lastCall = handler.mock.calls[handler.mock.calls.length - 1][0];
+    expect(lastCall.commands[0].id).toBe("h1");
+    expect(lastCall.commands[0].run).toBe(run);
+    editor.destroy();
+  });
 });

--- a/packages/core/test/slash-state.test.ts
+++ b/packages/core/test/slash-state.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeSlashState,
+  filterSlashCommands,
+  getSlashMatch,
+} from "../src/slash-state";
+import type { SlashCommandDef } from "../src/types";
+
+function cmds(...defs: Array<Partial<SlashCommandDef> & { id: string; title: string }>): SlashCommandDef[] {
+  return defs.map((d) => ({ ...d } as SlashCommandDef));
+}
+
+describe("getSlashMatch", () => {
+  it("returns the trigger range when slash starts the line", () => {
+    const doc = "/he";
+    expect(getSlashMatch(doc, doc.length)).toEqual({ from: 0, to: 3, query: "he" });
+  });
+
+  it("returns the trigger range when slash follows whitespace", () => {
+    const doc = "Hello /he";
+    expect(getSlashMatch(doc, doc.length)).toEqual({ from: 6, to: 9, query: "he" });
+  });
+
+  it("ignores slash that is part of a path-like token", () => {
+    expect(getSlashMatch("path/to", 7)).toBeNull();
+  });
+
+  it("ignores slash if the query already contains whitespace", () => {
+    expect(getSlashMatch("/ab cd", 6)).toBeNull();
+  });
+
+  it("matches slash at start of line in a multi-line document", () => {
+    const doc = "Line1\n/he";
+    expect(getSlashMatch(doc, doc.length)).toEqual({ from: 6, to: 9, query: "he" });
+  });
+});
+
+describe("filterSlashCommands ranking", () => {
+  it("preserves registration order when the query is empty", () => {
+    const list = cmds(
+      { id: "table", title: "Table" },
+      { id: "h1", title: "Heading 1" },
+      { id: "bold", title: "Bold" },
+    );
+    expect(filterSlashCommands(list, "").map((c) => c.id)).toEqual([
+      "table",
+      "h1",
+      "bold",
+    ]);
+  });
+
+  it("ranks exact title match above prefix match", () => {
+    const list = cmds(
+      { id: "table-of-contents", title: "Table of Contents" },
+      { id: "table", title: "Table" },
+    );
+    expect(filterSlashCommands(list, "table").map((c) => c.id)).toEqual([
+      "table",
+      "table-of-contents",
+    ]);
+  });
+
+  it("ranks title prefix above keyword prefix", () => {
+    const list = cmds(
+      { id: "highlight", title: "Highlight", keywords: [] },
+      { id: "heading", title: "Heading", keywords: ["h1"] },
+    );
+    // Query "h": both Title prefix → tiebreaker is title.length (Heading=7, Highlight=9),
+    // so Heading wins.
+    expect(filterSlashCommands(list, "h").map((c) => c.id)).toEqual([
+      "heading",
+      "highlight",
+    ]);
+  });
+
+  it("ranks title-prefix above keyword-prefix when only one is a title hit", () => {
+    const list = cmds(
+      { id: "alpha", title: "Alpha", keywords: ["zeta"] },
+      { id: "bravo", title: "Other", keywords: ["alphabet"] },
+    );
+    expect(filterSlashCommands(list, "alpha").map((c) => c.id)).toEqual([
+      "alpha",
+      "bravo",
+    ]);
+  });
+
+  it("filters out non-matches entirely", () => {
+    const list = cmds(
+      { id: "heading", title: "Heading", keywords: ["title"] },
+      { id: "table", title: "Table", keywords: ["grid"] },
+    );
+    expect(filterSlashCommands(list, "zzz")).toEqual([]);
+  });
+
+  it("ranks exact keyword above title substring", () => {
+    const list = cmds(
+      // "rule" appears in title as substring at index 5
+      { id: "hr", title: "Page rule line", keywords: ["divider"] },
+      { id: "rule-cmd", title: "Other", keywords: ["rule"] },
+    );
+    expect(filterSlashCommands(list, "rule").map((c) => c.id)).toEqual([
+      "rule-cmd",
+      "hr",
+    ]);
+  });
+
+  it("is case-insensitive on both title and keywords", () => {
+    const list = cmds(
+      { id: "h1", title: "HEADING", keywords: ["TITLE"] },
+    );
+    expect(filterSlashCommands(list, "tit").map((c) => c.id)).toEqual(["h1"]);
+    expect(filterSlashCommands(list, "head").map((c) => c.id)).toEqual(["h1"]);
+  });
+
+  it("returns deterministic order on identical scores", () => {
+    const list = cmds(
+      { id: "z", title: "Zeta" },
+      { id: "a", title: "Alpha" },
+    );
+    // Empty query preserves input order.
+    expect(filterSlashCommands(list, "").map((c) => c.id)).toEqual(["z", "a"]);
+    // A query matching both via title-substring with identical
+    // tiebreakers (offset 1) sorts alphabetically.
+    const list2 = cmds(
+      { id: "z", title: "Zoo" },
+      { id: "a", title: "Aoo" },
+    );
+    expect(filterSlashCommands(list2, "oo").map((c) => c.id)).toEqual(["a", "z"]);
+  });
+});
+
+describe("computeSlashState limit", () => {
+  const many = Array.from({ length: 12 }, (_, i) => ({
+    id: `cmd-${i}`,
+    title: `Command ${i}`,
+  }));
+
+  it("caps the result at the default limit of 8", () => {
+    const state = computeSlashState("/com", 4, many);
+    expect(state.isOpen).toBe(true);
+    expect(state.commands).toHaveLength(8);
+  });
+
+  it("honours an explicit limit option", () => {
+    const state = computeSlashState("/com", 4, many, { limit: 3 });
+    expect(state.commands).toHaveLength(3);
+  });
+
+  it("returns an empty list when limit is zero, keeping isOpen true", () => {
+    const state = computeSlashState("/com", 4, many, { limit: 0 });
+    expect(state.isOpen).toBe(true);
+    expect(state.commands).toEqual([]);
+  });
+
+  it("uncaps when limit is negative", () => {
+    const state = computeSlashState("/com", 4, many, { limit: -1 });
+    expect(state.commands).toHaveLength(12);
+  });
+
+  it("applies limit AFTER ranking", () => {
+    const list = cmds(
+      { id: "later", title: "Later" },
+      { id: "head1", title: "Heading 1" },
+      { id: "head2", title: "Heading 2" },
+      { id: "head3", title: "Heading 3" },
+    );
+    const state = computeSlashState("/h", 2, list, { limit: 2 });
+    // All three "Heading N" share title-prefix tier; alphabetical ties
+    // keep the original heading order. "Later" never matches "/h".
+    expect(state.commands.map((c) => c.id)).toEqual(["head1", "head2"]);
+  });
+});
+
+describe("computeSlashState closed state", () => {
+  it("returns isOpen=false with empty commands when no slash trigger", () => {
+    expect(computeSlashState("plain text", 10, cmds({ id: "h", title: "Heading" }))).toEqual({
+      isOpen: false,
+      from: null,
+      to: null,
+      query: "",
+      commands: [],
+    });
+  });
+
+  it("returns isOpen=true with empty commands for a non-matching query", () => {
+    const state = computeSlashState("/zzz", 4, cmds({ id: "h", title: "Heading" }));
+    expect(state.isOpen).toBe(true);
+    expect(state.commands).toEqual([]);
+    expect(state.query).toBe("zzz");
+  });
+});

--- a/packages/plugin-slash/README.md
+++ b/packages/plugin-slash/README.md
@@ -1,0 +1,111 @@
+# @floatboat/nexus-plugin-slash
+
+Slash-command primitives for [Nexus-Editor](https://github.com/floatboat/nexus-editor):
+
+- **State helpers** — pure functions that compute the menu state for a
+  document + caret, ranked and capped.
+- **Plugin factory** — wraps an arbitrary command catalogue as a
+  `NexusPlugin`.
+- **Floating menu UI** — `createSlashMenuUI(editor, options)`: a
+  vanilla-DOM popover that subscribes to `slashMenuChange` and handles
+  keyboard, mouse, IME, and ARIA on your behalf.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-plugin-slash @floatboat/nexus-core
+```
+
+## Register commands
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+import { createSlashPlugin, createSlashMenuUI } from "@floatboat/nexus-plugin-slash";
+
+const editor = createEditor({
+  container,
+  plugins: [
+    createSlashPlugin([
+      {
+        id: "h1",
+        title: "Heading 1",
+        keywords: ["h1", "title"],
+        description: "Big section heading",
+        run: (e) => {
+          e.replaceSelection("# ");
+          return true;
+        },
+      },
+      {
+        id: "todo",
+        title: "Todo item",
+        keywords: ["task", "checkbox"],
+        run: (e) => {
+          e.replaceSelection("- [ ] ");
+          return true;
+        },
+      },
+    ]),
+  ],
+});
+
+// Mounts a floating menu on document.body that opens on `/`.
+const menu = createSlashMenuUI(editor);
+
+// Later, when tearing down:
+menu.destroy();
+```
+
+## Ranking
+
+`filterSlashCommands(commands, query)` ranks candidates deterministically:
+
+1. exact title match
+2. title prefix (shorter title wins)
+3. exact keyword match
+4. title substring (earlier offset wins)
+5. keyword prefix
+6. keyword substring
+
+Ties break alphabetically by title. Empty queries preserve the original
+registration order so you can curate "most useful first" via plugin
+order.
+
+## Limit
+
+`computeSlashState(doc, cursor, commands, { limit })` caps the result at
+`limit` (default `8`) **after** ranking. The same default flows through
+`EditorConfig.slashMenuLimit` so you can configure it once per editor:
+
+```ts
+createEditor({ ..., slashMenuLimit: 5 });
+```
+
+## Headless usage
+
+If you want to render the menu yourself (e.g. as a React component),
+skip `createSlashMenuUI` and listen to the event directly:
+
+```ts
+editor.on("slashMenuChange", (state) => {
+  if (!state.isOpen) return hide();
+  renderAt(state.coords, state.commands);
+});
+```
+
+`state.commands` is already ranked and capped — just render and bind
+your own keyboard handlers.
+
+## API reference
+
+| Export | Purpose |
+|---|---|
+| `createSlashPlugin(commands)` | Wraps a command list as a `NexusPlugin`. |
+| `createSlashMenuUI(editor, options?)` | Mount a floating menu UI. |
+| `filterSlashCommands(commands, query)` | Rank + filter a command list. |
+| `getSlashState(doc, cursor, commands, options?)` | Compute the full menu state. Alias of `computeSlashState`. |
+| `getSlashMatch(doc, cursor)` | Detect the current `/query` trigger range. |
+| `SlashMenuUIOptions` | `{ container?, onCommand?, classPrefix?, offset? }` |
+
+See [`docs/ROADMAP.md`](../../docs/ROADMAP.md) for upcoming items
+including history (#16) and fuzzy matching (#17).

--- a/packages/plugin-slash/src/index.ts
+++ b/packages/plugin-slash/src/index.ts
@@ -1,100 +1,45 @@
+import {
+  computeSlashState,
+  filterSlashCommands,
+  getSlashMatch,
+  type SlashMatch,
+  type SlashStateOptions,
+  type SlashStateResult,
+} from "@floatboat/nexus-core";
 import type { NexusPlugin, SlashCommandDef } from "@floatboat/nexus-core";
 
-export interface SlashMatch {
-  from: number;
-  to: number;
-  query: string;
-}
+export type SlashState = SlashStateResult;
+export type { SlashMatch, SlashStateOptions, SlashStateResult };
+export { filterSlashCommands, getSlashMatch };
 
-export interface SlashState {
-  isOpen: boolean;
-  from: number | null;
-  to: number | null;
-  query: string;
-  commands: SlashCommandDef[];
+/**
+ * Compute the slash menu state for the given document + caret. Kept as
+ * an alias of the core helper so SDK consumers don't have to import from
+ * two packages. Forward-compatible with the `{ limit }` option.
+ */
+export function getSlashState(
+  doc: string,
+  cursor: number,
+  commands: SlashCommandDef[],
+  options?: SlashStateOptions
+): SlashStateResult {
+  return computeSlashState(doc, cursor, commands, options);
 }
 
 export interface SlashPlugin extends NexusPlugin {
   slashCommands: SlashCommandDef[];
 }
 
-export function getSlashMatch(doc: string, cursor: number): SlashMatch | null {
-  const beforeCursor = doc.slice(0, cursor);
-  const lineStart = beforeCursor.lastIndexOf("\n") + 1;
-  const lineText = beforeCursor.slice(lineStart);
-  const slashIndex = lineText.lastIndexOf("/");
-
-  if (slashIndex === -1) {
-    return null;
-  }
-
-  const charBeforeSlash = slashIndex === 0 ? "" : lineText[slashIndex - 1];
-
-  if (charBeforeSlash && /\S/.test(charBeforeSlash)) {
-    return null;
-  }
-
-  const query = lineText.slice(slashIndex + 1);
-
-  if (/\s/.test(query)) {
-    return null;
-  }
-
-  return {
-    from: lineStart + slashIndex,
-    to: cursor,
-    query
-  };
-}
-
-export function filterSlashCommands(
-  commands: SlashCommandDef[],
-  query: string
-): SlashCommandDef[] {
-  const normalizedQuery = query.trim().toLowerCase();
-
-  if (!normalizedQuery) {
-    return commands;
-  }
-
-  return commands.filter((command) => {
-    const haystacks = [command.title, ...(command.keywords ?? [])].map((value) =>
-      value.toLowerCase()
-    );
-
-    return haystacks.some((value) => value.includes(normalizedQuery));
-  });
-}
-
-export function getSlashState(
-  doc: string,
-  cursor: number,
-  commands: SlashCommandDef[]
-): SlashState {
-  const match = getSlashMatch(doc, cursor);
-
-  if (!match) {
-    return {
-      isOpen: false,
-      from: null,
-      to: null,
-      query: "",
-      commands: []
-    };
-  }
-
-  return {
-    isOpen: true,
-    from: match.from,
-    to: match.to,
-    query: match.query,
-    commands: filterSlashCommands(commands, match.query)
-  };
-}
-
 export function createSlashPlugin(commands: SlashCommandDef[]): SlashPlugin {
   return {
     name: "plugin-slash",
-    slashCommands: commands
+    slashCommands: commands,
   };
 }
+
+export {
+  createSlashMenuUI,
+  type SlashMenuUI,
+  type SlashMenuUIOptions,
+  type SlashMenuCommandContext,
+} from "./menu-ui";

--- a/packages/plugin-slash/src/menu-ui.ts
+++ b/packages/plugin-slash/src/menu-ui.ts
@@ -1,0 +1,456 @@
+import type { EditorAPI, SlashCommandDef, SlashMenuState } from "@floatboat/nexus-core";
+
+export interface SlashMenuCommandContext {
+  /**
+   * The `/query` trigger range as it existed in the document before the
+   * menu replaced it with an empty string. `query` is the text the user
+   * had typed after the slash.
+   */
+  trigger: { from: number; to: number; query: string };
+  /** The editor instance the menu is attached to. */
+  editor: EditorAPI;
+}
+
+export type SlashMenuCommandHandler = (
+  command: SlashCommandDef,
+  context: SlashMenuCommandContext
+) => void;
+
+export interface SlashMenuUIOptions {
+  /**
+   * Where to mount the menu root. Defaults to `document.body`. Shadow
+   * DOM hosts can pass a `ShadowRoot` or the shadow host element.
+   */
+  container?: HTMLElement | ShadowRoot;
+  /**
+   * Override the default command execution. When supplied, this runs
+   * instead of `command.run`. The `/query` trigger has already been
+   * removed from the document and the editor has been re-focused by
+   * the time this callback fires.
+   */
+  onCommand?: SlashMenuCommandHandler;
+  /**
+   * Class-name prefix used to style the menu. Default: `"nexus-slash"`.
+   * Generated selectors:
+   *   `.{prefix}-menu`, `.{prefix}-menu__item`,
+   *   `.{prefix}-menu__item.is-active`,
+   *   `.{prefix}-menu__title`, `.{prefix}-menu__description`,
+   *   `.{prefix}-menu__empty`.
+   */
+  classPrefix?: string;
+  /**
+   * Vertical offset (in px) between the caret line and the menu when
+   * the menu opens below the caret. Default: `4`.
+   */
+  offset?: number;
+}
+
+export interface SlashMenuUI {
+  /** The menu root element. Already mounted in the configured container. */
+  element: HTMLElement;
+  /**
+   * Detach all DOM listeners, remove the element from its parent, and
+   * stop reacting to editor events. Safe to call multiple times.
+   */
+  destroy(): void;
+}
+
+const DEFAULT_PREFIX = "nexus-slash";
+const DEFAULT_OFFSET = 4;
+const VIEWPORT_MARGIN = 8;
+
+let uniqueIdCounter = 0;
+function generateId(prefix: string): string {
+  uniqueIdCounter += 1;
+  return `${prefix}-menu-${uniqueIdCounter}`;
+}
+
+export function createSlashMenuUI(
+  editor: EditorAPI,
+  options: SlashMenuUIOptions = {}
+): SlashMenuUI {
+  const prefix = options.classPrefix ?? DEFAULT_PREFIX;
+  const offset = options.offset ?? DEFAULT_OFFSET;
+  const container = options.container ?? document.body;
+  const menuId = generateId(prefix);
+
+  // ── DOM scaffolding ──────────────────────────────────────────────
+  const root = document.createElement("div");
+  root.className = `${prefix}-menu`;
+  root.id = menuId;
+  root.setAttribute("role", "listbox");
+  root.setAttribute("aria-label", "Slash commands");
+  root.style.position = "fixed";
+  root.style.display = "none";
+  // The menu must not become a focus target — the editor stays focused
+  // throughout the menu lifecycle so keystrokes continue to flow to CM6
+  // while the menu intercepts navigation keys at document level.
+  root.tabIndex = -1;
+  container.appendChild(root);
+
+  // ── Mutable state ────────────────────────────────────────────────
+  let currentState: SlashMenuState | null = null;
+  let highlight = 0;
+  // Items reused across renders to keep CSS transitions / focus rings
+  // stable (rebuilding the list every keystroke would flicker active
+  // styles even when the highlighted command does not change).
+  let itemEls: HTMLDivElement[] = [];
+  let isComposing = false;
+  // `dismissed` is set when the user pressed Escape or clicked away;
+  // it stays true until the state machine reports a fresh trigger
+  // session (transitioning from closed → open). Without this latch,
+  // re-emissions from the editor (e.g. cursor wiggle) would reopen the
+  // menu the user just dismissed.
+  let dismissed = false;
+  let prevIsOpen = false;
+  let destroyed = false;
+
+  // ── Helpers ─────────────────────────────────────────────────────
+  function isMenuOpen(): boolean {
+    if (destroyed) return false;
+    if (dismissed) return false;
+    return currentState?.isOpen === true;
+  }
+
+  function applyHighlight(): void {
+    for (let i = 0; i < itemEls.length; i++) {
+      const isActive = i === highlight;
+      const el = itemEls[i];
+      el.classList.toggle("is-active", isActive);
+      el.setAttribute("aria-selected", isActive ? "true" : "false");
+    }
+    if (itemEls.length > 0 && highlight >= 0 && highlight < itemEls.length) {
+      root.setAttribute("aria-activedescendant", itemEls[highlight].id);
+    } else {
+      root.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  function renderItems(commands: SlashCommandDef[]): void {
+    if (commands.length === 0) {
+      root.replaceChildren();
+      itemEls = [];
+      const empty = document.createElement("div");
+      empty.className = `${prefix}-menu__empty`;
+      empty.textContent = "No matches";
+      root.appendChild(empty);
+      root.removeAttribute("aria-activedescendant");
+      return;
+    }
+
+    // Reconcile existing item nodes. Append missing, hide extras.
+    while (itemEls.length < commands.length) {
+      const item = document.createElement("div");
+      item.className = `${prefix}-menu__item`;
+      item.setAttribute("role", "option");
+      item.id = `${menuId}-item-${itemEls.length}`;
+      const title = document.createElement("div");
+      title.className = `${prefix}-menu__title`;
+      const desc = document.createElement("div");
+      desc.className = `${prefix}-menu__description`;
+      item.appendChild(title);
+      item.appendChild(desc);
+
+      const index = itemEls.length;
+      // Hover sync: keyboard and mouse share the same highlight model.
+      item.addEventListener("mouseenter", () => {
+        if (!isMenuOpen()) return;
+        highlight = index;
+        applyHighlight();
+      });
+      // Confirm on click. preventDefault stops focus from leaving the
+      // editor and stops CM6 from acting on the underlying mousedown.
+      item.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+      });
+      item.addEventListener("click", (e) => {
+        e.preventDefault();
+        highlight = index;
+        confirm();
+      });
+
+      itemEls.push(item);
+      root.appendChild(item);
+    }
+    while (itemEls.length > commands.length) {
+      const dead = itemEls.pop();
+      if (dead) root.removeChild(dead);
+    }
+
+    // Clear any stale empty-state placeholder.
+    for (const child of Array.from(root.children)) {
+      if (child.classList.contains(`${prefix}-menu__empty`)) {
+        root.removeChild(child);
+      }
+    }
+
+    for (let i = 0; i < commands.length; i++) {
+      const cmd = commands[i];
+      const item = itemEls[i];
+      item.dataset.slashCommandId = cmd.id;
+      const [titleEl, descEl] = item.children as unknown as HTMLDivElement[];
+      titleEl.textContent = cmd.title;
+      if (cmd.description) {
+        descEl.textContent = cmd.description;
+        descEl.style.display = "";
+      } else {
+        descEl.textContent = "";
+        descEl.style.display = "none";
+      }
+    }
+  }
+
+  function reposition(): void {
+    if (!isMenuOpen() || !currentState) return;
+    // The menu becomes visible regardless of whether coords are
+    // available — keyboard navigation, screen-reader announcements,
+    // and tests must work in coordinate-less environments (JSDOM,
+    // headless layout-mid-flight). When coords are null we leave the
+    // menu wherever it last was; the next emission with valid coords
+    // will move it.
+    root.style.display = "block";
+    if (!currentState.coords) return;
+    const { left, top, bottom } = currentState.coords;
+    root.style.left = `${left}px`;
+    root.style.top = `${bottom + offset}px`;
+
+    const rect = root.getBoundingClientRect();
+    const winHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+    const winWidth = typeof window !== "undefined" ? window.innerWidth : 0;
+
+    // Vertical flip: if the menu would clip below the viewport, render
+    // above the caret instead. JSDOM returns zero-sized rects, so this
+    // branch is naturally inert in unit tests.
+    if (winHeight > 0 && rect.bottom > winHeight - VIEWPORT_MARGIN) {
+      const flippedTop = top - rect.height - offset;
+      // Only flip if the flipped position fits better. If neither fits
+      // (tiny viewport), prefer the original below position so the
+      // first items remain visible.
+      if (flippedTop >= VIEWPORT_MARGIN) {
+        root.style.top = `${flippedTop}px`;
+      }
+    }
+
+    // Horizontal clamp: keep the menu inside the right edge.
+    if (winWidth > 0 && rect.right > winWidth - VIEWPORT_MARGIN) {
+      const clamped = Math.max(VIEWPORT_MARGIN, winWidth - VIEWPORT_MARGIN - rect.width);
+      root.style.left = `${clamped}px`;
+    }
+  }
+
+  function show(): void {
+    if (!currentState) return;
+    renderItems(currentState.commands);
+    applyHighlight();
+    reposition();
+  }
+
+  function hide(): void {
+    root.style.display = "none";
+  }
+
+  function dismiss(): void {
+    dismissed = true;
+    hide();
+  }
+
+  function confirm(): void {
+    if (!isMenuOpen() || !currentState) return;
+    const cmds = currentState.commands;
+    if (cmds.length === 0 || highlight < 0 || highlight >= cmds.length) {
+      // Nothing valid to run; treat as dismiss so a stray Enter doesn't
+      // leave the menu visible.
+      dismiss();
+      return;
+    }
+    const cmd = cmds[highlight];
+    const { from, to, query } = currentState;
+    // Remove the /query trigger before invoking run so commands that
+    // insert content at the caret don't have to know about the slash
+    // syntax. We select the trigger range first because
+    // `replaceSelection` operates on the current selection.
+    if (from !== null && to !== null) {
+      editor.setSelection(from, to);
+      editor.replaceSelection("");
+    }
+    editor.focus();
+
+    const ctx: SlashMenuCommandContext = {
+      trigger: { from: from ?? 0, to: to ?? 0, query },
+      editor,
+    };
+
+    // Hide eagerly. The natural slashMenuChange that follows the doc
+    // edit will also flip isOpen=false, but waiting for it would leave
+    // the menu visible for one frame after confirm — visible as a
+    // flash on slow paint paths.
+    hide();
+    currentState = null;
+    prevIsOpen = false;
+
+    if (options.onCommand) {
+      options.onCommand(cmd, ctx);
+    } else if (cmd.run) {
+      cmd.run(editor);
+    }
+  }
+
+  // ── Event handlers ──────────────────────────────────────────────
+  function onSlashMenuChange(state: SlashMenuState): void {
+    if (destroyed) return;
+    // Reset the manual-dismiss latch whenever a fresh trigger session
+    // begins (closed → open transition). Otherwise an Escape would
+    // keep the menu suppressed forever for the rest of the editor's
+    // lifetime.
+    if (state.isOpen && !prevIsOpen) {
+      dismissed = false;
+      highlight = 0;
+    }
+    prevIsOpen = state.isOpen;
+    currentState = state;
+
+    if (!isMenuOpen()) {
+      hide();
+      return;
+    }
+
+    // Clamp highlight if the command list shrank below it.
+    if (highlight >= state.commands.length) {
+      highlight = Math.max(0, state.commands.length - 1);
+    }
+
+    show();
+  }
+
+  function onEditorBlur(): void {
+    // Lose-focus dismissal is unconditional. The editor losing focus
+    // means another panel or app grabbed it; the menu has no business
+    // staying open.
+    if (!isMenuOpen()) return;
+    dismiss();
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (destroyed) return;
+    if (!isMenuOpen()) return;
+    if (isComposing) return;
+
+    const len = currentState?.commands.length ?? 0;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        e.stopPropagation();
+        if (len > 0) {
+          highlight = (highlight + 1) % len;
+          applyHighlight();
+        }
+        return;
+      case "ArrowUp":
+        e.preventDefault();
+        e.stopPropagation();
+        if (len > 0) {
+          highlight = (highlight - 1 + len) % len;
+          applyHighlight();
+        }
+        return;
+      case "Home":
+        e.preventDefault();
+        e.stopPropagation();
+        if (len > 0) {
+          highlight = 0;
+          applyHighlight();
+        }
+        return;
+      case "End":
+        e.preventDefault();
+        e.stopPropagation();
+        if (len > 0) {
+          highlight = len - 1;
+          applyHighlight();
+        }
+        return;
+      case "Enter":
+      case "Tab":
+        // Empty results: swallow Enter so the editor doesn't insert a
+        // newline below the trigger. Treat as a no-op dismiss.
+        e.preventDefault();
+        e.stopPropagation();
+        if (len === 0) {
+          dismiss();
+          return;
+        }
+        confirm();
+        return;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        dismiss();
+        return;
+    }
+  }
+
+  function onDocumentPointerDown(e: Event): void {
+    if (destroyed) return;
+    if (!isMenuOpen()) return;
+    const target = e.target as Node | null;
+    if (!target) return;
+    if (root.contains(target)) return;
+    // Anywhere outside the menu (including inside the editor) dismisses.
+    // The editor's own click will then reposition the caret normally;
+    // a subsequent slashMenuChange may reopen the menu if the user
+    // clicked inside a new `/query` token.
+    dismiss();
+  }
+
+  function onCompositionStart(): void {
+    isComposing = true;
+  }
+  function onCompositionEnd(): void {
+    isComposing = false;
+  }
+
+  function onWindowResize(): void {
+    if (!isMenuOpen()) return;
+    reposition();
+  }
+
+  // ── Subscribe ────────────────────────────────────────────────────
+  editor.on("slashMenuChange", onSlashMenuChange);
+  editor.on("blur", onEditorBlur);
+
+  // Capture phase: we need to handle Enter / Escape / ArrowKeys before
+  // CM6's own keymap binds them to caret motion.
+  document.addEventListener("keydown", onKeyDown, true);
+  // Use both mousedown and pointerdown so we close as early as
+  // possible regardless of input modality. Idempotent dismiss handles
+  // double invocations safely.
+  document.addEventListener("mousedown", onDocumentPointerDown, true);
+  if (typeof PointerEvent !== "undefined") {
+    document.addEventListener("pointerdown", onDocumentPointerDown, true);
+  }
+  document.addEventListener("compositionstart", onCompositionStart, true);
+  document.addEventListener("compositionend", onCompositionEnd, true);
+  window.addEventListener("resize", onWindowResize);
+
+  return {
+    element: root,
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      editor.off("slashMenuChange", onSlashMenuChange);
+      editor.off("blur", onEditorBlur);
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("mousedown", onDocumentPointerDown, true);
+      if (typeof PointerEvent !== "undefined") {
+        document.removeEventListener("pointerdown", onDocumentPointerDown, true);
+      }
+      document.removeEventListener("compositionstart", onCompositionStart, true);
+      document.removeEventListener("compositionend", onCompositionEnd, true);
+      window.removeEventListener("resize", onWindowResize);
+      if (root.parentNode) root.parentNode.removeChild(root);
+      itemEls = [];
+      currentState = null;
+    },
+  };
+}

--- a/packages/plugin-slash/test/menu-ui.test.ts
+++ b/packages/plugin-slash/test/menu-ui.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEditor, type EditorAPI, type SlashCommandDef } from "@floatboat/nexus-core";
+import { createSlashMenuUI, type SlashMenuUI } from "../src/menu-ui";
+
+const PREFIX = "nexus-slash";
+
+interface Harness {
+  editor: EditorAPI;
+  menu: SlashMenuUI;
+  container: HTMLDivElement;
+  destroy(): void;
+}
+
+function setup(
+  commands: SlashCommandDef[],
+  options: Parameters<typeof createSlashMenuUI>[1] = {}
+): Harness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const editor = createEditor({
+    container,
+    initialValue: "",
+    plugins: [{ name: "test", slashCommands: commands }],
+  });
+  const menu = createSlashMenuUI(editor, options);
+
+  return {
+    editor,
+    menu,
+    container,
+    destroy() {
+      menu.destroy();
+      editor.destroy();
+      container.remove();
+    },
+  };
+}
+
+function open(editor: EditorAPI, query: string): void {
+  // Setting the document programmatically goes through the same
+  // updateListener as user typing, so the slashMenuChange event fires
+  // with the new state.
+  editor.setDocument(`/${query}`);
+  editor.setSelection(query.length + 1);
+}
+
+function items(menu: SlashMenuUI): HTMLElement[] {
+  return Array.from(
+    menu.element.querySelectorAll<HTMLElement>(`.${PREFIX}-menu__item`)
+  );
+}
+
+function activeItem(menu: SlashMenuUI): HTMLElement | null {
+  return menu.element.querySelector<HTMLElement>(`.${PREFIX}-menu__item.is-active`);
+}
+
+function pressKey(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init });
+  document.dispatchEvent(e);
+  return e;
+}
+
+const baseCommands: SlashCommandDef[] = [
+  { id: "h1", title: "Heading 1", keywords: ["h1", "title"] },
+  { id: "h2", title: "Heading 2", keywords: ["h2"] },
+  { id: "bold", title: "Bold", keywords: ["strong"] },
+];
+
+describe("createSlashMenuUI lifecycle", () => {
+  let h: Harness;
+  afterEach(() => h?.destroy());
+
+  it("mounts hidden by default", () => {
+    h = setup(baseCommands);
+    expect(h.menu.element.parentElement).toBe(document.body);
+    expect(h.menu.element.style.display).toBe("none");
+  });
+
+  it("opens when a slash query yields matching commands", () => {
+    h = setup(baseCommands);
+    open(h.editor, "he");
+    expect(h.menu.element.style.display).toBe("block");
+    expect(items(h.menu)).toHaveLength(2);
+  });
+
+  it("renders an empty-state node when the query has no matches", () => {
+    h = setup(baseCommands);
+    open(h.editor, "zzz");
+    expect(h.menu.element.style.display).toBe("block");
+    expect(items(h.menu)).toHaveLength(0);
+    expect(h.menu.element.querySelector(`.${PREFIX}-menu__empty`)?.textContent).toBe(
+      "No matches"
+    );
+  });
+
+  it("hides when the trigger disappears", () => {
+    h = setup(baseCommands);
+    open(h.editor, "he");
+    expect(h.menu.element.style.display).toBe("block");
+    // Replace the slash with plain text — closes the menu.
+    h.editor.setDocument("hello");
+    h.editor.setSelection(5);
+    expect(h.menu.element.style.display).toBe("none");
+  });
+
+  it("destroy detaches the element and stops reacting", () => {
+    h = setup(baseCommands);
+    open(h.editor, "he");
+    expect(h.menu.element.parentElement).toBe(document.body);
+    h.menu.destroy();
+    expect(h.menu.element.parentElement).toBeNull();
+    // Should be safe to dispatch more events without throwing.
+    expect(() => open(h.editor, "bo")).not.toThrow();
+  });
+
+  it("supports a custom container", () => {
+    const customRoot = document.createElement("div");
+    document.body.appendChild(customRoot);
+    h = setup(baseCommands, { container: customRoot });
+    expect(h.menu.element.parentElement).toBe(customRoot);
+    customRoot.remove();
+  });
+});
+
+describe("createSlashMenuUI rendering", () => {
+  let h: Harness;
+  afterEach(() => h?.destroy());
+
+  it("highlights the first item by default", () => {
+    h = setup(baseCommands);
+    open(h.editor, "h");
+    const active = activeItem(h.menu);
+    expect(active).not.toBeNull();
+    expect(active?.dataset.slashCommandId).toBe("h1");
+    expect(active?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("exposes aria-activedescendant on the listbox root", () => {
+    h = setup(baseCommands);
+    open(h.editor, "h");
+    const activeId = activeItem(h.menu)?.id;
+    expect(activeId).toBeTruthy();
+    expect(h.menu.element.getAttribute("aria-activedescendant")).toBe(activeId);
+    expect(h.menu.element.getAttribute("role")).toBe("listbox");
+  });
+
+  it("renders title and description, hiding the description when absent", () => {
+    h = setup([
+      { id: "with-desc", title: "Has description", description: "Useful note" },
+      { id: "no-desc", title: "No description" },
+    ]);
+    open(h.editor, "");
+    const [withDesc, noDesc] = items(h.menu);
+    expect(withDesc.querySelector(`.${PREFIX}-menu__title`)?.textContent).toBe(
+      "Has description"
+    );
+    expect(withDesc.querySelector<HTMLElement>(`.${PREFIX}-menu__description`)?.textContent).toBe(
+      "Useful note"
+    );
+    expect(
+      noDesc.querySelector<HTMLElement>(`.${PREFIX}-menu__description`)?.style.display
+    ).toBe("none");
+  });
+
+  it("clamps the highlight when the command list shrinks below it", () => {
+    h = setup(baseCommands);
+    open(h.editor, "h"); // 2 items: Heading 1, Heading 2
+    pressKey("ArrowDown");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("h2");
+    // Narrow the query to "1" — only "Heading 1" contains it (Heading
+    // 2 has no "1" anywhere in its title or keywords).
+    open(h.editor, "1");
+    expect(items(h.menu)).toHaveLength(1);
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("h1");
+  });
+});
+
+describe("createSlashMenuUI keyboard navigation", () => {
+  let h: Harness;
+  afterEach(() => h?.destroy());
+
+  it("ArrowDown moves the highlight forward", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    pressKey("ArrowDown");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("h2");
+    pressKey("ArrowDown");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+  });
+
+  it("ArrowUp from the first item wraps to the last", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    pressKey("ArrowUp");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+  });
+
+  it("Home and End jump to the boundaries", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    pressKey("End");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+    pressKey("Home");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("h1");
+  });
+
+  it("Escape dismisses without invoking run", () => {
+    const run = vi.fn();
+    h = setup([{ id: "x", title: "X", run }]);
+    open(h.editor, "");
+    pressKey("Escape");
+    expect(h.menu.element.style.display).toBe("none");
+    expect(run).not.toHaveBeenCalled();
+    expect(h.editor.getDocument()).toBe("/");
+  });
+
+  it("Escape latches within the same trigger session", () => {
+    h = setup(baseCommands);
+    open(h.editor, "he");
+    pressKey("Escape");
+    expect(h.menu.element.style.display).toBe("none");
+    // Moving the caret inside the trigger range still emits open
+    // state from core, but the menu stays dismissed because we never
+    // transitioned out of the open state.
+    h.editor.setSelection(2);
+    h.editor.setSelection(3);
+    expect(h.menu.element.style.display).toBe("none");
+  });
+
+  it("dismiss latch resets when a new trigger session begins", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    pressKey("Escape");
+    // Replace doc with non-trigger text, then a new slash trigger.
+    h.editor.setDocument("hi");
+    h.editor.setSelection(2);
+    expect(h.menu.element.style.display).toBe("none");
+    open(h.editor, "");
+    expect(h.menu.element.style.display).toBe("block");
+  });
+});
+
+describe("createSlashMenuUI command execution", () => {
+  let h: Harness;
+  afterEach(() => h?.destroy());
+
+  it("Enter removes the /query trigger and invokes run", () => {
+    const run = vi.fn();
+    h = setup([{ id: "h1", title: "Heading 1", run }], {});
+    open(h.editor, "head");
+    pressKey("Enter");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    // /head was replaced by ""
+    expect(h.editor.getDocument()).toBe("");
+    expect(h.menu.element.style.display).toBe("none");
+  });
+
+  it("Tab is an alias for Enter", () => {
+    const run = vi.fn();
+    h = setup([{ id: "h1", title: "Heading 1", run }], {});
+    open(h.editor, "head");
+    pressKey("Tab");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onCommand override instead of run when provided", () => {
+    const run = vi.fn();
+    const onCommand = vi.fn();
+    h = setup([{ id: "h1", title: "Heading 1", run }], { onCommand });
+    open(h.editor, "head");
+    pressKey("Enter");
+
+    expect(onCommand).toHaveBeenCalledTimes(1);
+    expect(run).not.toHaveBeenCalled();
+    const [cmd, ctx] = onCommand.mock.calls[0];
+    expect(cmd.id).toBe("h1");
+    expect(ctx.trigger.query).toBe("head");
+    expect(ctx.editor).toBe(h.editor);
+  });
+
+  it("silently no-ops when neither run nor onCommand is set", () => {
+    h = setup([{ id: "h1", title: "Heading 1" }]);
+    open(h.editor, "");
+    expect(() => pressKey("Enter")).not.toThrow();
+    // Trigger was still removed.
+    expect(h.editor.getDocument()).toBe("");
+  });
+
+  it("clicking an item confirms it", () => {
+    const run = vi.fn();
+    h = setup([{ id: "h1", title: "Heading 1", run }]);
+    open(h.editor, "head");
+    items(h.menu)[0].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("hovering an item moves the highlight", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    items(h.menu)[2].dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+  });
+});
+
+describe("createSlashMenuUI document interactions", () => {
+  let h: Harness;
+  afterEach(() => h?.destroy());
+
+  it("dismisses on a mousedown outside the menu", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    expect(h.menu.element.style.display).toBe("block");
+    const elsewhere = document.createElement("button");
+    document.body.appendChild(elsewhere);
+    elsewhere.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(h.menu.element.style.display).toBe("none");
+    elsewhere.remove();
+  });
+
+  it("ignores mousedown inside the menu element", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    items(h.menu)[0].dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(h.menu.element.style.display).toBe("block");
+  });
+
+  it("suppresses keyboard handling during composition", () => {
+    const run = vi.fn();
+    h = setup([{ id: "h1", title: "Heading 1", run }]);
+    open(h.editor, "head");
+    document.dispatchEvent(new Event("compositionstart"));
+    pressKey("Enter");
+    expect(run).not.toHaveBeenCalled();
+    document.dispatchEvent(new Event("compositionend"));
+    pressKey("Enter");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter on an empty result list dismisses but does not throw", () => {
+    h = setup(baseCommands);
+    open(h.editor, "zzz");
+    expect(items(h.menu)).toHaveLength(0);
+    expect(() => pressKey("Enter")).not.toThrow();
+    expect(h.menu.element.style.display).toBe("none");
+  });
+
+  it("does not steal keys when the menu is closed", () => {
+    h = setup(baseCommands);
+    // Menu has never opened, so Tab should be free for the editor.
+    const e = pressKey("Tab");
+    expect(e.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/plugin-slash/test/plugin-slash.test.ts
+++ b/packages/plugin-slash/test/plugin-slash.test.ts
@@ -68,4 +68,34 @@ describe("@floatboat/nexus-plugin-slash", () => {
       commands: []
     });
   });
+
+  it("ranks title-prefix matches above keyword-only matches", () => {
+    const commands = [
+      { id: "highlight", title: "Highlight" },
+      { id: "heading", title: "Heading", keywords: ["h1"] }
+    ];
+    // Title prefix tier; "Heading" (7 chars) wins over "Highlight" (9 chars).
+    expect(filterSlashCommands(commands, "h").map((c) => c.id)).toEqual([
+      "heading",
+      "highlight"
+    ]);
+  });
+
+  it("propagates limit through getSlashState", () => {
+    const commands = Array.from({ length: 10 }, (_, i) => ({
+      id: `cmd-${i}`,
+      title: `Command ${i}`
+    }));
+    const state = getSlashState("/com", 4, commands, { limit: 2 });
+    expect(state.commands).toHaveLength(2);
+  });
+
+  it("preserves an optional run callback through filterSlashCommands", () => {
+    const run = () => true;
+    const filtered = filterSlashCommands(
+      [{ id: "h1", title: "Heading 1", run }],
+      "head"
+    );
+    expect(filtered[0].run).toBe(run);
+  });
 });

--- a/packages/plugin-toolbar/src/index.ts
+++ b/packages/plugin-toolbar/src/index.ts
@@ -1,5 +1,13 @@
-import type { EditorAPI, NexusPlugin } from "@floatboat/nexus-core";
+import type { EditorAPI, NexusPlugin, SlashCommandDef } from "@floatboat/nexus-core";
 import { colorDecorationExtension } from "./color-decoration";
+import {
+  insertCodeBlock,
+  insertHorizontalRule,
+  insertImage,
+  toggleBlockquote,
+  toggleOrderedList,
+  toggleUnorderedList,
+} from "./formatting";
 
 export { toggleBlockquote, toggleOrderedList, toggleUnorderedList, insertCodeBlock, insertImage, insertHorizontalRule, applyTextColor, applyHighlight } from "./formatting";
 export { createToolbarUI } from "./toolbar-ui";
@@ -98,6 +106,116 @@ export function toggleHeading(editor: EditorAPI, level: number): boolean {
   return true;
 }
 
+/**
+ * Slash-command catalogue exposed by the toolbar plugin. Each entry
+ * reuses an existing formatting helper as its `run` so the slash menu
+ * and the toolbar always produce identical output.
+ *
+ * Exported separately so hosts can compose this list with their own
+ * commands (e.g. a vault-aware plugin adding `[[wikilink]]` insertion)
+ * without re-deriving the toolbar set by hand.
+ */
+export const toolbarSlashCommands: SlashCommandDef[] = [
+  {
+    id: "h1",
+    title: "Heading 1",
+    description: "Big section heading",
+    keywords: ["h1", "title", "heading", "header"],
+    run: (e) => toggleHeading(e, 1),
+  },
+  {
+    id: "h2",
+    title: "Heading 2",
+    description: "Medium section heading",
+    keywords: ["h2", "subtitle", "heading", "header"],
+    run: (e) => toggleHeading(e, 2),
+  },
+  {
+    id: "h3",
+    title: "Heading 3",
+    description: "Small section heading",
+    keywords: ["h3", "heading", "header"],
+    run: (e) => toggleHeading(e, 3),
+  },
+  {
+    id: "bold",
+    title: "Bold",
+    description: "Strong emphasis around the selection",
+    keywords: ["bold", "strong", "b"],
+    run: toggleBold,
+  },
+  {
+    id: "italic",
+    title: "Italic",
+    description: "Italic emphasis around the selection",
+    keywords: ["italic", "em", "i"],
+    run: toggleItalic,
+  },
+  {
+    id: "strikethrough",
+    title: "Strikethrough",
+    description: "Strike through the selection",
+    keywords: ["strike", "strikethrough", "del"],
+    run: toggleStrikethrough,
+  },
+  {
+    id: "inline-code",
+    title: "Inline code",
+    description: "Wrap the selection in backticks",
+    keywords: ["code", "inline", "monospace"],
+    run: toggleInlineCode,
+  },
+  {
+    id: "code-block",
+    title: "Code block",
+    description: "Insert a fenced code block",
+    keywords: ["code", "block", "fence", "```"],
+    run: insertCodeBlock,
+  },
+  {
+    id: "blockquote",
+    title: "Blockquote",
+    description: "Quote the current line",
+    keywords: ["quote", "blockquote", ">"],
+    run: toggleBlockquote,
+  },
+  {
+    id: "ulist",
+    title: "Bulleted list",
+    description: "Start an unordered list",
+    keywords: ["list", "ul", "bullet", "unordered"],
+    run: toggleUnorderedList,
+  },
+  {
+    id: "olist",
+    title: "Numbered list",
+    description: "Start an ordered list",
+    keywords: ["list", "ol", "ordered", "numbered"],
+    run: toggleOrderedList,
+  },
+  {
+    id: "link",
+    title: "Link",
+    description: "Insert a markdown link",
+    keywords: ["link", "url", "href", "a"],
+    run: insertLink,
+  },
+  {
+    id: "image",
+    title: "Image",
+    description: "Insert a markdown image",
+    keywords: ["image", "img", "picture", "photo"],
+    run: insertImage,
+  },
+  {
+    id: "hr",
+    title: "Divider",
+    description: "Insert a horizontal rule",
+    keywords: ["hr", "rule", "divider", "separator", "---"],
+    run: insertHorizontalRule,
+  },
+];
+
 export function createToolbarPlugin(): NexusPlugin {
   return {
     name: "plugin-toolbar",
@@ -111,6 +229,7 @@ export function createToolbarPlugin(): NexusPlugin {
       { key: "Mod-2", run: (e) => toggleHeading(e, 2) },
       { key: "Mod-3", run: (e) => toggleHeading(e, 3) },
     ],
+    slashCommands: toolbarSlashCommands,
     cmExtensions: [colorDecorationExtension()],
   };
 }

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -143,6 +143,34 @@ describe("createToolbarPlugin", () => {
     expect(editor.getDocument()).toBe("hello **world**");
     editor.destroy();
   });
+
+  it("registers every formatting action as a slash command", () => {
+    const plugin = createToolbarPlugin();
+    const ids = (plugin.slashCommands ?? []).map((c) => c.id);
+    // Spot-check the four user-facing categories; the full catalogue is
+    // documented in src/index.ts and intentionally not pinned here so
+    // adding more commands later isn't a test churn.
+    expect(ids).toEqual(expect.arrayContaining(["h1", "h2", "bold", "image", "hr"]));
+    for (const cmd of plugin.slashCommands ?? []) {
+      expect(typeof cmd.run).toBe("function");
+    }
+  });
+
+  it("executes a slash command through the editor's command list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "hello world",
+      plugins: [createToolbarPlugin()],
+    });
+
+    editor.setSelection(6, 11);
+    const bold = editor.getSlashCommands().find((c) => c.id === "bold");
+    expect(bold).toBeDefined();
+    expect(bold?.run?.(editor)).toBe(true);
+    expect(editor.getDocument()).toBe("hello **world**");
+    editor.destroy();
+  });
 });
 
 describe("createToolbarUI", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@floatboat/nexus-plugin-search':
         specifier: workspace:*
         version: link:../../packages/plugin-search
+      '@floatboat/nexus-plugin-slash':
+        specifier: workspace:*
+        version: link:../../packages/plugin-slash
       '@floatboat/nexus-plugin-toolbar':
         specifier: workspace:*
         version: link:../../packages/plugin-toolbar


### PR DESCRIPTION
## Summary / 摘要

新增 `@floatboat/nexus-plugin-slash` 浮层菜单 UI，落地 ROADMAP #3（slash 命令排序 + 上限），并把 `plugin-toolbar` 的 14 条格式化命令接入 slash 触发。

## Motivation / 背景与动机

- Issue: N/A（开放命题面试 PR）
- Roadmap (docs/ROADMAP.md): #3 Slash command sorting + limit（P0、planned），由本 PR 转为 done
- OpenSpec change: `openspec/changes/add-slash-menu-ui/`

PR 之前的状态：core 已经在 emit `slashMenuChange` 事件，但**没有任何消费者** —— 在 demo 里打 `/` 完全没反应。规划中插件越加越多，没有排序与结果上限将来也会面临"列表太长无法浏览"的问题。本 PR 把这条链路补完，同时保持 headless 原则：宿主若想自己用 React/Vue 渲染菜单，仍可只听事件、通过 `onCommand` 接管派发，bundled UI 完全可选。

## Changes / 变更内容

- `packages/core`:
  - `SlashCommandDef` 新增可选字段 `run?: (editor) => boolean | void` 与 `description?: string`，向后兼容（metadata-only 用法依旧合法）
  - `filterSlashCommands` 重写为五档相关性排序：exact title → title prefix → exact keyword → title substring → keyword prefix → keyword substring；空 query 保留注册顺序
  - `computeSlashState(doc, cursor, commands, { limit })` 新增 `limit` 选项，默认 8；通过 `EditorConfig.slashMenuLimit` 透传
  - 从 `index.ts` 导出 `computeSlashState` / `filterSlashCommands` / `getSlashMatch` 及相关类型
- `packages/plugin-*`:
  - `plugin-slash`: 删除与 core 重复的 helpers 改为 re-export；**新增 `createSlashMenuUI(editor, options?)`**（vanilla DOM 浮层，含键盘 ↑↓⏎/Tab/Esc/Home/End、IME 抑制、视口翻转、右侧夹紧、`onCommand` 重写、ARIA listbox + activedescendant）；新增 `README.md`
  - `plugin-toolbar`: 导出 `toolbarSlashCommands` —— 14 条命令（h1-3 / bold / italic / strike / inline-code / code-block / blockquote / ulist / olist / link / image / hr），每条挂 `run` 复用既有格式化辅助函数
- `apps/electron-demo`:
  - `editor-shell.ts` 在 `createEditor` 之后挂载 `createSlashMenuUI(editor)`，`destroy()` 同步清理
  - `style.css` 新增主题化菜单样式（CSS variable 驱动，自动跟随 light/dark）
  - `sample-vault/slash-demo.md` 新增引导文档；`index.md` 加入链接
  - `package.json` 加入 `@floatboat/nexus-plugin-slash` workspace 依赖，`vite.config.ts` 加对应 alias
- `openspec/`:
  - 新增 `changes/add-slash-menu-ui/`，包含 `proposal.md` / `design.md` / `tasks.md`（全部勾完）
  - 两份 delta：`specs/editor-core/spec.md`（ranking / limit / run）+ `specs/slash-menu/spec.md`（**新增 capability**：浮层 UI 行为契约）
- 其他文档：`docs/ROADMAP.md` / `docs/ROADMAP.zh.md` 把 #3 标记为 done 并新增 #27 行；顶层 `README.md` / `README.zh.md` 更新 plugin 表格描述

## Testing / 测试

- [x] `pnpm test` passes / 全绿 —— **268 / 268 通过**
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过：
  - `@floatboat/nexus-core` —— JS 140.76 KB，d.ts 13.20 KB
  - `@floatboat/nexus-plugin-slash` —— JS 9.34 KB，d.ts 2.86 KB
  - `@floatboat/nexus-plugin-toolbar` —— JS 33.64 KB，d.ts 2.76 KB
  - `@floatboat/nexus-electron-demo` —— renderer + main 均通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - `packages/core/test/slash-state.test.ts`（新增，20 cases，覆盖空 query 顺序、各档排序优先级、limit 边界、字母序兜底）
  - `packages/core/test/events.test.ts`（扩展，新增 slashMenuLimit 透传、`run` 字段透传共 2 cases）
  - `packages/plugin-slash/test/menu-ui.test.ts`（新增 jsdom 套件，27 cases，覆盖挂载/卸载、渲染、键盘、鼠标、Escape 锁存、点菜单外、IME 抑制）
  - `packages/plugin-slash/test/plugin-slash.test.ts`（扩展，新增 ranking、limit、run 透传 4 cases）
  - `packages/plugin-toolbar/test/plugin-toolbar.test.ts`（扩展，验证 14 条 slash 命令注册 + 通过 `getSlashCommands` 派发执行）
- [x] Manual UI check in electron-demo / electron-demo 手动验证：
  - `/` 打开浮层并列出 8 条命令（命中默认 cap）
  - `/h2` 通过 title-prefix 排序收窄到 **Heading 2**
  - `/list` 同时展示 bulleted / numbered
  - `/zzz` 菜单保留打开，显示 **No matches** 占位（刻意为之，详见下方"UX 说明"）
  - `↑` / `↓` / `Home` / `End` 导航；`Enter` / `Tab` 确认并自动消除 `/query` 触发文本；`Esc` 关闭且不撤销输入
  - 点菜单外区域关闭
  - 菜单打开时缩放窗口 → 位置重新计算
  - 光标位于视口底部触发 → 菜单翻转到光标上方
  - light / dark 主题分别验证样式

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits（`feat(slash): ...`）
- [x] Public API changes update package README / types — 改了公共 API 已同步 README 与类型（`packages/plugin-slash/README.md` 新增；顶层 README 表格描述同步；`SlashCommandDef.run` / `EditorConfig.slashMenuLimit` 类型均在 `packages/core/src/types.ts` 中导出）
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则 —— **本 PR 未触及 `live-preview-table.ts`**
- [x] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec —— 见 `openspec/changes/add-slash-menu-ui/`
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## UX 说明（评审参考）

`/zzz` 故意**保留菜单 + 显示 No matches** 而不是直接关闭，四条理由：

1. "触发态丢失" vs "查询无匹配" 是两种状态，视觉必须区分；直接隐藏会让用户搞不清当前是哪一种。
2. 菜单可见时 `Esc` / `Enter` / `Tab` 的键位语义保持固定；若菜单忽隐忽现，按键会在"菜单动作"与"编辑器输入"之间反复切换。
3. 明确反馈"为什么没匹配" —— 用户立刻知道是关键字不对，删两个字符就能回到匹配，无需重新触发。
4. 与 Notion / Obsidian / VS Code 命令面板 / Linear 行为一致，符合用户肌肉记忆。

后续若需 `hideOnNoMatch: true` 选项可直接增量加，不影响现有默认。

## Commits（6 段，每段独立通过 `pnpm vitest run`）

1. `docs(openspec): scaffold add-slash-menu-ui proposal`
2. `feat(core): add run callback and ranking to slash commands`
3. `feat(slash): floating menu UI with keyboard navigation and a11y`
4. `feat(toolbar): register slash commands for formatting actions`
5. `feat(electron): mount slash menu and add demo content`
6. `docs: mark slash menu sorting/limit roadmap done`

## Out of scope（识别但本 PR 不做）

- 菜单分组 / 分类标题
- 持久化"最近使用"排序（需宿主注入存储适配器，独立设计讨论）
- 在 live-preview widget（如表格单元格）内部触发菜单
- 模糊匹配 —— 已记录在 ROADMAP #17（P2）

## Screenshots / Recordings · 截图或录屏 (UI changes)

> ⏩ 视频已加速至 2x，便于快速浏览。
https://github.com/user-attachments/assets/ba358aba-aa3e-44c4-8f7e-f88d336732c7

