### PR TITLE
chore(roadmap): mark #5 and #15 as in-progress

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
 | 2  | Whole-word matching | `plugin-search` | P1 | planned | No | Extension of existing search options |
-| 15 | Regex search | `plugin-search` | P1 | planned | No | Watch escape edge cases |
+| 15 | Regex search | `plugin-search` | P1 | in-progress | No | Watch escape edge cases — PR #9 in review |
 | 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | planned | Yes | Needs persistence (localStorage or host-injected) |
 | 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib |
 | 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
@@ -33,7 +33,7 @@ This document maps every planned feature to **package ownership / priority / sta
 
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
-| 5 | `getSelectedText()` API | `core` | P0 | planned | No | Public API addition; needs types + tests |
+| 5 | `getSelectedText()` API | `core` | P0 | in-progress | No | Public API addition; needs types + tests — PR #8 in review |
 | 6 | Multi-cursor / multi-selection | `core` | P1 | planned | Yes | CM6 supports it; must verify live-preview and table interactions |
 | 7 | AST enhancement / Markdown extensions | `core` + `preset-gfm` | P2 | planned | Yes | Affects serialization and every AST-dependent plugin |
 | 8 | Undo / redo grouping | `plugin-history` | P1 | planned | No | Coordinate with table's `tableEditingCount` |

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -23,7 +23,7 @@
 | # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
 |---|---|---|---|---|---|---|
 | 2  | whole-word 匹配 | `plugin-search` | P1 | planned | 否 | 现有 search 选项扩展 |
-| 15 | 正则搜索 | `plugin-search` | P1 | planned | 否 | 注意转义边界用例 |
+| 15 | 正则搜索 | `plugin-search` | P1 | in-progress | 否 | 注意转义边界用例 —— PR #9 review 中 |
 | 16 | 历史命令 / 搜索记忆 | `plugin-search` + `plugin-slash` | P2 | planned | 是 | 需要持久化层（localStorage 或宿主注入） |
 | 17 | 模糊搜索 | `plugin-search` | P2 | planned | 否 | 评估 fzf-like 算法 vs. 第三方 lib |
 | 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | done | 是 | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui` |
@@ -33,7 +33,7 @@
 
 | # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
 |---|---|---|---|---|---|---|
-| 5 | `getSelectedText()` API | `core` | P0 | planned | 否 | 公共 API 增量，需补类型 + 测试 |
+| 5 | `getSelectedText()` API | `core` | P0 | in-progress | 否 | 公共 API 增量，需补类型 + 测试 —— PR #8 review 中 |
 | 6 | 多光标 / 多选支持 | `core` | P1 | planned | 是 | CM6 已有底层，需在 live-preview 与表格交互中验证不破坏 |
 | 7 | AST 增强 / Markdown 扩展 | `core` + `preset-gfm` | P2 | planned | 是 | 影响序列化与所有依赖 AST 的插件 |
 | 8 | undo / redo 分组 | `plugin-history` | P1 | planned | 否 | 注意与表格交互的 `tableEditingCount` 协同 |


### PR DESCRIPTION
## Summary / 摘要

把两条 ROADMAP 状态从 `planned` 改成 `in-progress`，并在备注里挂上对应在 review 的 PR 链接：

- **#5 `getSelectedText()` API** — PR #8 in review
- **#15 Regex search** — PR #9 in review

中英双份同步。

## Motivation / 背景与动机

按 ROADMAP "Maintenance §2"：start work → `in-progress`。两条 P0 / P1 都已有候选 PR 在迭代，状态滞后会让 contributor 重复挑题（参考 #5 已经收到 3 份重复提交）。提前在 ROADMAP 标 in-progress + PR 号能减少这种碰撞。

## Changes / 变更内容

- \`docs/ROADMAP.md\`: 第 26 行 (#15) 与第 36 行 (#5) 状态字段改为 \`in-progress\`，备注追加 PR 引用
- \`docs/ROADMAP.zh.md\`: 同步两处

## Testing / 测试

文档改动，无需测试。

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] No secrets / personal vault data committed / 无敏感信息被提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)