### PR TITLE
fix(electron-demo): add nexus-plugin-slash tsconfig path mapping

### DIFF
--- a/apps/electron-demo/tsconfig.json
+++ b/apps/electron-demo/tsconfig.json
@@ -7,6 +7,7 @@
       "@floatboat/nexus-preset-gfm": ["packages/preset-gfm/src/index.ts"],
       "@floatboat/nexus-plugin-history": ["packages/plugin-history/src/index.ts"],
       "@floatboat/nexus-plugin-search": ["packages/plugin-search/src/index.ts"],
+      "@floatboat/nexus-plugin-slash": ["packages/plugin-slash/src/index.ts"],
       "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"]
     }
   },


### PR DESCRIPTION
## Summary / 摘要

补一行 `apps/electron-demo/tsconfig.json` 的 `paths` 映射，修 CI 上 main 分支 Typecheck 红：

\`\`\`
src/renderer/editor-shell.ts(11,53): error TS2307: Cannot find module '@floatboat/nexus-plugin-slash'
\`\`\`

## Root cause / 根因

PR #5（slash 浮层菜单 UI）落地时同步了：

- ✅ \`apps/electron-demo/package.json\` 新增 workspace 依赖
- ✅ \`apps/electron-demo/vite.config.ts\` 加 alias
- ✅ \`tsconfig.base.json\` 的全局 \`paths\` 表加 entry
- ❌ **遗漏**：\`apps/electron-demo/tsconfig.json\` 自己又重声明了一份 \`paths\`，对 TypeScript 来说子 tsconfig 的 \`paths\` 是**完全覆盖**而非合并基础配置，所以基础那条 entry 在 demo 这一级不生效。

本地之前可能因为 \`packages/plugin-slash/dist/\` 已构建而能解析；CI 全新环境没有 dist，tsc 直接报 TS2307。

## Fix / 修复

\`apps/electron-demo/tsconfig.json\` 的 \`paths\` 加一行：

\`\`\`json
"@floatboat/nexus-plugin-slash": ["packages/plugin-slash/src/index.ts"],
\`\`\`

## Testing / 测试

- [x] \`pnpm run typecheck\` 本地全绿（修前 demo 报 TS2307；修后无 error）
- [x] Conventional Commits 标题

## 顺带建议（不在本 PR 范围内）

demo 这份 \`tsconfig.json\` 的 \`paths\` 与 base 的高度重复，将来新增包很容易再次漏配。可考虑删除子 tsconfig 的 \`paths\` 段，完全继承 base —— 但那要 separately verify 没有 demo 特有的解析差异，留给后续 cleanup。

🤖 Generated with [Claude Code](https://claude.com/claude-code)