### PR TITLE
feat(core): add getSelectedText API

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 ```ts
 editor.getDocument()          // current Markdown string
 editor.getAst()               // current mdast Root
+editor.getSelectedText()      // current selected Markdown text
 editor.setDocument(md)        // replace entire document
 editor.setSelection(pos)      // move cursor
 editor.focus() / editor.blur()

--- a/README.zh.md
+++ b/README.zh.md
@@ -206,6 +206,7 @@ pnpm dev:electron-demo
 ```ts
 editor.getDocument()          // 当前 Markdown 文本
 editor.getAst()               // 当前 mdast 语法树
+editor.getSelectedText()      // 当前选中的 Markdown 文本
 editor.setDocument(md)        // 替换整个文档
 editor.setSelection(pos)      // 移动光标
 editor.focus() / editor.blur()

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -407,6 +407,12 @@ export function createEditor(config: EditorConfig): EditorAPI {
       const sel = view.state.selection.main;
       return { anchor: sel.anchor, head: sel.head };
     },
+    getSelectedText() {
+      const sel = view.state.selection.main;
+      const from = Math.min(sel.anchor, sel.head);
+      const to = Math.max(sel.anchor, sel.head);
+      return from === to ? "" : view.state.sliceDoc(from, to);
+    },
     getSlashCommands() {
       return slashCommands;
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,6 +129,7 @@ export interface EditorAPI {
   exportHTML(): string;
   setTheme(theme: import("./theme").NexusTheme): void;
   getSelection(): { anchor: number; head: number };
+  getSelectedText(): string;
   getSlashCommands(): SlashCommandDef[];
   uploadAsset(file: File): Promise<string | null>;
   setSelection(anchor: number, head?: number): void;

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -85,6 +85,21 @@ describe("createEditor", () => {
     editor.destroy();
   });
 
+  it("returns selected text from the current main selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello **world**" });
+
+    editor.setSelection(6, 15);
+    expect(editor.getSelectedText()).toBe("**world**");
+
+    editor.setSelection(15, 6);
+    expect(editor.getSelectedText()).toBe("**world**");
+
+    editor.setSelection(5);
+    expect(editor.getSelectedText()).toBe("");
+    editor.destroy();
+  });
+
   it("keeps the editor usable when the parser throws", () => {
     const container = document.createElement("div");
     const docs: string[] = [];


### PR DESCRIPTION
## Summary
- Add `EditorAPI.getSelectedText()` for reading the current main selection as Markdown text.
- Return an empty string for collapsed selections and normalize reversed anchor/head ranges.
- Document the new API in English and Chinese README files.

## Tests
- `pnpm test -- packages/core/test/editor.test.ts`
- `pnpm test`
- `pnpm build`

Roadmap item: P0 Core API completeness - `getSelectedText()` API.