### PR TITLE
docs(openspec): propose realtime collaboration plugin

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -63,7 +63,7 @@ This document maps every planned feature to **package ownership / priority / sta
 
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
-| 18 | Realtime collaboration (OT / CRDT) | new `plugin-collab` | P3 | planned | Yes | Large feature; start with a tech-selection design doc |
+| 18 | Realtime collaboration (OT / CRDT) | new `plugin-collab` | P3 | in-progress | Yes | See `openspec/changes/add-realtime-collaboration` |
 | 19 | Version history / snapshots | `core` + host storage | P2 | planned | Yes | electron-demo lands the reference impl first |
 | 20 | Shared comments / @mention | new `plugin-annotation` | P3 | planned | Yes | Depends on #18 |
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -63,7 +63,7 @@
 
 | # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
 |---|---|---|---|---|---|---|
-| 18 | 实时协作（OT / CRDT） | 新包 `plugin-collab` | P3 | planned | 是 | 大特性，先做技术选型 design doc |
+| 18 | 实时协作（OT / CRDT） | 新包 `plugin-collab` | P3 | in-progress | 是 | 见 `openspec/changes/add-realtime-collaboration` |
 | 19 | 版本历史 / 快照 | `core` + 宿主存储 | P2 | planned | 是 | electron-demo 先落地参考实现 |
 | 20 | 共享注释 / @mention | 新包 `plugin-annotation` | P3 | planned | 是 | 依赖 #18 完成 |
 

--- a/openspec/changes/add-realtime-collaboration/design.md
+++ b/openspec/changes/add-realtime-collaboration/design.md
@@ -1,0 +1,91 @@
+## Context
+
+Realtime collaboration is not just a UI feature. It changes how document changes are represented, merged, attributed, persisted, and replayed. The editor core is intentionally single-document and host-agnostic, so the collaboration layer should be a plugin that composes with CodeMirror state rather than a core rewrite.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Multiple clients editing the same logical document converge without manual merge conflicts.
+- Local edits remain responsive while remote edits arrive asynchronously.
+- Remote cursor and selection presence can be rendered without taking editor focus.
+- Hosts own transport, identity, authentication, authorization, and persistence.
+- The first implementation can be tested without a production server.
+
+**Non-Goals:**
+- Comments, @mentions, annotation threads, or review workflows. Those are Roadmap #20.
+- Cloud storage or vault sync. That is Roadmap #23.
+- Version history snapshots. That is Roadmap #19.
+- Permission models, ACLs, or end-to-end encryption.
+- A hosted collaboration server maintained by this package.
+
+## Decision 1: Use CRDT, not Operational Transform
+
+Use a CRDT document model for shared editing. Operational Transform can work well with a central authority, but it requires a stricter server contract and transformation logic across every operation shape. A CRDT model is a better fit for Nexus because the editor is local-first, host-embedded, and likely to support intermittent connections.
+
+Proposed implementation target: Yjs.
+
+Rationale:
+- Handles concurrent edits and reconnect replay without a custom OT server.
+- Has a mature ecosystem for awareness/presence and editor bindings.
+- Keeps the Nexus plugin focused on integration and API design instead of inventing merge algorithms.
+
+## Decision 2: Keep transport host-owned
+
+The package should not open sockets itself by default. Instead, it should accept a provider object supplied by the host:
+
+```ts
+export interface CollabProvider {
+  connect(): void | Promise<void>;
+  disconnect(): void | Promise<void>;
+  destroy(): void;
+  readonly status: "disconnected" | "connecting" | "connected" | "error";
+  onStatusChange(listener: (status: CollabProvider["status"]) => void): () => void;
+}
+```
+
+The concrete provider may wrap y-websocket, WebRTC, a custom backend, or an in-memory test transport. This keeps auth, tenancy, backend URLs, and persistence out of the editor package.
+
+## Decision 3: New package, not core API
+
+Create `@floatboat/nexus-plugin-collab`. Do not add collaboration concepts to `@floatboat/nexus-core` unless implementation proves that a small core hook is unavoidable.
+
+The core already lets plugins add CodeMirror extensions. Collaboration should be one such extension. Core remains usable for single-user local editors and does not acquire network or CRDT dependencies.
+
+## Decision 4: Awareness is optional and separated from document sync
+
+Document sync and user presence should be configured separately. Some hosts may want conflict-free shared editing but no visible remote cursors. Others may want presence metadata only after auth resolves user names and colors.
+
+Public options should look roughly like:
+
+```ts
+createCollabPlugin({
+  docId,
+  provider,
+  awareness
+});
+```
+
+`awareness` should expose local user metadata and remote peer changes. Rendering can start with selection decorations and cursor labels.
+
+## Decision 5: Define lifecycle and document-loading rules early
+
+Collaboration conflicts with naive `editor.setDocument()` usage. The plugin must define:
+- initial document seeding: only seed an empty shared doc once
+- remote update application: must not emit host `onChange` loops as local user saves
+- teardown: unsubscribe provider and awareness listeners on editor destroy
+- switching documents: destroy the old collaboration session before joining another `docId`
+
+## Risks / Trade-offs
+
+- CRDT dependency size: Yjs adds bundle weight. Keep the package opt-in and avoid pulling it into core.
+- Binding maturity: if the preferred CodeMirror binding is stale, we may need a small internal adapter.
+- Persistence ambiguity: hosts need clear docs that provider persistence is their responsibility.
+- Undo/redo semantics: collaborative undo differs from local history. The first implementation should document expected behavior and test that local history does not corrupt remote edits.
+- Live preview/table widgets: remote edits may arrive while widgets are active. Implementation must test editor stability but should not special-case every widget in v1.
+
+## Open Questions
+
+- Should the package export helper factories for common providers, or only types plus `createCollabPlugin`?
+- Should collaboration mode disable local `setDocument()` after connect, or allow it as an explicit document reset API?
+- Should awareness rendering be built in or exposed as data for host-rendered cursors?
+- Should the demo use a tiny local websocket server, BroadcastChannel, or pure in-memory paired editors for the first smoke test?

--- a/openspec/changes/add-realtime-collaboration/proposal.md
+++ b/openspec/changes/add-realtime-collaboration/proposal.md
@@ -1,0 +1,32 @@
+# Change: Add Realtime Collaboration Plugin
+
+## Why
+
+Nexus Editor has local-first editing, vault navigation, wiki links, and plugin APIs, but no multi-user editing model. Roadmap #18 calls for realtime collaboration as a long-term capability. This needs a design-first change because collaboration affects document authority, conflict resolution, cursor presence, persistence, and host infrastructure boundaries.
+
+## What Changes
+
+- Add a new `@floatboat/nexus-plugin-collab` package centered on CodeMirror 6 collaboration bindings.
+- Use a CRDT-based model for shared document state. The proposed implementation target is Yjs because it is peer/order tolerant, supports offline replay, and has established CodeMirror integration patterns.
+- Keep networking host-owned. The plugin accepts a provider adapter instead of bundling a server, websocket endpoint, auth, or storage backend.
+- Define public types for:
+  - `CollabProvider` lifecycle and sync events.
+  - `CollabAwareness` user presence, remote selections, and cursors.
+  - `createCollabPlugin(options)` for editor integration.
+- Add an electron-demo-only in-memory or localhost provider as a smoke-test harness, not a production sync backend.
+- Document non-goals: comments, mentions, permissions, cloud storage, version history, and multi-vault sync.
+
+## Impact
+
+- Affected specs:
+  - `collaboration` (new capability)
+- Affected code in the implementation phase:
+  - `packages/plugin-collab/` (new package)
+  - root workspace/package scripts for build and publish inclusion
+  - `apps/electron-demo` optional demo harness
+  - `README.md` / `README.zh.md` package table
+  - `docs/ROADMAP.md` / `docs/ROADMAP.zh.md`
+- New dependencies in the implementation phase:
+  - likely `yjs`
+  - likely a CodeMirror/Yjs binding package or a small internal binding if the external binding is unsuitable
+- Breaking changes: none intended. Collaboration is opt-in via a new plugin.

--- a/openspec/changes/add-realtime-collaboration/specs/collaboration/spec.md
+++ b/openspec/changes/add-realtime-collaboration/specs/collaboration/spec.md
@@ -1,0 +1,100 @@
+# Collaboration Spec
+
+## ADDED Requirements
+
+### Requirement: Opt-In Collaboration Plugin
+
+The system SHALL provide an opt-in `@floatboat/nexus-plugin-collab` package that can be registered as a Nexus plugin without changing single-user editor behavior when the package is not installed.
+
+#### Scenario: Editor without collaboration remains local
+- **WHEN** an editor is created without `createCollabPlugin`
+- **THEN** document editing, history, parsing, and live preview SHALL behave as they do today
+- **AND** no collaboration dependencies SHALL be loaded by `@floatboat/nexus-core`
+
+#### Scenario: Collaboration plugin registers cleanly
+- **WHEN** an editor is created with `createCollabPlugin({ docId, provider })`
+- **THEN** the plugin SHALL attach collaboration extensions for that document id
+- **AND** the editor SHALL remain editable before and after the provider connects
+
+### Requirement: Host-Owned Provider Boundary
+
+The collaboration package SHALL accept a host-supplied provider object for transport, identity, authentication, and persistence. The package SHALL NOT require a Nexus-hosted server.
+
+#### Scenario: Provider connection lifecycle
+- **WHEN** the editor is created with a disconnected provider
+- **THEN** the plugin SHALL allow the provider to connect
+- **AND** provider status changes SHALL be observable through the public API
+
+#### Scenario: Provider cleanup
+- **WHEN** the editor is destroyed
+- **THEN** the plugin SHALL unsubscribe all collaboration listeners
+- **AND** SHALL disconnect or destroy provider resources according to the provider contract
+
+### Requirement: Concurrent Editing Convergence
+
+Multiple editors joined to the same collaboration document SHALL converge to the same document text after all local and remote updates are delivered.
+
+#### Scenario: Concurrent inserts converge
+- **GIVEN** two editors are connected to the same `docId`
+- **WHEN** both editors insert text at overlapping positions before receiving the other's update
+- **THEN** both editors SHALL eventually contain identical document text
+- **AND** neither user's inserted text SHALL be silently dropped
+
+#### Scenario: Remote update does not echo as a new local change
+- **GIVEN** an editor receives a remote collaboration update
+- **WHEN** that update is applied to the local editor state
+- **THEN** the plugin SHALL NOT rebroadcast it as a new local edit
+
+### Requirement: Initial Document Seeding
+
+The collaboration plugin SHALL define deterministic initial document seeding so a host can join an existing shared document without overwriting it.
+
+#### Scenario: Empty shared document can be seeded
+- **GIVEN** the shared collaboration document is empty
+- **WHEN** the host provides initial editor content
+- **THEN** the plugin MAY seed the shared document once with that content
+
+#### Scenario: Existing shared document wins
+- **GIVEN** the shared collaboration document already has content
+- **WHEN** a new editor joins with local initial content
+- **THEN** the shared document content SHALL become the editor content
+- **AND** the joiner SHALL NOT overwrite the shared document implicitly
+
+### Requirement: Awareness and Remote Presence
+
+The collaboration plugin SHALL support optional user awareness data and remote selection/cursor rendering without changing the local editor selection.
+
+#### Scenario: Remote cursor is rendered
+- **GIVEN** awareness is enabled
+- **WHEN** another user moves their cursor
+- **THEN** the local editor SHALL render that remote cursor or selection
+- **AND** the local user's selection SHALL remain unchanged
+
+#### Scenario: Awareness can be disabled
+- **WHEN** the plugin is created without awareness options
+- **THEN** document collaboration SHALL still work
+- **AND** no remote cursor UI SHALL be rendered
+
+### Requirement: Document Switching
+
+The collaboration plugin SHALL provide a safe lifecycle for leaving one document and joining another.
+
+#### Scenario: Switching document ids tears down old session
+- **WHEN** the host switches from `docA` to `docB`
+- **THEN** the plugin SHALL leave or destroy the `docA` session
+- **AND** subsequent remote updates for `docA` SHALL NOT mutate the editor now joined to `docB`
+
+### Requirement: Error and Reconnect Handling
+
+Provider errors and reconnects SHALL be visible to the host without making the editor read-only by default.
+
+#### Scenario: Provider enters error state
+- **WHEN** the provider reports an error
+- **THEN** the host SHALL be able to observe the error/status
+- **AND** local editing SHALL continue unless the host explicitly disables it
+
+#### Scenario: Reconnect applies queued updates
+- **GIVEN** the provider supports offline queuing
+- **WHEN** a disconnected editor reconnects
+- **THEN** queued local updates SHALL sync to peers
+- **AND** the document SHALL converge after delivery

--- a/openspec/changes/add-realtime-collaboration/tasks.md
+++ b/openspec/changes/add-realtime-collaboration/tasks.md
@@ -1,0 +1,45 @@
+## 1. OpenSpec
+
+- [ ] 1.1 Review proposal with maintainers and choose the provider boundary.
+- [ ] 1.2 Decide whether to depend on an existing CodeMirror/Yjs binding or implement a small adapter.
+- [x] 1.3 Validate `add-realtime-collaboration` with OpenSpec CLI when available.
+
+## 2. Package Scaffold
+
+- [ ] 2.1 Add `packages/plugin-collab/package.json`, `tsconfig.json`, `src/index.ts`, and tests.
+- [ ] 2.2 Add the package to root `pnpm build` and publish scripts.
+- [ ] 2.3 Add README documentation for setup, lifecycle, and host-owned provider requirements.
+
+## 3. Collaboration Core
+
+- [ ] 3.1 Implement `createCollabPlugin(options)` with CodeMirror extensions for shared document sync.
+- [ ] 3.2 Define and export `CollabProvider`, `CollabAwareness`, `CollabUser`, and `CollabPluginOptions`.
+- [ ] 3.3 Ensure local edits are applied immediately and remote updates converge without duplicate local echoes.
+- [ ] 3.4 Ensure `destroy()`/editor teardown disconnects listeners and provider resources.
+- [ ] 3.5 Define behavior for switching `docId` and document reseeding.
+
+## 4. Awareness / Presence
+
+- [ ] 4.1 Track local user metadata and remote peer metadata.
+- [ ] 4.2 Render remote selections/cursors as decorations.
+- [ ] 4.3 Avoid stealing focus or changing the local selection when remote presence updates.
+
+## 5. Demo Harness
+
+- [ ] 5.1 Add an electron-demo smoke path with two editor instances or a local test provider.
+- [ ] 5.2 Demonstrate concurrent typing convergence.
+- [ ] 5.3 Demonstrate remote cursor/presence rendering.
+
+## 6. Tests
+
+- [ ] 6.1 Unit test provider lifecycle and cleanup.
+- [ ] 6.2 Integration test two editor instances editing the same document.
+- [ ] 6.3 Test offline/reconnect replay if the chosen provider supports it in-process.
+- [ ] 6.4 Test collaboration with the history plugin enabled.
+- [ ] 6.5 Test remote updates while live preview is enabled.
+
+## 7. Documentation / Roadmap
+
+- [ ] 7.1 Update `README.md` / `README.zh.md` package lists.
+- [ ] 7.2 Update `docs/ROADMAP.md` / `docs/ROADMAP.zh.md` once implementation status changes.
+- [ ] 7.3 Document non-goals and provider ownership clearly.


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal for Roadmap #18 realtime collaboration
- Document CRDT/Yjs direction, host-owned provider boundary, awareness, lifecycle, and non-goals
- Mark Roadmap #18 as in progress with OpenSpec linkage

## Scope
- Proposal/design/spec only
- No runtime implementation in this PR

## Tasks
- [x] Scaffold OpenSpec proposal
- [x] Add technical design doc
- [x] Add collaboration spec requirements and scenarios
- [x] Add implementation task list
- [x] Link Roadmap #18 to the OpenSpec change
- [x] Run OpenSpec strict validation
- [ ] Proposal reviewed
- [ ] Implementation PR opened after approval

## Validation
- [x] openspec validate add-realtime-collaboration --strict

OpenSpec change: add-realtime-collaboration
Roadmap: #18 Realtime collaboration