### PR TITLE
feat(search): support regex queries

### DIFF
--- a/packages/plugin-search/README.md
+++ b/packages/plugin-search/README.md
@@ -1,0 +1,54 @@
+# @floatboat/nexus-plugin-search
+
+Search panel and programmatic search/replace helpers for Nexus Editor.
+
+## Usage
+
+```ts
+import {
+  createSearchPlugin,
+  findSearchMatches,
+  replaceAllMatches
+} from "@floatboat/nexus-plugin-search";
+
+const searchPlugin = createSearchPlugin({
+  regexp: true,
+  caseSensitive: true
+});
+```
+
+## Options
+
+### `createSearchPlugin(options)`
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `top` | `boolean` | `true` | Render the search panel above the editor content. |
+| `caseSensitive` | `boolean` | `false` | Enable case-sensitive search by default. |
+| `regexp` | `boolean` | `false` | Enable regular expression search by default. When enabled, the CodeMirror search configuration uses regex semantics instead of literal search. |
+| `highlightSelectionMatches` | `boolean` | `true` | Highlight viewport matches for the current selection. |
+| `labels` | `Partial<SearchPluginLabels>` | `undefined` | Override search panel labels. |
+
+### `findSearchMatches(doc, query, options)`
+
+Returns all matches for `query`. Searches are case-insensitive and literal by default.
+
+Pass `{ regexp: true }` to interpret `query` as a JavaScript regular expression:
+
+```ts
+findSearchMatches("hello hullo", "h.llo", { regexp: true });
+```
+
+Invalid regular expressions are treated as no matches and emit a `console.warn`.
+
+### `replaceAllMatches(doc, query, replacement, options)`
+
+Replaces every match in `doc`. Literal replacement is used by default.
+
+With `{ regexp: true }`, replacement strings support JavaScript replacement syntax such as capture groups:
+
+```ts
+replaceAllMatches("width=10", "(\\w+)=(\\d+)", "$1: $2", { regexp: true });
+```
+
+Invalid regular expressions return the original document and emit a `console.warn`.

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,6 +25,7 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  regexp?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -36,6 +37,10 @@ export interface SearchPluginOptions {
    * Enable case-sensitive search by default.
    */
   caseSensitive?: boolean;
+  /**
+   * Enable regular expression search by default.
+   */
+  regexp?: boolean;
   /**
    * Highlight viewport matches for the current selection.
    */
@@ -79,6 +84,17 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function createSearchPattern(query: string, options: SearchOptions): RegExp | null {
+  const flags = options.caseSensitive ? "g" : "gi";
+  const source = options.regexp ? query : escapeRegExp(query);
+
+  try {
+    return new RegExp(source, flags);
+  } catch {
+    return null;
+  }
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -88,8 +104,11 @@ export function findSearchMatches(
     return [];
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  const pattern = new RegExp(escapeRegExp(query), flags);
+  const pattern = createSearchPattern(query, options);
+  if (!pattern) {
+    return [];
+  }
+
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {
@@ -116,8 +135,12 @@ export function replaceAllMatches(
     return doc;
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  return doc.replace(new RegExp(escapeRegExp(query), flags), replacement);
+  const pattern = createSearchPattern(query, options);
+  if (!pattern) {
+    return doc;
+  }
+
+  return doc.replace(pattern, replacement);
 }
 
 function resolveLabel(
@@ -539,6 +562,7 @@ export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlug
     search({
       top: options.top ?? true,
       caseSensitive: options.caseSensitive ?? false,
+      regexp: options.regexp ?? false,
       literal: true,
       createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels)
     }),

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -90,7 +90,10 @@ function createSearchPattern(query: string, options: SearchOptions): RegExp | nu
 
   try {
     return new RegExp(source, flags);
-  } catch {
+  } catch (error) {
+    if (options.regexp) {
+      console.warn("[@floatboat/nexus-plugin-search] Invalid regular expression treated as no matches.", error);
+    }
     return null;
   }
 }
@@ -563,7 +566,7 @@ export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlug
       top: options.top ?? true,
       caseSensitive: options.caseSensitive ?? false,
       regexp: options.regexp ?? false,
-      literal: true,
+      literal: !(options.regexp ?? false),
       createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels)
     }),
     keymap.of(searchKeymap)

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -21,8 +21,43 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("treats search text literally by default", () => {
+    expect(findSearchMatches("a.b axb a.b", "a.b")).toEqual([
+      { from: 0, to: 3, text: "a.b" },
+      { from: 8, to: 11, text: "a.b" }
+    ]);
+  });
+
+  it("supports regular expression search", () => {
+    expect(findSearchMatches("hello hullo hxllo", "h.llo", { regexp: true })).toEqual([
+      { from: 0, to: 5, text: "hello" },
+      { from: 6, to: 11, text: "hullo" },
+      { from: 12, to: 17, text: "hxllo" }
+    ]);
+  });
+
+  it("supports case-sensitive regular expression search", () => {
+    expect(findSearchMatches("ABC abc Abc", "a.c", { regexp: true, caseSensitive: true })).toEqual([
+      { from: 4, to: 7, text: "abc" }
+    ]);
+  });
+
+  it("returns no matches for invalid regular expressions", () => {
+    expect(findSearchMatches("alpha beta", "[", { regexp: true })).toEqual([]);
+  });
+
   it("replaces all matches in a document", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
+  });
+
+  it("supports capture groups in regular expression replacements", () => {
+    expect(
+      replaceAllMatches("width=10 height=20", "(\\w+)=(\\d+)", "$1: $2", { regexp: true })
+    ).toBe("width: 10 height: 20");
+  });
+
+  it("returns the original document when replacing with an invalid regular expression", () => {
+    expect(replaceAllMatches("alpha beta", "[", "x", { regexp: true })).toBe("alpha beta");
   });
 
   it("creates a search plugin descriptor", () => {
@@ -111,6 +146,46 @@ describe("@floatboat/nexus-plugin-search", () => {
     replaceToggle?.click();
     expect(replaceToggle?.getAttribute("aria-expanded")).toBe("false");
     expect(replaceRow?.hidden).toBe(true);
+
+    editor.destroy();
+    container.remove();
+  });
+
+  it("can enable regular expression search by default in the search panel", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const editor = createEditor({
+      container,
+      initialValue: "alpha beta",
+      plugins: [createSearchPlugin({ regexp: true })]
+    });
+
+    const content = container.querySelector<HTMLElement>(".cm-content");
+    expect(content).not.toBeNull();
+    content?.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+    );
+    if (!container.querySelector('[data-test-id="markdown-search-bar"]')) {
+      content?.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          code: "KeyF",
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+    }
+
+    const regexpToggle = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-regexp-toggle"]');
+    expect(regexpToggle).not.toBeNull();
+    expect(regexpToggle?.checked).toBe(true);
 
     editor.destroy();
     container.remove();

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createEditor } from "@floatboat/nexus-core";
 import {
   createSearchPlugin,
@@ -43,7 +43,12 @@ describe("@floatboat/nexus-plugin-search", () => {
   });
 
   it("returns no matches for invalid regular expressions", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
     expect(findSearchMatches("alpha beta", "[", { regexp: true })).toEqual([]);
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
   });
 
   it("replaces all matches in a document", () => {
@@ -57,7 +62,12 @@ describe("@floatboat/nexus-plugin-search", () => {
   });
 
   it("returns the original document when replacing with an invalid regular expression", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
     expect(replaceAllMatches("alpha beta", "[", "x", { regexp: true })).toBe("alpha beta");
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
   });
 
   it("creates a search plugin descriptor", () => {


### PR DESCRIPTION
## Summary
- Add `regexp` support to plugin-search helper APIs.
- Keep literal search as the default behavior and safely ignore invalid regex patterns.
- Allow `createSearchPlugin({ regexp: true })` to initialize the search panel in regexp mode.

## Tests
- `pnpm test -- packages/plugin-search/test/plugin-search.test.ts`
- `pnpm test`
- `pnpm build`

Roadmap item: P1 Search / Commands - Regex search.