### PR TITLE
feat(search): add fuzzy search helpers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 2  | Whole-word matching | `plugin-search` | P1 | planned | No | Extension of existing search options |
 | 15 | Regex search | `plugin-search` | P1 | in-progress | No | Watch escape edge cases — PR #9 in review |
 | 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | planned | Yes | Needs persistence (localStorage or host-injected) |
-| 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib |
+| 17 | Fuzzy search | `plugin-search` | P2 | in-progress | No | Evaluate fzf-like algorithm vs. third-party lib |
 | 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0 | done | Yes | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui` |
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -25,7 +25,7 @@
 | 2  | whole-word 匹配 | `plugin-search` | P1 | planned | 否 | 现有 search 选项扩展 |
 | 15 | 正则搜索 | `plugin-search` | P1 | in-progress | 否 | 注意转义边界用例 —— PR #9 review 中 |
 | 16 | 历史命令 / 搜索记忆 | `plugin-search` + `plugin-slash` | P2 | planned | 是 | 需要持久化层（localStorage 或宿主注入） |
-| 17 | 模糊搜索 | `plugin-search` | P2 | planned | 否 | 评估 fzf-like 算法 vs. 第三方 lib |
+| 17 | 模糊搜索 | `plugin-search` | P2 | in-progress | 否 | 评估 fzf-like 算法 vs. 第三方 lib |
 | 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | done | 是 | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash 命令浮层菜单 UI | `plugin-slash` + `electron-demo` | P0 | done | 是 | `createSlashMenuUI(editor, options)` —— 见 `openspec/changes/add-slash-menu-ui` |
 

--- a/packages/plugin-search/README.md
+++ b/packages/plugin-search/README.md
@@ -1,0 +1,52 @@
+# @floatboat/nexus-plugin-search
+
+Search panel and programmatic search/replace helpers for Nexus Editor.
+
+## Usage
+
+```ts
+import {
+  createSearchPlugin,
+  findSearchMatches,
+  replaceAllMatches
+} from "@floatboat/nexus-plugin-search";
+
+const searchPlugin = createSearchPlugin({
+  caseSensitive: true
+});
+```
+
+## Options
+
+### `createSearchPlugin(options)`
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `top` | `boolean` | `true` | Render the search panel above the editor content. |
+| `caseSensitive` | `boolean` | `false` | Enable case-sensitive search by default. |
+| `highlightSelectionMatches` | `boolean` | `true` | Highlight viewport matches for the current selection. |
+| `labels` | `Partial<SearchPluginLabels>` | `undefined` | Override search panel labels. |
+
+### `findSearchMatches(doc, query, options)`
+
+Returns all matches for `query`. Searches are case-insensitive and literal by default.
+
+Pass `{ fuzzy: true }` to interpret `query` as an ordered subsequence. Fuzzy search returns the smallest contiguous, line-local text window containing the query characters in order:
+
+```ts
+findSearchMatches("Nexus Editor", "nxed", { fuzzy: true });
+// [{ from: 0, to: 8, text: "Nexus Ed" }]
+```
+
+Fuzzy search does not match across line breaks. Combine with `{ caseSensitive: true }` to require exact character casing.
+
+### `replaceAllMatches(doc, query, replacement, options)`
+
+Replaces every match in `doc`. Literal replacement is used by default.
+
+With `{ fuzzy: true }`, replacement applies to each fuzzy match window:
+
+```ts
+replaceAllMatches("Nexus Ed note", "nxed", "Match", { fuzzy: true });
+// "Match note"
+```

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,6 +25,11 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  /**
+   * Treat the query as an ordered subsequence and return the smallest
+   * line-local text window containing those characters.
+   */
+  fuzzy?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -79,6 +84,87 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function normalizeSearchText(value: string, options: SearchOptions): string {
+  return options.caseSensitive ? value : value.toLowerCase();
+}
+
+function findFuzzyWindow(
+  text: string,
+  query: string,
+  options: SearchOptions,
+  fromIndex: number
+): { from: number; to: number } | null {
+  const haystack = normalizeSearchText(text, options);
+  const needle = normalizeSearchText(query, options);
+  let queryIndex = 0;
+  let end = -1;
+
+  for (let index = fromIndex; index < haystack.length; index += 1) {
+    if (haystack[index] !== needle[queryIndex]) {
+      continue;
+    }
+
+    queryIndex += 1;
+    if (queryIndex === needle.length) {
+      end = index;
+      break;
+    }
+  }
+
+  if (end < 0) {
+    return null;
+  }
+
+  queryIndex = needle.length - 1;
+  let start = end;
+
+  for (let index = end; index >= fromIndex; index -= 1) {
+    if (haystack[index] !== needle[queryIndex]) {
+      continue;
+    }
+
+    start = index;
+    queryIndex -= 1;
+    if (queryIndex < 0) {
+      break;
+    }
+  }
+
+  return { from: start, to: end + 1 };
+}
+
+function findFuzzySearchMatches(doc: string, query: string, options: SearchOptions): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+  let lineStart = 0;
+
+  for (let index = 0; index <= doc.length; index += 1) {
+    if (index !== doc.length && doc[index] !== "\n") {
+      continue;
+    }
+
+    const line = doc.slice(lineStart, index);
+    let cursor = 0;
+
+    while (cursor < line.length) {
+      const window = findFuzzyWindow(line, query, options, cursor);
+      if (!window) {
+        break;
+      }
+
+      matches.push({
+        from: lineStart + window.from,
+        to: lineStart + window.to,
+        text: line.slice(window.from, window.to)
+      });
+      cursor = window.to;
+    }
+
+    lineStart = index + 1;
+  }
+
+  return matches;
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -86,6 +172,10 @@ export function findSearchMatches(
 ): SearchMatch[] {
   if (!query) {
     return [];
+  }
+
+  if (options.fuzzy) {
+    return findFuzzySearchMatches(doc, query, options);
   }
 
   const flags = options.caseSensitive ? "g" : "gi";
@@ -114,6 +204,22 @@ export function replaceAllMatches(
 ): string {
   if (!query) {
     return doc;
+  }
+
+  if (options.fuzzy) {
+    const matches = findFuzzySearchMatches(doc, query, options);
+    if (matches.length === 0) {
+      return doc;
+    }
+
+    let next = "";
+    let cursor = 0;
+    for (const match of matches) {
+      next += doc.slice(cursor, match.from);
+      next += replacement;
+      cursor = match.to;
+    }
+    return next + doc.slice(cursor);
   }
 
   const flags = options.caseSensitive ? "g" : "gi";

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -21,8 +21,33 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("keeps searches literal by default instead of fuzzy", () => {
+    expect(findSearchMatches("Nexus Editor", "nxed")).toEqual([]);
+  });
+
+  it("supports fuzzy ordered-subsequence search", () => {
+    expect(findSearchMatches("Nexus Editor\nMarkdown Guide", "nxed", { fuzzy: true })).toEqual([
+      { from: 0, to: 8, text: "Nexus Ed" }
+    ]);
+  });
+
+  it("keeps fuzzy search within a single line", () => {
+    expect(findSearchMatches("ne\nxd", "nxd", { fuzzy: true })).toEqual([]);
+  });
+
+  it("supports case-sensitive fuzzy search", () => {
+    expect(findSearchMatches("Nexus Editor", "ne", { fuzzy: true, caseSensitive: true })).toEqual([]);
+    expect(findSearchMatches("Nexus Editor", "NE", { fuzzy: true, caseSensitive: true })).toEqual([
+      { from: 0, to: 7, text: "Nexus E" }
+    ]);
+  });
+
   it("replaces all matches in a document", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
+  });
+
+  it("replaces fuzzy match windows in a document", () => {
+    expect(replaceAllMatches("Nexus Ed note", "nxed", "Match", { fuzzy: true })).toBe("Match note");
   });
 
   it("creates a search plugin descriptor", () => {


### PR DESCRIPTION
## Summary
- Add fuzzy ordered-subsequence matching to plugin-search helpers
- Support fuzzy replacement over matched text windows
- Document the fuzzy helper behavior and mark Roadmap #17 in progress

## Changes

| Package | File | Change |
|---|---|---|
| plugin-search | `src/index.ts` | Add `fuzzy?: boolean` to `SearchOptions` |
| plugin-search | `src/index.ts` | Add line-local ordered-subsequence matcher for `findSearchMatches` |
| plugin-search | `src/index.ts` | Add fuzzy replacement window support to `replaceAllMatches` |
| plugin-search | `test/plugin-search.test.ts` | Add fuzzy default, match, case-sensitive, line-boundary, and replace tests |
| plugin-search | `README.md` | Document fuzzy helper behavior and examples |
| docs | `ROADMAP.md`, `ROADMAP.zh.md` | Mark Roadmap #17 as `in-progress` |

## Tasks
- [x] Add fuzzy option to `SearchOptions`
- [x] Implement line-local ordered-subsequence matching
- [x] Preserve literal search as the default behavior
- [x] Support case-sensitive fuzzy search
- [x] Support fuzzy replacement windows
- [x] Add focused unit tests
- [x] Add `packages/plugin-search/README.md` docs
- [x] Mark Roadmap #17 in progress
- [ ] Reviewer approval
- [ ] Merge after checks pass

## Tests
- [x] pnpm test -- packages/plugin-search/test/plugin-search.test.ts
- [x] pnpm --filter @floatboat/nexus-plugin-search build

Roadmap: #17 Fuzzy search