### PR TITLE
docs(openspec): propose cloud storage interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 
 | Package | Description |
 |---|---|
-| `@floatboat/nexus-core` | Editor engine — CM6 state, AST pipeline, live preview, events, widget API |
+| `@floatboat/nexus-core` | Editor engine — CM6 state, AST pipeline, live preview, events, widget API, storage adapter contract |
 | `@floatboat/nexus-react` | React binding — `useEditor` hook and `<Editor />` component |
 | `@floatboat/nexus-vue` | Vue 3 binding — `useEditor` composable |
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown preset (tables, strikethrough, task lists) |
@@ -192,7 +192,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 - **Plugin System** — three tiers: shortcuts & slash commands, remark plugins & widgets, raw CM6 extensions.
 - **Event System** — subscribe to `change`, `focus`, `blur`, `selectionChange`, `slashMenuChange`.
 - **Widget API** — render custom components for any AST node type (code blocks, tables, diagrams).
-- **Local-First** — built for Electron/Tauri with file IO hooks and debounced parsing.
+- **Local-First** — built for Electron/Tauri and cloud-capable hosts through a provider-neutral storage adapter contract.
 
 ---
 
@@ -247,6 +247,37 @@ const myPlugin: NexusPlugin = {
   cmExtensions: [myCodeMirrorExtension],
 };
 ```
+
+</details>
+
+<details>
+<summary><b>Storage adapter contract</b> — host-owned note vault IO</summary>
+
+`@floatboat/nexus-core` exports dependency-free storage types. Core does not read files, call Electron, use browser storage, or authenticate to cloud providers; hosts provide a `NoteVaultAdapter`.
+
+```ts
+import {
+  readAllNoteVaultFiles,
+  type NoteVaultAdapter,
+} from "@floatboat/nexus-core";
+
+const adapter: NoteVaultAdapter = {
+  id: "my-provider",
+  label: "My notes",
+  capabilities: { createFile: true, createFolder: true, trash: true, watch: false },
+  list: async () => [],
+  read: async (ref) => ({ ref: { ...ref, kind: "file" }, content: "" }),
+  write: async (ref, content, opts) => ({ ref: { ...ref, kind: "file" } }),
+  createFile: async (parent, name, content = "") => ({ providerId: "my-provider", id: name, kind: "file" }),
+  createFolder: async (parent, name) => ({ providerId: "my-provider", id: name, kind: "folder" }),
+  rename: async (ref, name) => ({ ...ref, name }),
+  delete: async (ref, opts) => {},
+};
+
+const files = await readAllNoteVaultFiles(adapter);
+```
+
+Refs are provider-owned, so local adapters can use validated paths while cloud adapters can use opaque IDs. Common failure modes are represented with `NoteVaultError` codes such as `auth-required`, `permission-denied`, `conflict`, `offline`, and `unsupported-operation`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ const files = await readAllNoteVaultFiles(adapter);
 ```
 
 Refs are provider-owned, so local adapters can use validated paths while cloud adapters can use opaque IDs. Common failure modes are represented with `NoteVaultError` codes such as `auth-required`, `permission-denied`, `conflict`, `offline`, and `unsupported-operation`.
+Adapters can optionally implement `readAll` for batched startup/indexing reads; otherwise `readAllNoteVaultFiles` falls back to bounded-concurrency `list` + `read`.
 
 </details>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -278,6 +278,7 @@ const files = await readAllNoteVaultFiles(adapter);
 ```
 
 Ref 由 provider 拥有，所以本地适配器可以使用经过边界校验的路径，云端适配器也可以使用不透明 ID。常见失败场景通过 `NoteVaultError` code 表达，例如 `auth-required`、`permission-denied`、`conflict`、`offline`、`unsupported-operation`。
+适配器可以选择实现 `readAll` 来做启动/索引阶段的批量读取；否则 `readAllNoteVaultFiles` 会退回到有界并发的 `list` + `read`。
 
 </details>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -169,7 +169,7 @@ pnpm dev:electron-demo
 
 | 包名 | 说明 |
 |---|---|
-| `@floatboat/nexus-core` | 编辑器引擎 —— CM6 状态机、AST 管道、实时预览、事件系统、Widget API |
+| `@floatboat/nexus-core` | 编辑器引擎 —— CM6 状态机、AST 管道、实时预览、事件系统、Widget API、存储适配器契约 |
 | `@floatboat/nexus-react` | React 绑定 —— `useEditor` Hook 与 `<Editor />` 组件 |
 | `@floatboat/nexus-vue` | Vue 3 绑定 —— `useEditor` 组合式函数 |
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown 预设（表格、删除线、任务列表） |
@@ -192,7 +192,7 @@ pnpm dev:electron-demo
 - **插件系统** —— 三层架构：快捷键与斜杠命令、remark 插件与 Widget、原生 CM6 扩展。
 - **事件系统** —— 订阅 `change`、`focus`、`blur`、`selectionChange`、`slashMenuChange`。
 - **Widget API** —— 为任意 AST 节点类型（代码块、表格、图表等）渲染自定义组件。
-- **本地优先** —— 为 Electron / Tauri 设计，内置文件 IO 钩子与防抖解析。
+- **本地优先** —— 面向 Electron / Tauri 和云端宿主，通过 provider-neutral 的存储适配器契约接入。
 
 ---
 
@@ -247,6 +247,37 @@ const myPlugin: NexusPlugin = {
   cmExtensions: [myCodeMirrorExtension],
 };
 ```
+
+</details>
+
+<details>
+<summary><b>存储适配器契约</b> —— 宿主拥有 note vault IO</summary>
+
+`@floatboat/nexus-core` 导出无依赖的存储类型。Core 不读文件、不调用 Electron、不使用浏览器存储，也不处理云服务登录；宿主负责提供 `NoteVaultAdapter`。
+
+```ts
+import {
+  readAllNoteVaultFiles,
+  type NoteVaultAdapter,
+} from "@floatboat/nexus-core";
+
+const adapter: NoteVaultAdapter = {
+  id: "my-provider",
+  label: "My notes",
+  capabilities: { createFile: true, createFolder: true, trash: true, watch: false },
+  list: async () => [],
+  read: async (ref) => ({ ref: { ...ref, kind: "file" }, content: "" }),
+  write: async (ref, content, opts) => ({ ref: { ...ref, kind: "file" } }),
+  createFile: async (parent, name, content = "") => ({ providerId: "my-provider", id: name, kind: "file" }),
+  createFolder: async (parent, name) => ({ providerId: "my-provider", id: name, kind: "folder" }),
+  rename: async (ref, name) => ({ ...ref, name }),
+  delete: async (ref, opts) => {},
+};
+
+const files = await readAllNoteVaultFiles(adapter);
+```
+
+Ref 由 provider 拥有，所以本地适配器可以使用经过边界校验的路径，云端适配器也可以使用不透明 ID。常见失败场景通过 `NoteVaultError` code 表达，例如 `auth-required`、`permission-denied`、`conflict`、`offline`、`unsupported-operation`。
 
 </details>
 

--- a/apps/electron-demo/dist-electron/main.js
+++ b/apps/electron-demo/dist-electron/main.js
@@ -29,23 +29,8 @@ module.exports = __toCommonJS(main_exports);
 var import_electron = require("electron");
 var import_promises = require("fs/promises");
 var import_node_fs = require("fs");
-var import_node_path2 = __toESM(require("path"));
-var import_node_url = require("url");
-
-// electron/vault-path.ts
 var import_node_path = __toESM(require("path"));
-function assertPathInsideVault(vaultRoot, target) {
-  const root = import_node_path.default.resolve(vaultRoot);
-  const resolved = import_node_path.default.resolve(target);
-  const rel = import_node_path.default.relative(root, resolved);
-  if (rel === "" || rel === ".") return resolved;
-  if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
-    throw new Error(`Path escapes vault: ${target}`);
-  }
-  return resolved;
-}
-
-// electron/main.ts
+var import_node_url = require("url");
 import_electron.protocol.registerSchemesAsPrivileged([
   {
     scheme: "nexus-vault",
@@ -71,7 +56,7 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      preload: import_node_path2.default.join(__dirname, "preload.js")
+      preload: import_node_path.default.join(__dirname, "preload.js")
     }
   });
   mainWindow.once("ready-to-show", () => {
@@ -81,7 +66,7 @@ function createWindow() {
   if (devUrl) {
     mainWindow.loadURL(devUrl);
   } else {
-    mainWindow.loadFile(import_node_path2.default.join(__dirname, "../dist/index.html"));
+    mainWindow.loadFile(import_node_path.default.join(__dirname, "../dist/index.html"));
   }
   mainWindow.webContents.on("before-input-event", (_event, input) => {
     const meta = input.meta || input.control;
@@ -132,7 +117,13 @@ function assertInsideVault(target) {
   if (!activeVault) {
     throw new Error("No active vault");
   }
-  return assertPathInsideVault(activeVault, target);
+  const resolved = import_node_path.default.resolve(target);
+  const rel = import_node_path.default.relative(activeVault, resolved);
+  if (rel === "" || rel === ".") return resolved;
+  if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
+    throw new Error(`Path escapes vault: ${target}`);
+  }
+  return resolved;
 }
 async function scanDirectory(dir) {
   const entries = await (0, import_promises.readdir)(dir, { withFileTypes: true });
@@ -141,7 +132,7 @@ async function scanDirectory(dir) {
     if (entry.name.startsWith(".") && SKIP_DIRS.has(entry.name)) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
     if (entry.name.startsWith(".")) continue;
-    const childPath = import_node_path2.default.join(dir, entry.name);
+    const childPath = import_node_path.default.join(dir, entry.name);
     if (entry.isDirectory()) {
       const children = await scanDirectory(childPath);
       if (children.length > 0) {
@@ -155,7 +146,7 @@ async function scanDirectory(dir) {
       continue;
     }
     if (entry.isFile()) {
-      const ext = import_node_path2.default.extname(entry.name).toLowerCase();
+      const ext = import_node_path.default.extname(entry.name).toLowerCase();
       if (!SUPPORTED_EXT.has(ext)) continue;
       nodes.push({ name: entry.name, path: childPath, kind: "file" });
     }
@@ -199,7 +190,7 @@ function startWatcher(vaultPath) {
   }
 }
 function vaultStatePath() {
-  return import_node_path2.default.join(import_electron.app.getPath("userData"), "vault.json");
+  return import_node_path.default.join(import_electron.app.getPath("userData"), "vault.json");
 }
 async function readVaultState() {
   const file = vaultStatePath();
@@ -227,7 +218,7 @@ import_electron.ipcMain.handle("vault:pick", async () => {
   return { path: result.filePaths[0] };
 });
 import_electron.ipcMain.handle("vault:list", async (_event, vaultPath) => {
-  const abs = import_node_path2.default.resolve(vaultPath);
+  const abs = import_node_path.default.resolve(vaultPath);
   const info = await (0, import_promises.stat)(abs);
   if (!info.isDirectory()) throw new Error(`Not a directory: ${abs}`);
   activeVault = abs;
@@ -244,12 +235,12 @@ async function collectFiles(dir, acc) {
   for (const entry of entries) {
     if (entry.name.startsWith(".")) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
-    const childPath = import_node_path2.default.join(dir, entry.name);
+    const childPath = import_node_path.default.join(dir, entry.name);
     if (entry.isDirectory()) {
       await collectFiles(childPath, acc);
       continue;
     }
-    if (entry.isFile() && SUPPORTED_EXT.has(import_node_path2.default.extname(entry.name).toLowerCase())) {
+    if (entry.isFile() && SUPPORTED_EXT.has(import_node_path.default.extname(entry.name).toLowerCase())) {
       acc.push(childPath);
     }
   }
@@ -291,19 +282,19 @@ import_electron.ipcMain.handle(
     const baseNameRaw = segments.pop();
     const subDirs = segments.join("/");
     const parent = assertInsideVault(
-      subDirs ? import_node_path2.default.join(parentDir, subDirs) : parentDir
+      subDirs ? import_node_path.default.join(parentDir, subDirs) : parentDir
     );
     if (subDirs) {
       await (0, import_promises.mkdir)(parent, { recursive: true });
     }
-    const hasExt = SUPPORTED_EXT.has(import_node_path2.default.extname(baseNameRaw).toLowerCase());
+    const hasExt = SUPPORTED_EXT.has(import_node_path.default.extname(baseNameRaw).toLowerCase());
     const baseName = hasExt ? baseNameRaw : `${baseNameRaw}.md`;
-    const ext = import_node_path2.default.extname(baseName);
+    const ext = import_node_path.default.extname(baseName);
     const stem = baseName.slice(0, baseName.length - ext.length);
-    let candidate = import_node_path2.default.join(parent, baseName);
+    let candidate = import_node_path.default.join(parent, baseName);
     let suffix = 1;
     while ((0, import_node_fs.existsSync)(candidate)) {
-      candidate = import_node_path2.default.join(parent, `${stem}-${suffix}${ext}`);
+      candidate = import_node_path.default.join(parent, `${stem}-${suffix}${ext}`);
       suffix += 1;
     }
     const finalPath = assertInsideVault(candidate);
@@ -316,7 +307,7 @@ import_electron.ipcMain.handle(
   async (_event, parentDir, name) => {
     const parent = assertInsideVault(parentDir);
     const safeName = name.trim() || "new-folder";
-    const target = assertInsideVault(import_node_path2.default.join(parent, safeName));
+    const target = assertInsideVault(import_node_path.default.join(parent, safeName));
     if ((0, import_node_fs.existsSync)(target)) {
       throw new Error(`Folder already exists: ${safeName}`);
     }
@@ -328,13 +319,13 @@ import_electron.ipcMain.handle(
   "vault:rename",
   async (_event, oldPath, newName) => {
     const src = assertInsideVault(oldPath);
-    const parent = import_node_path2.default.dirname(src);
+    const parent = import_node_path.default.dirname(src);
     const trimmed = newName.trim();
     if (!trimmed) throw new Error("New name cannot be empty");
     if (trimmed.includes("/") || trimmed.includes("\\")) {
       throw new Error("New name cannot contain path separators");
     }
-    const target = assertInsideVault(import_node_path2.default.join(parent, trimmed));
+    const target = assertInsideVault(import_node_path.default.join(parent, trimmed));
     if ((0, import_node_fs.existsSync)(target) && target !== src) {
       throw new Error(`Target already exists: ${trimmed}`);
     }
@@ -372,9 +363,9 @@ import_electron.app.whenReady().then(() => {
       const url = new URL(request.url);
       const relPath = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
       if (!relPath) return new Response("Empty path", { status: 400 });
-      const abs = import_node_path2.default.resolve(activeVault, relPath);
-      const rel = import_node_path2.default.relative(activeVault, abs);
-      if (rel.startsWith("..") || import_node_path2.default.isAbsolute(rel)) {
+      const abs = import_node_path.default.resolve(activeVault, relPath);
+      const rel = import_node_path.default.relative(activeVault, abs);
+      if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
         return new Response("Path escapes vault", { status: 403 });
       }
       if (!(0, import_node_fs.existsSync)(abs)) return new Response("Not found", { status: 404 });

--- a/apps/electron-demo/dist-electron/main.js
+++ b/apps/electron-demo/dist-electron/main.js
@@ -29,8 +29,23 @@ module.exports = __toCommonJS(main_exports);
 var import_electron = require("electron");
 var import_promises = require("fs/promises");
 var import_node_fs = require("fs");
-var import_node_path = __toESM(require("path"));
+var import_node_path2 = __toESM(require("path"));
 var import_node_url = require("url");
+
+// electron/vault-path.ts
+var import_node_path = __toESM(require("path"));
+function assertPathInsideVault(vaultRoot, target) {
+  const root = import_node_path.default.resolve(vaultRoot);
+  const resolved = import_node_path.default.resolve(target);
+  const rel = import_node_path.default.relative(root, resolved);
+  if (rel === "" || rel === ".") return resolved;
+  if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
+    throw new Error(`Path escapes vault: ${target}`);
+  }
+  return resolved;
+}
+
+// electron/main.ts
 import_electron.protocol.registerSchemesAsPrivileged([
   {
     scheme: "nexus-vault",
@@ -56,7 +71,7 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      preload: import_node_path.default.join(__dirname, "preload.js")
+      preload: import_node_path2.default.join(__dirname, "preload.js")
     }
   });
   mainWindow.once("ready-to-show", () => {
@@ -66,7 +81,7 @@ function createWindow() {
   if (devUrl) {
     mainWindow.loadURL(devUrl);
   } else {
-    mainWindow.loadFile(import_node_path.default.join(__dirname, "../dist/index.html"));
+    mainWindow.loadFile(import_node_path2.default.join(__dirname, "../dist/index.html"));
   }
   mainWindow.webContents.on("before-input-event", (_event, input) => {
     const meta = input.meta || input.control;
@@ -117,13 +132,7 @@ function assertInsideVault(target) {
   if (!activeVault) {
     throw new Error("No active vault");
   }
-  const resolved = import_node_path.default.resolve(target);
-  const rel = import_node_path.default.relative(activeVault, resolved);
-  if (rel === "" || rel === ".") return resolved;
-  if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
-    throw new Error(`Path escapes vault: ${target}`);
-  }
-  return resolved;
+  return assertPathInsideVault(activeVault, target);
 }
 async function scanDirectory(dir) {
   const entries = await (0, import_promises.readdir)(dir, { withFileTypes: true });
@@ -132,7 +141,7 @@ async function scanDirectory(dir) {
     if (entry.name.startsWith(".") && SKIP_DIRS.has(entry.name)) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
     if (entry.name.startsWith(".")) continue;
-    const childPath = import_node_path.default.join(dir, entry.name);
+    const childPath = import_node_path2.default.join(dir, entry.name);
     if (entry.isDirectory()) {
       const children = await scanDirectory(childPath);
       if (children.length > 0) {
@@ -146,7 +155,7 @@ async function scanDirectory(dir) {
       continue;
     }
     if (entry.isFile()) {
-      const ext = import_node_path.default.extname(entry.name).toLowerCase();
+      const ext = import_node_path2.default.extname(entry.name).toLowerCase();
       if (!SUPPORTED_EXT.has(ext)) continue;
       nodes.push({ name: entry.name, path: childPath, kind: "file" });
     }
@@ -190,7 +199,7 @@ function startWatcher(vaultPath) {
   }
 }
 function vaultStatePath() {
-  return import_node_path.default.join(import_electron.app.getPath("userData"), "vault.json");
+  return import_node_path2.default.join(import_electron.app.getPath("userData"), "vault.json");
 }
 async function readVaultState() {
   const file = vaultStatePath();
@@ -218,7 +227,7 @@ import_electron.ipcMain.handle("vault:pick", async () => {
   return { path: result.filePaths[0] };
 });
 import_electron.ipcMain.handle("vault:list", async (_event, vaultPath) => {
-  const abs = import_node_path.default.resolve(vaultPath);
+  const abs = import_node_path2.default.resolve(vaultPath);
   const info = await (0, import_promises.stat)(abs);
   if (!info.isDirectory()) throw new Error(`Not a directory: ${abs}`);
   activeVault = abs;
@@ -235,12 +244,12 @@ async function collectFiles(dir, acc) {
   for (const entry of entries) {
     if (entry.name.startsWith(".")) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
-    const childPath = import_node_path.default.join(dir, entry.name);
+    const childPath = import_node_path2.default.join(dir, entry.name);
     if (entry.isDirectory()) {
       await collectFiles(childPath, acc);
       continue;
     }
-    if (entry.isFile() && SUPPORTED_EXT.has(import_node_path.default.extname(entry.name).toLowerCase())) {
+    if (entry.isFile() && SUPPORTED_EXT.has(import_node_path2.default.extname(entry.name).toLowerCase())) {
       acc.push(childPath);
     }
   }
@@ -282,19 +291,19 @@ import_electron.ipcMain.handle(
     const baseNameRaw = segments.pop();
     const subDirs = segments.join("/");
     const parent = assertInsideVault(
-      subDirs ? import_node_path.default.join(parentDir, subDirs) : parentDir
+      subDirs ? import_node_path2.default.join(parentDir, subDirs) : parentDir
     );
     if (subDirs) {
       await (0, import_promises.mkdir)(parent, { recursive: true });
     }
-    const hasExt = SUPPORTED_EXT.has(import_node_path.default.extname(baseNameRaw).toLowerCase());
+    const hasExt = SUPPORTED_EXT.has(import_node_path2.default.extname(baseNameRaw).toLowerCase());
     const baseName = hasExt ? baseNameRaw : `${baseNameRaw}.md`;
-    const ext = import_node_path.default.extname(baseName);
+    const ext = import_node_path2.default.extname(baseName);
     const stem = baseName.slice(0, baseName.length - ext.length);
-    let candidate = import_node_path.default.join(parent, baseName);
+    let candidate = import_node_path2.default.join(parent, baseName);
     let suffix = 1;
     while ((0, import_node_fs.existsSync)(candidate)) {
-      candidate = import_node_path.default.join(parent, `${stem}-${suffix}${ext}`);
+      candidate = import_node_path2.default.join(parent, `${stem}-${suffix}${ext}`);
       suffix += 1;
     }
     const finalPath = assertInsideVault(candidate);
@@ -307,7 +316,7 @@ import_electron.ipcMain.handle(
   async (_event, parentDir, name) => {
     const parent = assertInsideVault(parentDir);
     const safeName = name.trim() || "new-folder";
-    const target = assertInsideVault(import_node_path.default.join(parent, safeName));
+    const target = assertInsideVault(import_node_path2.default.join(parent, safeName));
     if ((0, import_node_fs.existsSync)(target)) {
       throw new Error(`Folder already exists: ${safeName}`);
     }
@@ -319,13 +328,13 @@ import_electron.ipcMain.handle(
   "vault:rename",
   async (_event, oldPath, newName) => {
     const src = assertInsideVault(oldPath);
-    const parent = import_node_path.default.dirname(src);
+    const parent = import_node_path2.default.dirname(src);
     const trimmed = newName.trim();
     if (!trimmed) throw new Error("New name cannot be empty");
     if (trimmed.includes("/") || trimmed.includes("\\")) {
       throw new Error("New name cannot contain path separators");
     }
-    const target = assertInsideVault(import_node_path.default.join(parent, trimmed));
+    const target = assertInsideVault(import_node_path2.default.join(parent, trimmed));
     if ((0, import_node_fs.existsSync)(target) && target !== src) {
       throw new Error(`Target already exists: ${trimmed}`);
     }
@@ -363,9 +372,9 @@ import_electron.app.whenReady().then(() => {
       const url = new URL(request.url);
       const relPath = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
       if (!relPath) return new Response("Empty path", { status: 400 });
-      const abs = import_node_path.default.resolve(activeVault, relPath);
-      const rel = import_node_path.default.relative(activeVault, abs);
-      if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
+      const abs = import_node_path2.default.resolve(activeVault, relPath);
+      const rel = import_node_path2.default.relative(activeVault, abs);
+      if (rel.startsWith("..") || import_node_path2.default.isAbsolute(rel)) {
         return new Response("Path escapes vault", { status: 403 });
       }
       if (!(0, import_node_fs.existsSync)(abs)) return new Response("Not found", { status: 404 });

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile, readdir, mkdir, rename, stat } from "node:fs/promi
 import { existsSync, watch, type FSWatcher } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { assertPathInsideVault } from "./vault-path";
 
 // Must be called before app ready — declares our custom scheme as privileged
 // so images served via nexus-vault:// pass fetch/<img> with credentials / CORS.
@@ -128,13 +129,7 @@ function assertInsideVault(target: string): string {
   if (!activeVault) {
     throw new Error("No active vault");
   }
-  const resolved = path.resolve(target);
-  const rel = path.relative(activeVault, resolved);
-  if (rel === "" || rel === "." ) return resolved;
-  if (rel.startsWith("..") || path.isAbsolute(rel)) {
-    throw new Error(`Path escapes vault: ${target}`);
-  }
-  return resolved;
+  return assertPathInsideVault(activeVault, target);
 }
 
 async function scanDirectory(dir: string): Promise<VaultNode[]> {

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -279,10 +279,17 @@ async function collectFiles(dir: string, acc: string[]): Promise<void> {
   }
 }
 
-ipcMain.handle("vault:read-all", async () => {
-  if (!activeVault) return [];
+ipcMain.handle("vault:read-all", async (_event, vaultPath?: string) => {
+  const root = vaultPath ? path.resolve(vaultPath) : activeVault;
+  if (!root) return [];
+  const info = await stat(root);
+  if (!info.isDirectory()) throw new Error(`Not a directory: ${root}`);
+
+  activeVault = root;
+  startWatcher(root);
+
   const paths: string[] = [];
-  await collectFiles(activeVault, paths);
+  await collectFiles(root, paths);
   // Bounded-concurrency parallel read — ~5-10x faster than serial on large
   // vaults, without risking EMFILE.
   const CONCURRENCY = 32;

--- a/apps/electron-demo/electron/preload.ts
+++ b/apps/electron-demo/electron/preload.ts
@@ -21,7 +21,7 @@ export interface VaultBridge {
   pick(): Promise<{ path: string } | null>;
   list(vaultPath: string): Promise<VaultNode[]>;
   read(filePath: string): Promise<DemoFileHandle>;
-  readAll(): Promise<Array<{ path: string; content: string }>>;
+  readAll(vaultPath?: string): Promise<Array<{ path: string; content: string }>>;
   write(filePath: string, content: string): Promise<{ path: string }>;
   createFile(parentDir: string, name: string): Promise<{ path: string }>;
   createFolder(parentDir: string, name: string): Promise<{ path: string }>;
@@ -49,8 +49,8 @@ const vaultBridge: VaultBridge = {
   read(filePath) {
     return ipcRenderer.invoke("vault:read", filePath);
   },
-  readAll() {
-    return ipcRenderer.invoke("vault:read-all");
+  readAll(vaultPath) {
+    return ipcRenderer.invoke("vault:read-all", vaultPath);
   },
   write(filePath, content) {
     return ipcRenderer.invoke("vault:write", filePath, content);

--- a/apps/electron-demo/electron/vault-path.ts
+++ b/apps/electron-demo/electron/vault-path.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+
+export function assertPathInsideVault(vaultRoot: string, target: string): string {
+  const root = path.resolve(vaultRoot);
+  const resolved = path.resolve(target);
+  const rel = path.relative(root, resolved);
+  if (rel === "" || rel === ".") return resolved;
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(`Path escapes vault: ${target}`);
+  }
+  return resolved;
+}

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -7,6 +7,8 @@ import { createVaultPanel, type VaultPanel } from "./vault-panel";
 import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
 import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
 import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
+import { readAllNoteVaultFiles } from "@floatboat/nexus-core";
+import { createElectronVaultAdapter, type ElectronVaultAdapter } from "./vault-adapter";
 
 installLongTaskWatch(50);
 
@@ -17,6 +19,7 @@ let outline: OutlinePanel;
 let searchBar: SearchBar;
 let vault: VaultPanel;
 let backlinks: BacklinksPanel;
+let vaultAdapter: ElectronVaultAdapter;
 
 const linkIndex = new LinkIndex();
 state.linkIndex = linkIndex;
@@ -143,7 +146,7 @@ async function handleSave(): Promise<void> {
     const targetPath = state.activeFile ?? state.filePath;
     if (targetPath) {
       if (state.vaultPath && targetPath.startsWith(state.vaultPath)) {
-        await window.nexusDemo.vault.write(targetPath, state.content);
+        await vaultAdapter.write(vaultAdapter.pathToFileRef(targetPath), state.content);
       } else {
         await window.nexusDemo.saveFile(targetPath, state.content);
       }
@@ -209,18 +212,19 @@ async function handleVaultFileOpen(filePath: string): Promise<void> {
     if (!(await confirmDiscardIfDirty())) return;
 
     const ipc = perfStart("open-file.ipc-read");
-    const result = await window.nexusDemo.vault.read(filePath);
+    const result = await vaultAdapter.read(vaultAdapter.pathToFileRef(filePath));
     perfEnd(ipc, { bytes: result.content.length });
 
-    state.filePath = result.path;
-    state.activeFile = result.path;
+    const resultPath = vaultAdapter.refToPath(result.ref);
+    state.filePath = resultPath;
+    state.activeFile = resultPath;
 
     const load = perfStart("open-file.loadDocument");
     shell.loadDocument(result.content);
     perfEnd(load);
 
     const setActive = perfStart("open-file.vault.setActiveFile");
-    vault.setActiveFile(result.path);
+    vault.setActiveFile(resultPath);
     perfEnd(setActive);
 
     const bl = perfStart("open-file.backlinks.refresh");
@@ -245,8 +249,21 @@ async function seedLinkIndex(): Promise<void> {
   const myToken = ++seedToken;
   const total = perfStart("seed-link-index");
   try {
+    if (!state.vaultPath) {
+      perfEnd(total, { skipped: true });
+      return;
+    }
     const ipc = perfStart("seed-link-index.ipc-readAll");
-    const files = await window.nexusDemo.vault.readAll();
+    const vaultFiles = await readAllNoteVaultFiles(vaultAdapter, {
+      root: vaultAdapter.rootRef(state.vaultPath),
+      onError(error, ref) {
+        console.warn("readAllNoteVaultFiles skipped:", vaultAdapter.refToPath(ref), error);
+      },
+    });
+    const files = vaultFiles.map((file) => ({
+      path: vaultAdapter.refToPath(file.ref),
+      content: file.content,
+    }));
     const totalBytes = files.reduce((n, f) => n + f.content.length, 0);
     perfEnd(ipc, { files: files.length, bytes: totalBytes });
 
@@ -314,10 +331,11 @@ async function handleWikilinkNavigate(target: string, opts: { unresolved: boolea
         ? dirname(state.activeFile)
         : state.vaultPath;
     const name = bare.toLowerCase().endsWith(".md") ? bare : `${bare}.md`;
-    const created = await window.nexusDemo.vault.createFile(parent, name);
+    const created = await vaultAdapter.createFile(vaultAdapter.pathToFolderRef(parent), name);
     await vault.refresh();
-    linkIndex.updateFile(created.path, "");
-    await handleVaultFileOpen(created.path);
+    const createdPath = vaultAdapter.refToPath(created);
+    linkIndex.updateFile(createdPath, "");
+    await handleVaultFileOpen(createdPath);
   } catch (err) {
     state.error = err instanceof Error ? err.message : String(err);
     renderStatus();
@@ -326,7 +344,7 @@ async function handleWikilinkNavigate(target: string, opts: { unresolved: boolea
 
 async function tryRestoreLastVault(): Promise<void> {
   try {
-    const last = await window.nexusDemo.vault.getLast();
+    const last = await vaultAdapter.getLast();
     if (last.lastVault) {
       state.vaultPath = last.lastVault;
       await vault.openVault(last.lastVault);
@@ -347,6 +365,7 @@ function boot(): void {
 
   const appToolbar = createAppToolbar();
   const statusLine = createStatusLine();
+  vaultAdapter = createElectronVaultAdapter();
 
   const mainArea = document.createElement("div");
   mainArea.className = "main-area";
@@ -377,6 +396,7 @@ function boot(): void {
   });
 
   vault = createVaultPanel({
+    adapter: vaultAdapter,
     onOpenFile: (filePath) => {
       void handleVaultFileOpen(filePath);
     },
@@ -411,7 +431,7 @@ function boot(): void {
   mainArea.append(vault.element, editorColumn, outline.element, backlinks.element);
 
   // External file changes → re-seed the index (cheap for typical vaults).
-  window.nexusDemo.vault.onChanged(() => {
+  vaultAdapter.watch?.(() => {
     void seedLinkIndex();
   });
 

--- a/apps/electron-demo/src/renderer/bridge.d.ts
+++ b/apps/electron-demo/src/renderer/bridge.d.ts
@@ -19,7 +19,7 @@ interface VaultBridge {
   pick(): Promise<{ path: string } | null>;
   list(vaultPath: string): Promise<VaultNode[]>;
   read(filePath: string): Promise<DemoFileHandle>;
-  readAll(): Promise<Array<{ path: string; content: string }>>;
+  readAll(vaultPath?: string): Promise<Array<{ path: string; content: string }>>;
   write(filePath: string, content: string): Promise<{ path: string }>;
   createFile(parentDir: string, name: string): Promise<{ path: string }>;
   createFolder(parentDir: string, name: string): Promise<{ path: string }>;

--- a/apps/electron-demo/src/renderer/state.ts
+++ b/apps/electron-demo/src/renderer/state.ts
@@ -1,4 +1,5 @@
 import type { LinkIndex } from "./link-index";
+import type { NoteVaultNode } from "@floatboat/nexus-core";
 
 export interface AppState {
   filePath: string | null;
@@ -6,7 +7,7 @@ export interface AppState {
   dirty: boolean;
   error: string | null;
   vaultPath: string | null;
-  vaultTree: VaultNode[];
+  vaultTree: NoteVaultNode[];
   activeFile: string | null;
   linkIndex: LinkIndex | null;
 }

--- a/apps/electron-demo/src/renderer/vault-adapter.ts
+++ b/apps/electron-demo/src/renderer/vault-adapter.ts
@@ -1,0 +1,155 @@
+import {
+  createNoteVaultError,
+  type AnyNoteVaultRef,
+  type NoteVaultAdapter,
+  type NoteVaultCapabilities,
+  type NoteVaultChangeEvent,
+  type NoteVaultFileRef,
+  type NoteVaultFolderRef,
+  type NoteVaultNode,
+  type NoteVaultRef,
+} from "@floatboat/nexus-core";
+
+const PROVIDER_ID = "electron-local-vault";
+
+export interface ElectronVaultAdapter extends NoteVaultAdapter {
+  pick(): Promise<{ path: string } | null>;
+  getLast(): Promise<VaultState>;
+  setLast(vaultPath: string): Promise<void>;
+  rootRef(vaultPath: string): NoteVaultFolderRef;
+  refToPath(ref: NoteVaultRef): string;
+  pathToFileRef(filePath: string): NoteVaultFileRef;
+  pathToFolderRef(folderPath: string): NoteVaultFolderRef;
+}
+
+const capabilities: NoteVaultCapabilities = {
+  watch: true,
+  trash: true,
+  renameFile: true,
+  renameFolder: true,
+  createFile: true,
+  createFolder: true,
+  deleteFile: true,
+  deleteFolder: true,
+  optimisticWrites: false,
+};
+
+export function createElectronVaultAdapter(bridge: VaultBridge = window.nexusDemo.vault): ElectronVaultAdapter {
+  function nameFromPath(value: string): string {
+    const norm = value.replace(/\\/g, "/");
+    return norm.slice(norm.lastIndexOf("/") + 1) || value;
+  }
+
+  function pathFromRef(ref: NoteVaultRef): string {
+    if (ref.providerId !== PROVIDER_ID) {
+      throw createNoteVaultError("invalid-ref", `Unsupported vault provider: ${ref.providerId}`, {
+        ref,
+      });
+    }
+    return ref.displayPath ?? ref.id;
+  }
+
+  function fileRef(filePath: string): NoteVaultFileRef {
+    return {
+      providerId: PROVIDER_ID,
+      id: filePath,
+      kind: "file",
+      name: nameFromPath(filePath),
+      displayPath: filePath,
+    };
+  }
+
+  function folderRef(folderPath: string): NoteVaultFolderRef {
+    return {
+      providerId: PROVIDER_ID,
+      id: folderPath,
+      kind: "folder",
+      name: nameFromPath(folderPath),
+      displayPath: folderPath,
+    };
+  }
+
+  function nodeFromBridge(node: VaultNode): NoteVaultNode {
+    const kind = node.kind === "directory" ? "folder" : "file";
+    const ref = kind === "folder" ? folderRef(node.path) : fileRef(node.path);
+    return {
+      ref,
+      name: node.name,
+      kind,
+      displayPath: node.path,
+      children: node.children?.map(nodeFromBridge),
+    };
+  }
+
+  const adapter: ElectronVaultAdapter = {
+    id: PROVIDER_ID,
+    label: "Local vault",
+    capabilities,
+    pick() {
+      return bridge.pick();
+    },
+    async getLast() {
+      return bridge.getLast();
+    },
+    async setLast(vaultPath) {
+      await bridge.setLast(vaultPath);
+    },
+    rootRef: folderRef,
+    refToPath: pathFromRef,
+    pathToFileRef: fileRef,
+    pathToFolderRef: folderRef,
+    async list(options = {}) {
+      const root = options.root ? pathFromRef(options.root) : null;
+      if (!root) {
+        throw createNoteVaultError("invalid-ref", "Local vault list requires a root folder ref", {
+          operation: "list",
+        });
+      }
+      const nodes = await bridge.list(root);
+      return nodes.map(nodeFromBridge);
+    },
+    async read(ref) {
+      const result = await bridge.read(pathFromRef(ref));
+      return {
+        ref: fileRef(result.path),
+        content: result.content,
+      };
+    },
+    async write(ref, content) {
+      const result = await bridge.write(pathFromRef(ref), content);
+      return { ref: fileRef(result.path) };
+    },
+    async createFile(parent, name, content = "") {
+      const result = await bridge.createFile(pathFromRef(parent), name);
+      if (content) await bridge.write(result.path, content);
+      return fileRef(result.path);
+    },
+    async createFolder(parent, name) {
+      const result = await bridge.createFolder(pathFromRef(parent), name);
+      return folderRef(result.path);
+    },
+    async rename(ref, name): Promise<AnyNoteVaultRef> {
+      const result = await bridge.rename(pathFromRef(ref), name);
+      return ref.kind === "folder" ? folderRef(result.path) : fileRef(result.path);
+    },
+    async delete(ref, options = {}) {
+      if (options.trash === false) {
+        throw createNoteVaultError("unsupported-operation", "Local vault delete always uses the system trash", {
+          ref,
+          operation: "delete",
+        });
+      }
+      await bridge.delete(pathFromRef(ref));
+    },
+    watch(listener: (event: NoteVaultChangeEvent) => void) {
+      return bridge.onChanged((payload) => {
+        listener({
+          kind: "refreshed",
+          ref: folderRef(payload.vault),
+        });
+      });
+    },
+  };
+
+  return adapter;
+}

--- a/apps/electron-demo/src/renderer/vault-adapter.ts
+++ b/apps/electron-demo/src/renderer/vault-adapter.ts
@@ -4,8 +4,10 @@ import {
   type NoteVaultAdapter,
   type NoteVaultCapabilities,
   type NoteVaultChangeEvent,
+  type NoteVaultFile,
   type NoteVaultFileRef,
   type NoteVaultFolderRef,
+  type NoteVaultListOptions,
   type NoteVaultNode,
   type NoteVaultRef,
 } from "@floatboat/nexus-core";
@@ -20,6 +22,7 @@ export interface ElectronVaultAdapter extends NoteVaultAdapter {
   refToPath(ref: NoteVaultRef): string;
   pathToFileRef(filePath: string): NoteVaultFileRef;
   pathToFolderRef(folderPath: string): NoteVaultFolderRef;
+  readAll(options?: NoteVaultListOptions): Promise<NoteVaultFile[]>;
 }
 
 const capabilities: NoteVaultCapabilities = {
@@ -46,7 +49,7 @@ export function createElectronVaultAdapter(bridge: VaultBridge = window.nexusDem
         ref,
       });
     }
-    return ref.displayPath ?? ref.id;
+    return ref.id;
   }
 
   function fileRef(filePath: string): NoteVaultFileRef {
@@ -114,6 +117,14 @@ export function createElectronVaultAdapter(bridge: VaultBridge = window.nexusDem
         ref: fileRef(result.path),
         content: result.content,
       };
+    },
+    async readAll(options = {}) {
+      const root = options.root ? pathFromRef(options.root) : undefined;
+      const results = await bridge.readAll(root);
+      return results.map((result) => ({
+        ref: fileRef(result.path),
+        content: result.content,
+      }));
     },
     async write(ref, content) {
       const result = await bridge.write(pathFromRef(ref), content);

--- a/apps/electron-demo/src/renderer/vault-panel.ts
+++ b/apps/electron-demo/src/renderer/vault-panel.ts
@@ -1,4 +1,8 @@
+import type { NoteVaultNode } from "@floatboat/nexus-core";
+import type { ElectronVaultAdapter } from "./vault-adapter";
+
 export interface VaultPanelCallbacks {
+  adapter: ElectronVaultAdapter;
   onOpenFile(filePath: string): void;
   onError(message: string): void;
   onStatus(message: string): void;
@@ -183,6 +187,7 @@ function fileIcon(): string {
 }
 
 export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
+  const adapter = callbacks.adapter;
   const panel = document.createElement("div");
   panel.className = "nexus-vault-panel";
   panel.style.cssText = PANEL_STYLES;
@@ -235,7 +240,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
   panel.append(header, tree);
 
   let vaultPath: string | null = null;
-  let currentTree: VaultNode[] = [];
+  let currentTree: NoteVaultNode[] = [];
   let activeFile: string | null = null;
   const collapsed = new Set<string>();
   let unsubscribeChanged: (() => void) | null = null;
@@ -248,20 +253,21 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     tree.appendChild(empty);
   }
 
-  function renderNode(node: VaultNode, depth: number, parent: HTMLElement): void {
+  function renderNode(node: NoteVaultNode, depth: number, parent: HTMLElement): void {
+    const nodePath = adapter.refToPath(node.ref);
     const row = document.createElement("div");
     row.style.cssText = ITEM_BASE;
     row.style.paddingLeft = `${8 + depth * 14}px`;
-    row.dataset.path = node.path;
+    row.dataset.path = nodePath;
     row.dataset.kind = node.kind;
 
-    const isActive = node.kind === "file" && activeFile === node.path;
+    const isActive = node.kind === "file" && activeFile === nodePath;
     if (isActive) row.style.cssText = ITEM_BASE + ACTIVE_STYLES;
 
     const icon = document.createElement("span");
     icon.style.cssText = "width: 12px; flex-shrink: 0; color: #888; font-size: 11px;";
-    if (node.kind === "directory") {
-      const open = !collapsed.has(node.path);
+    if (node.kind === "folder") {
+      const open = !collapsed.has(nodePath);
       icon.textContent = folderIcon(open);
     } else {
       icon.textContent = fileIcon();
@@ -282,12 +288,12 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     });
 
     row.addEventListener("click", () => {
-      if (node.kind === "directory") {
-        if (collapsed.has(node.path)) collapsed.delete(node.path);
-        else collapsed.add(node.path);
+      if (node.kind === "folder") {
+        if (collapsed.has(nodePath)) collapsed.delete(nodePath);
+        else collapsed.add(nodePath);
         renderTree();
       } else {
-        callbacks.onOpenFile(node.path);
+        callbacks.onOpenFile(nodePath);
       }
     });
 
@@ -303,7 +309,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
       openNodeContextMenu(e.clientX, e.clientY, node);
     });
 
-    if (node.kind === "directory" && !collapsed.has(node.path) && node.children) {
+    if (node.kind === "folder" && !collapsed.has(nodePath) && node.children) {
       for (const child of node.children) {
         renderNode(child, depth + 1, parent);
       }
@@ -323,7 +329,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     for (const node of currentTree) renderNode(node, 0, tree);
   }
 
-  function beginInlineRename(row: HTMLElement, label: HTMLElement, node: VaultNode): void {
+  function beginInlineRename(row: HTMLElement, label: HTMLElement, node: NoteVaultNode): void {
     const input = document.createElement("input");
     input.type = "text";
     input.value = node.name;
@@ -353,7 +359,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
         return;
       }
       try {
-        await window.nexusDemo.vault.rename(node.path, newName);
+        await adapter.rename(node.ref, newName);
         await refresh();
       } catch (err) {
         callbacks.onError(err instanceof Error ? err.message : String(err));
@@ -373,23 +379,24 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     input.addEventListener("blur", () => finish(true));
   }
 
-  function openNodeContextMenu(x: number, y: number, node: VaultNode): void {
-    const parentDir = node.kind === "directory" ? node.path : node.path.replace(/[\\/][^\\/]+$/, "");
+  function openNodeContextMenu(x: number, y: number, node: NoteVaultNode): void {
+    const nodePath = adapter.refToPath(node.ref);
+    const parentDir = node.kind === "folder" ? nodePath : nodePath.replace(/[\\/][^\\/]+$/, "");
     const items: ContextMenuItem[] = [];
 
-    if (node.kind === "directory") {
+    if (node.kind === "folder") {
       items.push({
         label: "New file here",
-        onClick: () => createFilePrompt(node.path),
+        onClick: () => createFilePrompt(nodePath),
       });
       items.push({
         label: "New folder here",
-        onClick: () => createFolderPrompt(node.path),
+        onClick: () => createFolderPrompt(nodePath),
       });
     } else {
       items.push({
         label: "Open",
-        onClick: () => callbacks.onOpenFile(node.path),
+        onClick: () => callbacks.onOpenFile(nodePath),
       });
       items.push({
         label: "New file in same folder",
@@ -400,7 +407,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     items.push({
       label: "Rename",
       onClick: () => {
-        const row = tree.querySelector<HTMLElement>(`[data-path="${cssEscape(node.path)}"]`);
+        const row = tree.querySelector<HTMLElement>(`[data-path="${cssEscape(nodePath)}"]`);
         const label = row?.querySelector<HTMLElement>("span:last-child");
         if (row && label) beginInlineRename(row, label, node);
       },
@@ -484,9 +491,9 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
       selectExt: true,
       iconChar: fileIcon(),
       onCommit: async (name) => {
-        const result = await window.nexusDemo.vault.createFile(parentDir, name);
+        const result = await adapter.createFile(adapter.pathToFolderRef(parentDir), name);
         await refresh();
-        callbacks.onOpenFile(result.path);
+        callbacks.onOpenFile(adapter.refToPath(result));
       },
     });
   }
@@ -497,19 +504,20 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
       selectExt: false,
       iconChar: folderIcon(true),
       onCommit: async (name) => {
-        await window.nexusDemo.vault.createFolder(parentDir, name);
+        await adapter.createFolder(adapter.pathToFolderRef(parentDir), name);
         await refresh();
       },
     });
   }
 
-  async function deleteNode(node: VaultNode): Promise<void> {
+  async function deleteNode(node: NoteVaultNode): Promise<void> {
+    const nodePath = adapter.refToPath(node.ref);
     // In Electron window.confirm may be a no-op; the context menu entry is
     // destructive-styled and requires an explicit click, so we proceed directly.
     try {
-      await window.nexusDemo.vault.delete(node.path);
+      await adapter.delete(node.ref, { trash: true });
       callbacks.onStatus(`Moved ${node.name} to Trash`);
-      if (node.kind === "file" && activeFile === node.path) {
+      if (node.kind === "file" && activeFile === nodePath) {
         activeFile = null;
       }
       await refresh();
@@ -521,7 +529,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
   async function refresh(): Promise<void> {
     if (!vaultPath) return;
     try {
-      currentTree = await window.nexusDemo.vault.list(vaultPath);
+      currentTree = await adapter.list({ root: adapter.rootRef(vaultPath) });
       renderTree();
     } catch (err) {
       callbacks.onError(err instanceof Error ? err.message : String(err));
@@ -536,17 +544,17 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     collapsed.clear();
 
     if (unsubscribeChanged) unsubscribeChanged();
-    unsubscribeChanged = window.nexusDemo.vault.onChanged(() => {
+    unsubscribeChanged = adapter.watch?.(() => {
       void refresh();
-    });
+    }) ?? null;
 
     await refresh();
-    await window.nexusDemo.vault.setLast(nextPath);
+    await adapter.setLast(nextPath);
   }
 
   async function promptPickVault(): Promise<void> {
     try {
-      const picked = await window.nexusDemo.vault.pick();
+      const picked = await adapter.pick();
       if (!picked) return;
       await openVault(picked.path);
     } catch (err) {

--- a/apps/electron-demo/test/vault-adapter.test.ts
+++ b/apps/electron-demo/test/vault-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { readAllNoteVaultFiles } from "@floatboat/nexus-core";
 import { createElectronVaultAdapter } from "../src/renderer/vault-adapter";
 
 function createBridge(): VaultBridge {
@@ -15,7 +16,7 @@ function createBridge(): VaultBridge {
     pick: vi.fn(),
     list: vi.fn(async () => nodes),
     read: vi.fn(async (filePath: string) => ({ path: filePath, content: "# Note" })),
-    readAll: vi.fn(),
+    readAll: vi.fn(async (vaultPath?: string) => [{ path: `${vaultPath ?? "/vault"}/Folder/Note.md`, content: "# Batch" }]),
     write: vi.fn(async (filePath: string) => ({ path: filePath })),
     createFile: vi.fn(async (parentDir: string, name: string) => ({ path: `${parentDir}/${name}` })),
     createFolder: vi.fn(async (parentDir: string, name: string) => ({ path: `${parentDir}/${name}` })),
@@ -69,6 +70,43 @@ describe("createElectronVaultAdapter", () => {
     expect(bridge.write).toHaveBeenCalledWith("/vault/New.md", "body");
     expect(bridge.rename).toHaveBeenCalledWith("/vault/New.md", "Renamed.md");
     expect(bridge.delete).toHaveBeenCalledWith("/vault/Renamed.md");
+  });
+
+  it("uses ref ids rather than display paths for stable operation identity", async () => {
+    const bridge = createBridge();
+    const adapter = createElectronVaultAdapter(bridge);
+    const file = {
+      ...adapter.pathToFileRef("/vault/Note.md"),
+      displayPath: "/display-only/Note.md",
+    };
+
+    await adapter.read(file);
+
+    expect(bridge.read).toHaveBeenCalledWith("/vault/Note.md");
+  });
+
+  it("routes readAllNoteVaultFiles through the batch bridge path", async () => {
+    const bridge = createBridge();
+    const adapter = createElectronVaultAdapter(bridge);
+
+    const files = await readAllNoteVaultFiles(adapter, {
+      root: adapter.rootRef("/vault"),
+    });
+
+    expect(bridge.readAll).toHaveBeenCalledWith("/vault");
+    expect(bridge.read).not.toHaveBeenCalled();
+    expect(files).toEqual([
+      {
+        ref: {
+          providerId: "electron-local-vault",
+          id: "/vault/Folder/Note.md",
+          kind: "file",
+          name: "Note.md",
+          displayPath: "/vault/Folder/Note.md",
+        },
+        content: "# Batch",
+      },
+    ]);
   });
 
   it("surfaces hard-delete requests as unsupported because local delete uses trash", async () => {

--- a/apps/electron-demo/test/vault-adapter.test.ts
+++ b/apps/electron-demo/test/vault-adapter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createElectronVaultAdapter } from "../src/renderer/vault-adapter";
+
+function createBridge(): VaultBridge {
+  const nodes: VaultNode[] = [
+    {
+      name: "Folder",
+      path: "/vault/Folder",
+      kind: "directory",
+      children: [{ name: "Note.md", path: "/vault/Folder/Note.md", kind: "file" }],
+    },
+  ];
+  return {
+    pick: vi.fn(),
+    list: vi.fn(async () => nodes),
+    read: vi.fn(async (filePath: string) => ({ path: filePath, content: "# Note" })),
+    readAll: vi.fn(),
+    write: vi.fn(async (filePath: string) => ({ path: filePath })),
+    createFile: vi.fn(async (parentDir: string, name: string) => ({ path: `${parentDir}/${name}` })),
+    createFolder: vi.fn(async (parentDir: string, name: string) => ({ path: `${parentDir}/${name}` })),
+    rename: vi.fn(async (oldPath: string, newName: string) => ({
+      path: `${oldPath.replace(/[\\/][^\\/]+$/, "")}/${newName}`,
+    })),
+    delete: vi.fn(async () => ({ ok: true })),
+    getLast: vi.fn(async () => ({ lastVault: null, recents: [] })),
+    setLast: vi.fn(async () => ({ ok: true })),
+    onChanged: vi.fn(() => () => undefined),
+  };
+}
+
+describe("createElectronVaultAdapter", () => {
+  it("maps bridge directory nodes to provider-neutral folder refs", async () => {
+    const bridge = createBridge();
+    const adapter = createElectronVaultAdapter(bridge);
+
+    const nodes = await adapter.list({ root: adapter.rootRef("/vault") });
+
+    expect(bridge.list).toHaveBeenCalledWith("/vault");
+    expect(nodes[0]).toMatchObject({
+      name: "Folder",
+      kind: "folder",
+      ref: {
+        providerId: "electron-local-vault",
+        id: "/vault/Folder",
+        kind: "folder",
+      },
+    });
+    expect(nodes[0].children?.[0].kind).toBe("file");
+  });
+
+  it("routes read/write/create/rename/delete through ref paths", async () => {
+    const bridge = createBridge();
+    const adapter = createElectronVaultAdapter(bridge);
+    const folder = adapter.pathToFolderRef("/vault");
+    const file = adapter.pathToFileRef("/vault/Note.md");
+
+    await expect(adapter.read(file)).resolves.toMatchObject({
+      ref: { id: "/vault/Note.md", kind: "file" },
+      content: "# Note",
+    });
+    await adapter.write(file, "updated");
+    const created = await adapter.createFile(folder, "New.md", "body");
+    const renamed = await adapter.rename(created, "Renamed.md");
+    await adapter.delete(renamed, { trash: true });
+
+    expect(bridge.write).toHaveBeenCalledWith("/vault/Note.md", "updated");
+    expect(bridge.createFile).toHaveBeenCalledWith("/vault", "New.md");
+    expect(bridge.write).toHaveBeenCalledWith("/vault/New.md", "body");
+    expect(bridge.rename).toHaveBeenCalledWith("/vault/New.md", "Renamed.md");
+    expect(bridge.delete).toHaveBeenCalledWith("/vault/Renamed.md");
+  });
+
+  it("surfaces hard-delete requests as unsupported because local delete uses trash", async () => {
+    const adapter = createElectronVaultAdapter(createBridge());
+
+    await expect(adapter.delete(adapter.pathToFileRef("/vault/Note.md"), { trash: false })).rejects.toMatchObject({
+      code: "unsupported-operation",
+      operation: "delete",
+    });
+  });
+});

--- a/apps/electron-demo/test/vault-panel.test.ts
+++ b/apps/electron-demo/test/vault-panel.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  NoteVaultChangeEvent,
+  NoteVaultFileRef,
+  NoteVaultFolderRef,
+  NoteVaultNode,
+  NoteVaultRef,
+} from "@floatboat/nexus-core";
+import type { ElectronVaultAdapter } from "../src/renderer/vault-adapter";
+import { createVaultPanel } from "../src/renderer/vault-panel";
+
+function waitForAsyncHandlers(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createRef(path: string, kind: "file"): NoteVaultFileRef;
+function createRef(path: string, kind: "folder"): NoteVaultFolderRef;
+function createRef(path: string, kind: "file" | "folder"): NoteVaultFileRef | NoteVaultFolderRef;
+function createRef(path: string, kind: "file" | "folder"): NoteVaultFileRef | NoteVaultFolderRef {
+  return {
+    providerId: "test-vault",
+    id: path,
+    kind,
+    name: path.split("/").pop() || path,
+    displayPath: path,
+  } as NoteVaultFileRef | NoteVaultFolderRef;
+}
+
+function createNode(path: string, kind: "file", children?: NoteVaultNode[]): NoteVaultNode;
+function createNode(path: string, kind: "folder", children?: NoteVaultNode[]): NoteVaultNode;
+function createNode(path: string, kind: "file" | "folder", children?: NoteVaultNode[]): NoteVaultNode {
+  return {
+    name: path.split("/").pop() || path,
+    kind,
+    ref: createRef(path, kind),
+    displayPath: path,
+    children,
+  };
+}
+
+function createAdapter() {
+  let nodes: NoteVaultNode[] = [
+    createNode("/vault/Folder", "folder", [createNode("/vault/Folder/Note.md", "file")]),
+  ];
+  const unsubscribe = vi.fn();
+  const adapter: ElectronVaultAdapter = {
+    id: "test-vault",
+    label: "Test vault",
+    capabilities: {
+      watch: true,
+      trash: true,
+      createFile: true,
+      createFolder: true,
+      renameFile: true,
+      renameFolder: true,
+      deleteFile: true,
+      deleteFolder: true,
+    },
+    pick: vi.fn(async () => ({ path: "/vault" })),
+    getLast: vi.fn(async () => ({ lastVault: null, recents: [] })),
+    setLast: vi.fn(async () => undefined),
+    rootRef: (vaultPath: string) => createRef(vaultPath, "folder"),
+    refToPath: (ref: NoteVaultRef) => ref.displayPath ?? ref.id,
+    pathToFileRef: (filePath: string) => createRef(filePath, "file"),
+    pathToFolderRef: (folderPath: string) => createRef(folderPath, "folder"),
+    list: vi.fn(async () => nodes),
+    read: vi.fn(async (ref) => ({ ref: createRef(ref.displayPath ?? ref.id, "file"), content: "" })),
+    write: vi.fn(async (ref) => ({ ref: createRef(ref.displayPath ?? ref.id, "file") })),
+    createFile: vi.fn(async (parent, name) => {
+      const path = `${parent.displayPath ?? parent.id}/${name}`;
+      const created = createNode(path, "file");
+      nodes = [created, ...nodes];
+      return created.ref as NoteVaultFileRef;
+    }),
+    createFolder: vi.fn(async (parent, name) => {
+      const path = `${parent.displayPath ?? parent.id}/${name}`;
+      const created = createNode(path, "folder", []);
+      nodes = [created, ...nodes];
+      return created.ref as NoteVaultFolderRef;
+    }),
+    rename: vi.fn(async (ref, name) => createRef(`${(ref.displayPath ?? ref.id).replace(/[\\/][^\\/]+$/, "")}/${name}`, ref.kind)),
+    delete: vi.fn(async (ref) => {
+      const path = ref.displayPath ?? ref.id;
+      nodes = nodes.filter((node) => (node.ref.displayPath ?? node.ref.id) !== path);
+    }),
+    watch: vi.fn((_listener: (event: NoteVaultChangeEvent) => void) => unsubscribe),
+  };
+  return { adapter, unsubscribe };
+}
+
+describe("createVaultPanel storage adapter integration", () => {
+  it("opens a vault through the adapter, renders files, and opens clicked notes", async () => {
+    const { adapter, unsubscribe } = createAdapter();
+    const onOpenFile = vi.fn();
+    const panel = createVaultPanel({
+      adapter,
+      onOpenFile,
+      onError: vi.fn(),
+      onStatus: vi.fn(),
+    });
+    document.body.appendChild(panel.element);
+
+    await panel.openVault("/vault");
+    const noteRow = panel.element.querySelector<HTMLElement>('[data-path="/vault/Folder/Note.md"]');
+    expect(noteRow).not.toBeNull();
+
+    noteRow!.click();
+
+    expect(adapter.list).toHaveBeenCalledWith({ root: expect.objectContaining({ id: "/vault", kind: "folder" }) });
+    expect(adapter.setLast).toHaveBeenCalledWith("/vault");
+    expect(adapter.watch).toHaveBeenCalledTimes(1);
+    expect(onOpenFile).toHaveBeenCalledWith("/vault/Folder/Note.md");
+
+    panel.destroy();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a root note through the adapter and opens the created file", async () => {
+    const { adapter } = createAdapter();
+    const onOpenFile = vi.fn();
+    const panel = createVaultPanel({
+      adapter,
+      onOpenFile,
+      onError: vi.fn(),
+      onStatus: vi.fn(),
+    });
+    document.body.appendChild(panel.element);
+    await panel.openVault("/vault");
+
+    panel.element.querySelector<HTMLButtonElement>('button[title="New file at root"]')!.click();
+    const input = panel.element.querySelector<HTMLInputElement>("input")!;
+    input.value = "New.md";
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    await waitForAsyncHandlers();
+
+    expect(adapter.createFile).toHaveBeenCalledWith(expect.objectContaining({ id: "/vault", kind: "folder" }), "New.md");
+    expect(onOpenFile).toHaveBeenCalledWith("/vault/New.md");
+    expect(panel.element.querySelector('[data-path="/vault/New.md"]')).not.toBeNull();
+
+    panel.destroy();
+  });
+
+  it("deletes notes with trash semantics from the context menu", async () => {
+    const { adapter } = createAdapter();
+    const onStatus = vi.fn();
+    const panel = createVaultPanel({
+      adapter,
+      onOpenFile: vi.fn(),
+      onError: vi.fn(),
+      onStatus,
+    });
+    document.body.appendChild(panel.element);
+    await panel.openVault("/vault");
+
+    const noteRow = panel.element.querySelector<HTMLElement>('[data-path="/vault/Folder/Note.md"]')!;
+    noteRow.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 10, clientY: 10 }));
+    const deleteButton = Array.from(document.querySelectorAll<HTMLButtonElement>(".nexus-vault-ctxmenu button"))
+      .find((button) => button.textContent === "Delete");
+    expect(deleteButton).not.toBeUndefined();
+    deleteButton!.click();
+    await waitForAsyncHandlers();
+
+    expect(adapter.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "/vault/Folder/Note.md", kind: "file" }),
+      { trash: true }
+    );
+    expect(onStatus).toHaveBeenCalledWith("Moved Note.md to Trash");
+
+    panel.destroy();
+  });
+});

--- a/apps/electron-demo/test/vault-panel.test.ts
+++ b/apps/electron-demo/test/vault-panel.test.ts
@@ -66,6 +66,7 @@ function createAdapter() {
     pathToFolderRef: (folderPath: string) => createRef(folderPath, "folder"),
     list: vi.fn(async () => nodes),
     read: vi.fn(async (ref) => ({ ref: createRef(ref.displayPath ?? ref.id, "file"), content: "" })),
+    readAll: vi.fn(async () => []),
     write: vi.fn(async (ref) => ({ ref: createRef(ref.displayPath ?? ref.id, "file") })),
     createFile: vi.fn(async (parent, name) => {
       const path = `${parent.displayPath ?? parent.id}/${name}`;

--- a/apps/electron-demo/test/vault-path.test.ts
+++ b/apps/electron-demo/test/vault-path.test.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { assertPathInsideVault } from "../electron/vault-path";
+
+describe("assertPathInsideVault", () => {
+  const root = path.resolve("/tmp/nexus-vault");
+
+  it("allows the vault root and descendants", () => {
+    expect(assertPathInsideVault(root, root)).toBe(root);
+    expect(assertPathInsideVault(root, path.join(root, "Notes/A.md"))).toBe(path.join(root, "Notes/A.md"));
+  });
+
+  it("rejects sibling paths with the same prefix", () => {
+    expect(() => assertPathInsideVault(root, `${root}-other/A.md`)).toThrow(/escapes vault/);
+  });
+
+  it("rejects parent traversal outside the vault", () => {
+    expect(() => assertPathInsideVault(root, path.join(root, "../outside.md"))).toThrow(/escapes vault/);
+  });
+});

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,7 +73,7 @@ This document maps every planned feature to **package ownership / priority / sta
 |---|---|---|---|---|---|---|
 | 21 | Electron packaging optimization | `apps/electron-demo` | P1 | planned | No | Size, startup time, autoUpdater |
 | 22 | Web Component / iframe wrapper | new `wc` package | P2 | planned | Yes | Share core instance with React/Vue SDK |
-| 23 | Cloud storage interface | `core` storage adapter layer | P2 | planned | Yes | NoteVault interface with pluggable backends |
+| 23 | Cloud storage interface | `core` storage adapter layer | P2 | in-progress | Yes | See `openspec/changes/add-cloud-storage-interface` |
 
 ## 9. Developer Experience
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -73,7 +73,7 @@
 |---|---|---|---|---|---|---|
 | 21 | Electron 打包优化 | `apps/electron-demo` | P1 | planned | 否 | 关注体积、启动时长、autoUpdater |
 | 22 | Web Component / iframe 封装 | 新包 `wc` | P2 | planned | 是 | 与 React/Vue SDK 共享 core 实例 |
-| 23 | 云端存储接口 | `core`（storage 适配层） | P2 | planned | 是 | 抽象 NoteVault interface，多后端实现 |
+| 23 | 云端存储接口 | `core`（storage 适配层） | P2 | in-progress | 是 | 见 `openspec/changes/add-cloud-storage-interface` |
 
 ## 9. 开发体验
 

--- a/openspec/changes/add-cloud-storage-interface/design.md
+++ b/openspec/changes/add-cloud-storage-interface/design.md
@@ -1,0 +1,129 @@
+## Context
+
+The current vault implementation lives in `apps/electron-demo` and exposes operations through Electron IPC:
+
+- `vault:list`
+- `vault:read`
+- `vault:read-all`
+- `vault:write`
+- `vault:create-file`
+- `vault:create-folder`
+- `vault:rename`
+- `vault:delete`
+- `vault:get-last` / `vault:set-last`
+- `vault:changed`
+
+That design was correct for the first desktop demo because it kept filesystem access outside `@floatboat/nexus-core`. Roadmap #23 asks for the next abstraction layer: a storage interface that can describe note/vault operations across local filesystem and cloud-like backends without coupling core to Electron or any provider SDK.
+
+## Target Outcome
+
+The proposal should make a later implementation PR straightforward by answering:
+
+- What interface must a storage adapter implement?
+- Which paths/IDs are stable and which are provider-specific?
+- How are note tree listing, file reads/writes, mutation operations, and change notifications represented?
+- How do hosts surface conflicts, permission failures, auth failures, offline state, and unsupported operations?
+- What is explicitly outside v1?
+
+## Proposed Interface Shape
+
+The exact TypeScript names can change during implementation, but the intended contract is:
+
+```ts
+export interface NoteVaultAdapter {
+  readonly id: string;
+  readonly label: string;
+  capabilities: NoteVaultCapabilities;
+  list(options?: NoteVaultListOptions): Promise<NoteVaultNode[]>;
+  read(ref: NoteVaultRef): Promise<NoteVaultFile>;
+  write(ref: NoteVaultRef, content: string, options?: NoteVaultWriteOptions): Promise<NoteVaultWriteResult>;
+  createFile(parent: NoteVaultRef, name: string, content?: string): Promise<NoteVaultFileRef>;
+  createFolder(parent: NoteVaultRef, name: string): Promise<NoteVaultFolderRef>;
+  rename(ref: NoteVaultRef, name: string): Promise<NoteVaultRef>;
+  delete(ref: NoteVaultRef, options?: NoteVaultDeleteOptions): Promise<void>;
+  watch?(listener: (event: NoteVaultChangeEvent) => void): () => void;
+}
+```
+
+Important design choices:
+
+- Use provider-owned refs rather than assuming POSIX paths. Local files can use absolute paths internally, but cloud providers may need opaque IDs.
+- Include display paths for UI, but do not make display paths the only identity.
+- Represent capabilities explicitly because not every backend can watch, trash, rename folders, or provide revision tokens.
+- Writes should allow optimistic concurrency via an optional revision/etag token when the provider supports it.
+
+## Decision: Contract First, Provider SDKs Later
+
+Do not bundle Google Drive, Dropbox, S3, WebDAV, or any auth SDK in v1. Provider integrations can be separate packages or host code once the adapter contract is stable.
+
+Rationale:
+
+- Cloud SDKs bring auth, token refresh, rate limits, retry policy, and bundle-size concerns.
+- Hosts already own identity and persistence decisions.
+- The first implementation can prove the contract by adapting the existing Electron local vault.
+
+## Decision: Keep Core Headless
+
+The contract may be exported from core or from a small storage package, but it must not make core perform IO. Core should remain a headless editor engine. If core exports types, they are only contracts for hosts and plugins.
+
+The implementation proposal should compare two options:
+
+- `@floatboat/nexus-core` exports the minimal types.
+- New package such as `@floatboat/nexus-storage` exports the adapter contract and helper tests.
+
+The proposal leans toward core-exported types only if they remain dependency-free and do not add runtime IO behavior.
+
+## Decision: Existing Electron Vault Is the Reference Backend
+
+The existing Electron vault is the best first adapter target because it already covers:
+
+- recursive tree listing
+- markdown file filtering
+- read/write/create/rename/delete
+- change notification via watcher
+- path-escape validation
+- last-vault persistence
+
+The implementation PR should adapt this behavior without removing the current user-facing demo flow.
+
+## Boundary Validation
+
+The design boundary is validated by these checks:
+
+- No cloud provider SDK appears in core.
+- No Electron, Node filesystem, or browser storage APIs are imported by core adapter types.
+- Adapter refs can represent both local paths and opaque cloud IDs.
+- All destructive or write operations can report unsupported, permission-denied, auth-required, conflict, offline, and unknown errors.
+- Watch support is optional and capability-gated.
+- Existing electron-demo vault behavior can be mapped onto the interface without losing path-escape checks.
+
+## Test Plan
+
+Proposal validation:
+
+- `openspec validate add-cloud-storage-interface --strict`
+- Search for unresolved conflict markers in the new OpenSpec files and Roadmap files.
+- Confirm diff contains only OpenSpec + Roadmap files.
+
+Implementation validation in a later PR:
+
+- Adapter contract tests using an in-memory adapter.
+- Local filesystem/electron adapter tests for list/read/write/create/rename/delete.
+- Conflict tests for stale revision/etag writes.
+- Capability tests for unsupported watch/trash/rename operations.
+- Path/boundary tests proving local filesystem adapter cannot escape its vault root.
+- Electron-demo smoke test for existing open/read/write/create/rename/delete/watch flows after refactor.
+
+## Risks / Trade-offs
+
+- Too much in core would violate headless design. Keep concrete IO out.
+- Too little in the contract would force every host to invent incompatible semantics. Define errors, refs, capabilities, and revision handling clearly.
+- Cloud providers differ heavily. Capability flags are required to avoid pretending every backend supports the same operations.
+- Conflict handling can grow large. v1 should define conflict signals, not a full merge UI.
+
+## Open Questions
+
+- Should the adapter contract live in `@floatboat/nexus-core` as types only, or in a new package?
+- Should `readAll` be a required method or a helper built from `list` + `read`?
+- Should delete prefer trash semantics when supported, or should trash be a separate optional capability?
+- How much of last-vault/recent-vault persistence belongs in the adapter versus host UI state?

--- a/openspec/changes/add-cloud-storage-interface/design.md
+++ b/openspec/changes/add-cloud-storage-interface/design.md
@@ -35,6 +35,7 @@ export interface NoteVaultAdapter {
   readonly label: string;
   capabilities: NoteVaultCapabilities;
   list(options?: NoteVaultListOptions): Promise<NoteVaultNode[]>;
+  readAll?(options?: NoteVaultListOptions): Promise<NoteVaultFile[]>;
   read(ref: NoteVaultRef): Promise<NoteVaultFile>;
   write(ref: NoteVaultRef, content: string, options?: NoteVaultWriteOptions): Promise<NoteVaultWriteResult>;
   createFile(parent: NoteVaultRef, name: string, content?: string): Promise<NoteVaultFileRef>;
@@ -51,6 +52,7 @@ Important design choices:
 - Include display paths for UI, but do not make display paths the only identity.
 - Represent capabilities explicitly because not every backend can watch, trash, rename folders, or provide revision tokens.
 - Writes should allow optimistic concurrency via an optional revision/etag token when the provider supports it.
+- Let adapters expose an optional `readAll` batch path for startup/indexing. The shared helper falls back to bounded-concurrency `list` + `read` so providers are not forced to implement a batch endpoint.
 
 ## Decision: Contract First, Provider SDKs Later
 
@@ -124,6 +126,5 @@ Implementation validation in a later PR:
 ## Open Questions
 
 - Should the adapter contract live in `@floatboat/nexus-core` as types only, or in a new package?
-- Should `readAll` be a required method or a helper built from `list` + `read`?
 - Should delete prefer trash semantics when supported, or should trash be a separate optional capability?
 - How much of last-vault/recent-vault persistence belongs in the adapter versus host UI state?

--- a/openspec/changes/add-cloud-storage-interface/proposal.md
+++ b/openspec/changes/add-cloud-storage-interface/proposal.md
@@ -1,0 +1,48 @@
+# Change: Add Cloud Storage Interface
+
+## Why
+
+The electron demo already has a vault workflow backed by local filesystem IPC, but that implementation is host-specific and cannot be reused by web, mobile, iframe, or cloud-backed hosts. Roadmap #23 calls for a cloud storage interface so Nexus can describe note/vault IO through a stable adapter contract while leaving concrete storage backends to the host.
+
+## Goals
+
+- Define a minimal `NoteVault` / storage adapter contract for listing, reading, writing, creating, renaming, deleting, and watching note-like resources.
+- Keep storage backend ownership with the host. Nexus defines the contract; hosts provide local filesystem, WebDAV, S3, Dropbox, Google Drive, IndexedDB, or custom implementations.
+- Preserve the existing editor-core headless model. The editor should not directly authenticate to cloud services or bundle provider SDKs.
+- Provide enough contract detail for future implementation PRs to refactor the electron demo vault behind the same interface.
+- Define test expectations for adapter contract behavior, boundary/security checks, and error semantics before runtime code is written.
+
+## What Changes
+
+This proposal phase changes only documentation/spec files:
+
+- Add `openspec/changes/add-cloud-storage-interface/proposal.md`.
+- Add `openspec/changes/add-cloud-storage-interface/design.md`.
+- Add `openspec/changes/add-cloud-storage-interface/tasks.md`.
+- Add `openspec/changes/add-cloud-storage-interface/specs/storage-interface/spec.md`.
+- Update `docs/ROADMAP.md` and `docs/ROADMAP.zh.md` to mark Roadmap #23 as `in-progress` and link this change id.
+
+The later implementation phase is expected to affect:
+
+- `packages/core/src/types.ts` or a focused core module for exported adapter types.
+- `packages/core/test/*` for adapter contract tests if the contract lands in core.
+- `apps/electron-demo/electron/*` and `apps/electron-demo/src/renderer/*` if the existing vault IPC is adapted to the new contract.
+- README/package docs for public API usage.
+
+## Non-Goals
+
+- No runtime code in this proposal PR.
+- No bundled cloud provider SDKs in v1.
+- No Google Drive, Dropbox, S3, WebDAV, or sync server implementation in v1.
+- No auth/token refresh UI.
+- No cross-device conflict resolution UI beyond defining required adapter conflict/error signals.
+- No version history snapshots; Roadmap #19 owns that.
+- No realtime collaboration; Roadmap #18 owns that.
+
+## Impact
+
+- Affected specs: `storage-interface` (new capability)
+- Affected roadmap rows: #23 in English and Chinese roadmap files
+- Runtime impact in this proposal phase: none
+- Dependency impact in this proposal phase: none
+- Backwards compatibility: existing local file and vault flows remain unchanged until a later implementation PR

--- a/openspec/changes/add-cloud-storage-interface/specs/storage-interface/spec.md
+++ b/openspec/changes/add-cloud-storage-interface/specs/storage-interface/spec.md
@@ -109,6 +109,11 @@ The storage interface SHALL be expressive enough to model the existing electron-
 - **WHEN** the existing electron-demo vault lists, reads, writes, creates, renames, deletes, and watches local markdown files
 - **THEN** each operation SHALL have an equivalent storage adapter method or documented helper
 
+#### Scenario: Startup index reads use batch path when available
+- **WHEN** an adapter exposes a batch read method for all supported note files
+- **THEN** shared read-all helpers SHALL use that batch method instead of issuing one read call per file
+- **AND** adapters without a batch method SHALL still be supported through bounded-concurrency reads
+
 #### Scenario: Path escape guard preserved
 - **WHEN** a local filesystem adapter receives a ref or target path that resolves outside the active vault root
 - **THEN** the adapter SHALL reject the operation

--- a/openspec/changes/add-cloud-storage-interface/specs/storage-interface/spec.md
+++ b/openspec/changes/add-cloud-storage-interface/specs/storage-interface/spec.md
@@ -1,0 +1,115 @@
+# Storage Interface Spec
+
+## ADDED Requirements
+
+### Requirement: Host-Owned Storage Adapter Contract
+
+The system SHALL define a storage adapter contract for note/vault operations without requiring Nexus core to perform IO or authenticate to cloud services.
+
+#### Scenario: Host supplies adapter
+- **WHEN** a host wants to use a local, browser, or cloud-backed note store
+- **THEN** it SHALL provide an adapter implementing the storage interface
+- **AND** Nexus SHALL interact with the note store through that adapter contract
+
+#### Scenario: Core remains IO-free
+- **WHEN** the storage interface is introduced
+- **THEN** `@floatboat/nexus-core` SHALL NOT import Node filesystem, Electron, browser storage, or cloud provider SDKs for concrete IO
+- **AND** single-document editor usage SHALL continue to work without storage configuration
+
+### Requirement: Provider-Neutral Resource References
+
+The storage interface SHALL identify files and folders through provider-neutral refs that can represent both local filesystem paths and opaque cloud IDs.
+
+#### Scenario: Local filesystem ref
+- **WHEN** a local filesystem adapter returns a file
+- **THEN** the returned ref MAY include a path-like display value
+- **AND** the adapter SHALL still validate operations against its configured vault root
+
+#### Scenario: Cloud provider ref
+- **WHEN** a cloud adapter returns a file whose provider uses opaque IDs
+- **THEN** the returned ref SHALL be able to carry that opaque ID
+- **AND** UI display paths SHALL NOT be treated as the only stable identity
+
+### Requirement: Basic Vault Operations
+
+The storage adapter SHALL support the basic note vault operations needed by existing Nexus vault workflows: list, read, write, create file, create folder, rename, and delete.
+
+#### Scenario: List note tree
+- **WHEN** the host lists a vault
+- **THEN** the adapter SHALL return file and folder nodes with stable refs, names, node kind, and optional children
+
+#### Scenario: Read file content
+- **WHEN** the host reads a file ref
+- **THEN** the adapter SHALL return the current text content
+- **AND** it MAY return provider revision metadata for later optimistic writes
+
+#### Scenario: Write file content
+- **WHEN** the host writes text content to a file ref
+- **THEN** the adapter SHALL persist the content or return a typed error
+- **AND** it SHALL return updated ref/revision metadata when available
+
+#### Scenario: Mutate tree
+- **WHEN** the host creates, renames, or deletes a file or folder
+- **THEN** the adapter SHALL perform the mutation or return a typed error
+- **AND** the adapter SHALL NOT silently mutate a different resource
+
+### Requirement: Capabilities
+
+The storage interface SHALL expose backend capabilities so hosts can disable UI actions that a provider does not support.
+
+#### Scenario: Watch unsupported
+- **WHEN** a provider cannot stream external changes
+- **THEN** its capabilities SHALL mark watch support as unavailable
+- **AND** the host SHALL be able to fall back to manual refresh
+
+#### Scenario: Trash unsupported
+- **WHEN** a provider cannot send deleted resources to trash
+- **THEN** its capabilities SHALL mark trash support as unavailable
+- **AND** delete behavior SHALL be explicit rather than silently hard-deleting
+
+### Requirement: Typed Error Semantics
+
+The storage adapter SHALL return typed errors for common storage failures.
+
+#### Scenario: Auth required
+- **WHEN** a cloud provider requires login or token refresh
+- **THEN** the adapter SHALL report an auth-required error
+- **AND** the host SHALL own the UI flow for re-authentication
+
+#### Scenario: Permission denied
+- **WHEN** the current user cannot read or write a resource
+- **THEN** the adapter SHALL report a permission-denied error
+
+#### Scenario: Conflict detected
+- **WHEN** a write uses a stale revision/etag
+- **THEN** the adapter SHALL report a conflict error
+- **AND** it SHALL NOT overwrite remote content silently
+
+#### Scenario: Offline
+- **WHEN** a backend is unavailable because the client is offline
+- **THEN** the adapter SHALL report offline state or an offline error according to its capabilities
+
+### Requirement: Optional Change Notifications
+
+The storage adapter SHALL support optional change notifications for backends that can watch or subscribe to external mutations.
+
+#### Scenario: External file changed
+- **WHEN** an external process or remote client changes a watched note
+- **THEN** a watch-capable adapter SHALL emit a change event identifying the affected ref and change kind
+
+#### Scenario: Unsubscribe from watch
+- **WHEN** the host calls the unsubscribe function returned by watch
+- **THEN** the adapter SHALL stop delivering change events to that listener
+
+### Requirement: Existing Electron Vault Compatibility
+
+The storage interface SHALL be expressive enough to model the existing electron-demo vault workflow.
+
+#### Scenario: Existing local vault operations map to adapter methods
+- **WHEN** the existing electron-demo vault lists, reads, writes, creates, renames, deletes, and watches local markdown files
+- **THEN** each operation SHALL have an equivalent storage adapter method or documented helper
+
+#### Scenario: Path escape guard preserved
+- **WHEN** a local filesystem adapter receives a ref or target path that resolves outside the active vault root
+- **THEN** the adapter SHALL reject the operation
+- **AND** no file outside the vault SHALL be read or mutated

--- a/openspec/changes/add-cloud-storage-interface/tasks.md
+++ b/openspec/changes/add-cloud-storage-interface/tasks.md
@@ -1,0 +1,37 @@
+## 1. Proposal
+
+- [x] 1.1 Review Roadmap #23 and existing Electron vault IPC surface.
+- [x] 1.2 Define proposal goals, non-goals, expected files, and impact.
+- [x] 1.3 Define design boundary and validation strategy.
+- [x] 1.4 Run `openspec validate add-cloud-storage-interface --strict`.
+- [ ] 1.5 Submit proposal PR and wait for approval before implementation.
+
+## 2. Interface Design
+
+- [ ] 2.1 Decide whether the contract lives in `@floatboat/nexus-core` as dependency-free types or in a new storage package.
+- [ ] 2.2 Finalize `NoteVaultAdapter`, `NoteVaultRef`, `NoteVaultNode`, capability, write-result, and error types.
+- [ ] 2.3 Define revision/etag semantics for optimistic writes.
+- [ ] 2.4 Define optional watch/change event semantics.
+- [ ] 2.5 Define unsupported-operation, auth-required, permission-denied, conflict, offline, and unknown error shapes.
+
+## 3. Future Implementation
+
+- [ ] 3.1 Add exported TypeScript contract in the approved package/module.
+- [ ] 3.2 Add in-memory adapter for contract tests.
+- [ ] 3.3 Adapt electron-demo local vault behavior behind the contract without changing current user flows.
+- [ ] 3.4 Preserve path-escape validation in the local filesystem adapter.
+- [ ] 3.5 Document host-owned provider responsibilities and cloud SDK non-goals.
+
+## 4. Future Tests
+
+- [ ] 4.1 Contract tests cover list/read/write/create/rename/delete.
+- [ ] 4.2 Conflict tests cover stale revision/etag writes.
+- [ ] 4.3 Capability tests cover unsupported watch/trash/rename operations.
+- [ ] 4.4 Boundary tests prove local filesystem refs cannot escape the vault root.
+- [ ] 4.5 Electron-demo smoke test covers existing vault workflows after refactor.
+
+## 5. Documentation / Roadmap
+
+- [x] 5.1 Update `docs/ROADMAP.md` and `docs/ROADMAP.zh.md` with this OpenSpec change id.
+- [ ] 5.2 Add README/API docs in the implementation PR if public types are introduced.
+- [ ] 5.3 Keep implementation PR separate from this proposal PR.

--- a/openspec/changes/add-cloud-storage-interface/tasks.md
+++ b/openspec/changes/add-cloud-storage-interface/tasks.md
@@ -8,30 +8,31 @@
 
 ## 2. Interface Design
 
-- [ ] 2.1 Decide whether the contract lives in `@floatboat/nexus-core` as dependency-free types or in a new storage package.
-- [ ] 2.2 Finalize `NoteVaultAdapter`, `NoteVaultRef`, `NoteVaultNode`, capability, write-result, and error types.
-- [ ] 2.3 Define revision/etag semantics for optimistic writes.
-- [ ] 2.4 Define optional watch/change event semantics.
-- [ ] 2.5 Define unsupported-operation, auth-required, permission-denied, conflict, offline, and unknown error shapes.
+- [x] 2.1 Decide whether the contract lives in `@floatboat/nexus-core` as dependency-free types or in a new storage package.
+- [x] 2.2 Finalize `NoteVaultAdapter`, `NoteVaultRef`, `NoteVaultNode`, capability, write-result, and error types.
+- [x] 2.3 Define revision/etag semantics for optimistic writes.
+- [x] 2.4 Define optional watch/change event semantics.
+- [x] 2.5 Define unsupported-operation, auth-required, permission-denied, conflict, offline, and unknown error shapes.
 
 ## 3. Future Implementation
 
-- [ ] 3.1 Add exported TypeScript contract in the approved package/module.
-- [ ] 3.2 Add in-memory adapter for contract tests.
-- [ ] 3.3 Adapt electron-demo local vault behavior behind the contract without changing current user flows.
-- [ ] 3.4 Preserve path-escape validation in the local filesystem adapter.
-- [ ] 3.5 Document host-owned provider responsibilities and cloud SDK non-goals.
+- [x] 3.1 Add exported TypeScript contract in the approved package/module.
+- [x] 3.2 Add in-memory adapter for contract tests.
+- [x] 3.3 Adapt electron-demo local vault behavior behind the contract without changing current user flows.
+- [x] 3.4 Preserve path-escape validation in the local filesystem adapter.
+- [x] 3.5 Document host-owned provider responsibilities and cloud SDK non-goals.
 
 ## 4. Future Tests
 
-- [ ] 4.1 Contract tests cover list/read/write/create/rename/delete.
-- [ ] 4.2 Conflict tests cover stale revision/etag writes.
-- [ ] 4.3 Capability tests cover unsupported watch/trash/rename operations.
-- [ ] 4.4 Boundary tests prove local filesystem refs cannot escape the vault root.
-- [ ] 4.5 Electron-demo smoke test covers existing vault workflows after refactor.
+- [x] 4.1 Contract tests cover list/read/write/create/rename/delete.
+- [x] 4.2 Conflict tests cover stale revision/etag writes.
+- [x] 4.3 Capability tests cover unsupported watch/trash/rename operations.
+- [x] 4.4 Boundary tests prove local filesystem refs cannot escape the vault root.
+- [x] 4.5 Renderer adapter integration tests cover vault open, file open, root file creation, and trash delete through the vault panel.
+- [ ] 4.6 Electron-demo smoke test covers existing vault workflows after refactor.
 
 ## 5. Documentation / Roadmap
 
 - [x] 5.1 Update `docs/ROADMAP.md` and `docs/ROADMAP.zh.md` with this OpenSpec change id.
-- [ ] 5.2 Add README/API docs in the implementation PR if public types are introduced.
+- [x] 5.2 Add README/API docs in the implementation PR if public types are introduced.
 - [ ] 5.3 Keep implementation PR separate from this proposal PR.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,31 @@ export {
 } from "./slash-state";
 export { lightTheme, darkTheme, type NexusTheme } from "./theme";
 export {
+  NoteVaultError,
+  createNoteVaultError,
+  flattenNoteVaultNodes,
+  isNoteVaultError,
+  readAllNoteVaultFiles,
+  type AnyNoteVaultRef,
+  type NoteVaultAdapter,
+  type NoteVaultCapabilities,
+  type NoteVaultChangeEvent,
+  type NoteVaultChangeKind,
+  type NoteVaultDeleteOptions,
+  type NoteVaultErrorCode,
+  type NoteVaultErrorDetails,
+  type NoteVaultFile,
+  type NoteVaultFileRef,
+  type NoteVaultFolderRef,
+  type NoteVaultListOptions,
+  type NoteVaultNode,
+  type NoteVaultNodeKind,
+  type NoteVaultReadAllOptions,
+  type NoteVaultRef,
+  type NoteVaultWriteOptions,
+  type NoteVaultWriteResult,
+} from "./storage";
+export {
   scanWikiLinks,
   createWikilinksExtension,
   createWikilinksPlugin,

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -1,0 +1,173 @@
+export type NoteVaultNodeKind = "file" | "folder";
+
+export interface NoteVaultRef {
+  /** Stable within the adapter, e.g. "local-fs" or "dropbox". */
+  providerId: string;
+  /** Provider-owned identity: an absolute path, relative path, or opaque ID. */
+  id: string;
+  kind: NoteVaultNodeKind;
+  name?: string;
+  /** UI-friendly path. Hosts must not treat this as the only stable identity. */
+  displayPath?: string;
+  revision?: string;
+  etag?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NoteVaultFileRef extends NoteVaultRef {
+  kind: "file";
+}
+
+export interface NoteVaultFolderRef extends NoteVaultRef {
+  kind: "folder";
+}
+
+export type AnyNoteVaultRef = NoteVaultFileRef | NoteVaultFolderRef;
+
+export interface NoteVaultNode {
+  ref: AnyNoteVaultRef;
+  name: string;
+  kind: NoteVaultNodeKind;
+  children?: NoteVaultNode[];
+  revision?: string;
+  etag?: string;
+  displayPath?: string;
+}
+
+export interface NoteVaultFile {
+  ref: NoteVaultFileRef;
+  content: string;
+  revision?: string;
+  etag?: string;
+}
+
+export interface NoteVaultCapabilities {
+  watch?: boolean;
+  trash?: boolean;
+  renameFile?: boolean;
+  renameFolder?: boolean;
+  createFile?: boolean;
+  createFolder?: boolean;
+  deleteFile?: boolean;
+  deleteFolder?: boolean;
+  optimisticWrites?: boolean;
+  offline?: boolean;
+}
+
+export interface NoteVaultListOptions {
+  root?: NoteVaultFolderRef;
+  recursive?: boolean;
+}
+
+export interface NoteVaultWriteOptions {
+  revision?: string;
+  etag?: string;
+}
+
+export interface NoteVaultWriteResult {
+  ref: NoteVaultFileRef;
+  revision?: string;
+  etag?: string;
+}
+
+export interface NoteVaultDeleteOptions {
+  trash?: boolean;
+}
+
+export type NoteVaultChangeKind = "created" | "updated" | "deleted" | "renamed" | "refreshed";
+
+export interface NoteVaultChangeEvent {
+  kind: NoteVaultChangeKind;
+  ref?: AnyNoteVaultRef;
+  previousRef?: AnyNoteVaultRef;
+}
+
+export type NoteVaultErrorCode =
+  | "unsupported-operation"
+  | "auth-required"
+  | "permission-denied"
+  | "conflict"
+  | "offline"
+  | "not-found"
+  | "invalid-ref"
+  | "unknown";
+
+export interface NoteVaultErrorDetails {
+  ref?: AnyNoteVaultRef;
+  operation?: string;
+  cause?: unknown;
+}
+
+export class NoteVaultError extends Error {
+  readonly code: NoteVaultErrorCode;
+  readonly ref?: AnyNoteVaultRef;
+  readonly operation?: string;
+  readonly cause?: unknown;
+
+  constructor(code: NoteVaultErrorCode, message: string, details: NoteVaultErrorDetails = {}) {
+    super(message);
+    this.name = "NoteVaultError";
+    this.code = code;
+    this.ref = details.ref;
+    this.operation = details.operation;
+    this.cause = details.cause;
+  }
+}
+
+export function createNoteVaultError(
+  code: NoteVaultErrorCode,
+  message: string,
+  details?: NoteVaultErrorDetails
+): NoteVaultError {
+  return new NoteVaultError(code, message, details);
+}
+
+export function isNoteVaultError(value: unknown): value is NoteVaultError {
+  return value instanceof NoteVaultError;
+}
+
+export interface NoteVaultAdapter {
+  readonly id: string;
+  readonly label: string;
+  readonly capabilities: NoteVaultCapabilities;
+  list(options?: NoteVaultListOptions): Promise<NoteVaultNode[]>;
+  read(ref: NoteVaultRef): Promise<NoteVaultFile>;
+  write(ref: NoteVaultRef, content: string, options?: NoteVaultWriteOptions): Promise<NoteVaultWriteResult>;
+  createFile(parent: NoteVaultRef, name: string, content?: string): Promise<NoteVaultFileRef>;
+  createFolder(parent: NoteVaultRef, name: string): Promise<NoteVaultFolderRef>;
+  rename(ref: NoteVaultRef, name: string): Promise<AnyNoteVaultRef>;
+  delete(ref: NoteVaultRef, options?: NoteVaultDeleteOptions): Promise<void>;
+  watch?(listener: (event: NoteVaultChangeEvent) => void): () => void;
+}
+
+export interface NoteVaultReadAllOptions extends NoteVaultListOptions {
+  onError?: (error: unknown, ref: NoteVaultFileRef) => void;
+}
+
+export function flattenNoteVaultNodes(nodes: readonly NoteVaultNode[]): AnyNoteVaultRef[] {
+  const refs: AnyNoteVaultRef[] = [];
+  for (const node of nodes) {
+    refs.push(node.ref);
+    if (node.children) refs.push(...flattenNoteVaultNodes(node.children));
+  }
+  return refs;
+}
+
+export async function readAllNoteVaultFiles(
+  adapter: NoteVaultAdapter,
+  options: NoteVaultReadAllOptions = {}
+): Promise<NoteVaultFile[]> {
+  const nodes = await adapter.list(options);
+  const files = flattenNoteVaultNodes(nodes).filter((ref): ref is NoteVaultFileRef => ref.kind === "file");
+  const out: NoteVaultFile[] = [];
+
+  for (const ref of files) {
+    try {
+      out.push(await adapter.read(ref));
+    } catch (err) {
+      options.onError?.(err, ref);
+    }
+  }
+
+  return out;
+}

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -131,6 +131,7 @@ export interface NoteVaultAdapter {
   readonly label: string;
   readonly capabilities: NoteVaultCapabilities;
   list(options?: NoteVaultListOptions): Promise<NoteVaultNode[]>;
+  readAll?(options?: NoteVaultListOptions): Promise<NoteVaultFile[]>;
   read(ref: NoteVaultRef): Promise<NoteVaultFile>;
   write(ref: NoteVaultRef, content: string, options?: NoteVaultWriteOptions): Promise<NoteVaultWriteResult>;
   createFile(parent: NoteVaultRef, name: string, content?: string): Promise<NoteVaultFileRef>;
@@ -143,6 +144,8 @@ export interface NoteVaultAdapter {
 export interface NoteVaultReadAllOptions extends NoteVaultListOptions {
   onError?: (error: unknown, ref: NoteVaultFileRef) => void;
 }
+
+const DEFAULT_READ_ALL_CONCURRENCY = 32;
 
 export function flattenNoteVaultNodes(nodes: readonly NoteVaultNode[]): AnyNoteVaultRef[] {
   const refs: AnyNoteVaultRef[] = [];
@@ -157,17 +160,30 @@ export async function readAllNoteVaultFiles(
   adapter: NoteVaultAdapter,
   options: NoteVaultReadAllOptions = {}
 ): Promise<NoteVaultFile[]> {
-  const nodes = await adapter.list(options);
-  const files = flattenNoteVaultNodes(nodes).filter((ref): ref is NoteVaultFileRef => ref.kind === "file");
-  const out: NoteVaultFile[] = [];
+  const listOptions: NoteVaultListOptions = {
+    root: options.root,
+    recursive: options.recursive,
+  };
+  if (adapter.readAll) return adapter.readAll(listOptions);
 
-  for (const ref of files) {
-    try {
-      out.push(await adapter.read(ref));
-    } catch (err) {
-      options.onError?.(err, ref);
+  const nodes = await adapter.list(listOptions);
+  const files = flattenNoteVaultNodes(nodes).filter((ref): ref is NoteVaultFileRef => ref.kind === "file");
+  const out = new Array<NoteVaultFile | undefined>(files.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < files.length) {
+      const index = cursor++;
+      const ref = files[index];
+      try {
+        out[index] = await adapter.read(ref);
+      } catch (err) {
+        options.onError?.(err, ref);
+      }
     }
   }
 
-  return out;
+  await Promise.all(Array.from({ length: Math.min(DEFAULT_READ_ALL_CONCURRENCY, files.length) }, worker));
+
+  return out.filter((file): file is NoteVaultFile => file !== undefined);
 }

--- a/packages/core/test/storage-interface.test.ts
+++ b/packages/core/test/storage-interface.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  NoteVaultError,
+  createNoteVaultError,
+  flattenNoteVaultNodes,
+  isNoteVaultError,
+  readAllNoteVaultFiles,
+  type AnyNoteVaultRef,
+  type NoteVaultAdapter,
+  type NoteVaultChangeEvent,
+  type NoteVaultFile,
+  type NoteVaultFileRef,
+  type NoteVaultFolderRef,
+  type NoteVaultNode,
+  type NoteVaultRef,
+} from "../src/index";
+
+interface MemoryEntry {
+  kind: "file" | "folder";
+  name: string;
+  parent: string | null;
+  content?: string;
+  revision: number;
+}
+
+class InMemoryNoteVaultAdapter implements NoteVaultAdapter {
+  readonly id = "memory";
+  readonly label = "Memory vault";
+  readonly capabilities = {
+    watch: true,
+    trash: false,
+    renameFile: true,
+    renameFolder: true,
+    createFile: true,
+    createFolder: true,
+    deleteFile: true,
+    deleteFolder: true,
+    optimisticWrites: true,
+  };
+
+  private entries = new Map<string, MemoryEntry>([
+    ["/", { kind: "folder", name: "", parent: null, revision: 1 }],
+  ]);
+  private listeners = new Set<(event: NoteVaultChangeEvent) => void>();
+
+  rootRef(): NoteVaultFolderRef {
+    return this.ref("/", "folder");
+  }
+
+  async list(): Promise<NoteVaultNode[]> {
+    return this.childrenOf("/");
+  }
+
+  async read(ref: NoteVaultRef): Promise<NoteVaultFile> {
+    const id = this.assertRef(ref, "file");
+    const entry = this.entries.get(id)!;
+    return {
+      ref: this.ref(id, "file"),
+      content: entry.content ?? "",
+      revision: String(entry.revision),
+    };
+  }
+
+  async write(ref: NoteVaultRef, content: string, options: { revision?: string } = {}) {
+    const id = this.assertRef(ref, "file");
+    const entry = this.entries.get(id)!;
+    if (options.revision && options.revision !== String(entry.revision)) {
+      throw createNoteVaultError("conflict", "Stale revision", {
+        ref: this.ref(id, "file"),
+        operation: "write",
+      });
+    }
+    entry.content = content;
+    entry.revision += 1;
+    this.emit({ kind: "updated", ref: this.ref(id, "file") });
+    return { ref: this.ref(id, "file"), revision: String(entry.revision) };
+  }
+
+  async createFile(parent: NoteVaultRef, name: string, content = ""): Promise<NoteVaultFileRef> {
+    const parentId = this.assertRef(parent, "folder");
+    const id = this.childId(parentId, name);
+    if (this.entries.has(id)) throw createNoteVaultError("conflict", `Already exists: ${name}`);
+    this.entries.set(id, { kind: "file", name, parent: parentId, content, revision: 1 });
+    const ref = this.ref(id, "file");
+    this.emit({ kind: "created", ref });
+    return ref;
+  }
+
+  async createFolder(parent: NoteVaultRef, name: string): Promise<NoteVaultFolderRef> {
+    const parentId = this.assertRef(parent, "folder");
+    const id = this.childId(parentId, name);
+    if (this.entries.has(id)) throw createNoteVaultError("conflict", `Already exists: ${name}`);
+    this.entries.set(id, { kind: "folder", name, parent: parentId, revision: 1 });
+    const ref = this.ref(id, "folder");
+    this.emit({ kind: "created", ref });
+    return ref;
+  }
+
+  async rename(ref: NoteVaultRef, name: string): Promise<AnyNoteVaultRef> {
+    const id = this.assertRef(ref);
+    const entry = this.entries.get(id)!;
+    if (entry.parent === null) throw createNoteVaultError("unsupported-operation", "Cannot rename root");
+    const nextId = this.childId(entry.parent, name);
+    if (this.entries.has(nextId)) throw createNoteVaultError("conflict", `Already exists: ${name}`);
+
+    const moved = new Map<string, MemoryEntry>();
+    for (const [entryId, child] of this.entries) {
+      if (entryId === id || entryId.startsWith(`${id}/`)) {
+        const rewrittenId = `${nextId}${entryId.slice(id.length)}`;
+        moved.set(rewrittenId, {
+          ...child,
+          name: entryId === id ? name : child.name,
+          parent: child.parent === id ? nextId : child.parent?.startsWith(`${id}/`) ? `${nextId}${child.parent.slice(id.length)}` : child.parent,
+        });
+        this.entries.delete(entryId);
+      }
+    }
+    for (const [entryId, child] of moved) this.entries.set(entryId, child);
+
+    const previousRef = this.ref(id, entry.kind);
+    const nextRef = this.ref(nextId, entry.kind);
+    this.emit({ kind: "renamed", ref: nextRef, previousRef });
+    return nextRef;
+  }
+
+  async delete(ref: NoteVaultRef, options: { trash?: boolean } = {}): Promise<void> {
+    if (options.trash) {
+      throw createNoteVaultError("unsupported-operation", "Trash is not supported", {
+        ref,
+        operation: "delete",
+      });
+    }
+    const id = this.assertRef(ref);
+    for (const entryId of [...this.entries.keys()]) {
+      if (entryId === id || entryId.startsWith(`${id}/`)) this.entries.delete(entryId);
+    }
+    this.emit({ kind: "deleted", ref: { ...ref, id } });
+  }
+
+  watch(listener: (event: NoteVaultChangeEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private childrenOf(parent: string): NoteVaultNode[] {
+    const children = [...this.entries.entries()]
+      .filter(([, entry]) => entry.parent === parent)
+      .sort((a, b) => {
+        if (a[1].kind !== b[1].kind) return a[1].kind === "folder" ? -1 : 1;
+        return a[1].name.localeCompare(b[1].name);
+      });
+
+    return children.map(([id, entry]) => ({
+      name: entry.name,
+      kind: entry.kind,
+      ref: this.ref(id, entry.kind),
+      revision: String(entry.revision),
+      displayPath: id,
+      children: entry.kind === "folder" ? this.childrenOf(id) : undefined,
+    }));
+  }
+
+  private assertRef(ref: NoteVaultRef, kind?: "file"): string;
+  private assertRef(ref: NoteVaultRef, kind?: "folder"): string;
+  private assertRef(ref: NoteVaultRef, kind?: "file" | "folder"): string {
+    if (ref.providerId !== this.id) {
+      throw createNoteVaultError("invalid-ref", `Wrong provider: ${ref.providerId}`, { ref });
+    }
+    const entry = this.entries.get(ref.id);
+    if (!entry) throw createNoteVaultError("not-found", `Missing ref: ${ref.id}`, { ref });
+    if (kind && entry.kind !== kind) {
+      throw createNoteVaultError("invalid-ref", `Expected ${kind}`, { ref });
+    }
+    return ref.id;
+  }
+
+  private ref(id: string, kind: "file"): NoteVaultFileRef;
+  private ref(id: string, kind: "folder"): NoteVaultFolderRef;
+  private ref(id: string, kind: "file" | "folder"): AnyNoteVaultRef;
+  private ref(id: string, kind: "file" | "folder"): AnyNoteVaultRef {
+    const entry = this.entries.get(id);
+    return {
+      providerId: this.id,
+      id,
+      kind,
+      name: entry?.name,
+      displayPath: id,
+      revision: entry ? String(entry.revision) : undefined,
+    } as AnyNoteVaultRef;
+  }
+
+  private childId(parent: string, name: string): string {
+    return parent === "/" ? `/${name}` : `${parent}/${name}`;
+  }
+
+  private emit(event: NoteVaultChangeEvent): void {
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+describe("storage interface", () => {
+  it("models list/read/write/create/rename/delete through a provider-neutral adapter", async () => {
+    const adapter = new InMemoryNoteVaultAdapter();
+    const folder = await adapter.createFolder(adapter.rootRef(), "Daily");
+    const file = await adapter.createFile(folder, "today.md", "# Today");
+
+    expect(file.id).toBe("/Daily/today.md");
+    expect(file.displayPath).toBe("/Daily/today.md");
+
+    const tree = await adapter.list();
+    expect(tree[0].kind).toBe("folder");
+    expect(tree[0].children?.[0].name).toBe("today.md");
+    expect(flattenNoteVaultNodes(tree).map((ref) => ref.id)).toEqual(["/Daily", "/Daily/today.md"]);
+
+    const before = await adapter.read(file);
+    expect(before.content).toBe("# Today");
+
+    const written = await adapter.write(file, "# Updated", { revision: before.revision });
+    expect(written.revision).toBe("2");
+    await expect(adapter.read(written.ref)).resolves.toMatchObject({ content: "# Updated" });
+
+    const renamed = await adapter.rename(written.ref, "tomorrow.md");
+    expect(renamed.id).toBe("/Daily/tomorrow.md");
+
+    await adapter.delete(renamed);
+    await expect(adapter.read(renamed)).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("supports optional read-all helper built from list plus read", async () => {
+    const adapter = new InMemoryNoteVaultAdapter();
+    await adapter.createFile(adapter.rootRef(), "a.md", "A");
+    const folder = await adapter.createFolder(adapter.rootRef(), "Nested");
+    await adapter.createFile(folder, "b.md", "B");
+
+    const files = await readAllNoteVaultFiles(adapter);
+
+    expect(files.map((file) => [file.ref.id, file.content])).toEqual([
+      ["/Nested/b.md", "B"],
+      ["/a.md", "A"],
+    ]);
+  });
+
+  it("reports typed conflicts for stale optimistic writes", async () => {
+    const adapter = new InMemoryNoteVaultAdapter();
+    const file = await adapter.createFile(adapter.rootRef(), "note.md", "first");
+    const firstRead = await adapter.read(file);
+    await adapter.write(file, "second", { revision: firstRead.revision });
+
+    await expect(adapter.write(file, "third", { revision: firstRead.revision })).rejects.toMatchObject({
+      name: "NoteVaultError",
+      code: "conflict",
+      operation: "write",
+    });
+  });
+
+  it("exposes unsupported capabilities as typed errors", async () => {
+    const adapter = new InMemoryNoteVaultAdapter();
+    const file = await adapter.createFile(adapter.rootRef(), "note.md", "");
+
+    expect(adapter.capabilities.trash).toBe(false);
+    await expect(adapter.delete(file, { trash: true })).rejects.toMatchObject({
+      code: "unsupported-operation",
+      operation: "delete",
+    });
+  });
+
+  it("lets hosts capability-gate unsupported watch and rename operations", async () => {
+    const fileRef: NoteVaultFileRef = {
+      providerId: "limited",
+      id: "opaque-file-id",
+      kind: "file",
+    };
+    const adapter: NoteVaultAdapter = {
+      id: "limited",
+      label: "Limited provider",
+      capabilities: {
+        watch: false,
+        renameFile: false,
+        renameFolder: false,
+      },
+      list: async () => [{ name: "note.md", kind: "file", ref: fileRef }],
+      read: async () => ({ ref: fileRef, content: "" }),
+      write: async () => ({ ref: fileRef }),
+      createFile: async () => fileRef,
+      createFolder: async () => {
+        throw createNoteVaultError("unsupported-operation", "Folder creation is unsupported");
+      },
+      rename: async (ref) => {
+        throw createNoteVaultError("unsupported-operation", "Rename is unsupported", {
+          ref,
+          operation: "rename",
+        });
+      },
+      delete: async () => undefined,
+    };
+
+    expect(adapter.capabilities.watch).toBe(false);
+    expect(adapter.watch).toBeUndefined();
+    await expect(adapter.rename(fileRef, "next.md")).rejects.toMatchObject({
+      code: "unsupported-operation",
+      operation: "rename",
+    });
+  });
+
+  it("delivers watch events until unsubscribed", async () => {
+    const adapter = new InMemoryNoteVaultAdapter();
+    const listener = vi.fn();
+    const unsubscribe = adapter.watch(listener);
+
+    await adapter.createFile(adapter.rootRef(), "watched.md", "");
+    unsubscribe();
+    await adapter.createFile(adapter.rootRef(), "quiet.md", "");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ kind: "created" }));
+  });
+
+  it("provides a concrete error guard", () => {
+    const err = createNoteVaultError("offline", "offline");
+
+    expect(err).toBeInstanceOf(NoteVaultError);
+    expect(isNoteVaultError(err)).toBe(true);
+    expect(isNoteVaultError(new Error("x"))).toBe(false);
+  });
+});

--- a/packages/core/test/storage-interface.test.ts
+++ b/packages/core/test/storage-interface.test.ts
@@ -12,6 +12,7 @@ import {
   type NoteVaultFile,
   type NoteVaultFileRef,
   type NoteVaultFolderRef,
+  type NoteVaultListOptions,
   type NoteVaultNode,
   type NoteVaultRef,
 } from "../src/index";
@@ -239,6 +240,72 @@ describe("storage interface", () => {
       ["/Nested/b.md", "B"],
       ["/a.md", "A"],
     ]);
+  });
+
+  it("uses an adapter batch readAll implementation when available", async () => {
+    const adapter = new InMemoryNoteVaultAdapter() as InMemoryNoteVaultAdapter & {
+      readAll: (options?: NoteVaultListOptions) => Promise<NoteVaultFile[]>;
+    };
+    const root = adapter.rootRef();
+    const file = await adapter.createFile(root, "a.md", "A");
+    const list = vi.spyOn(adapter, "list");
+    const read = vi.spyOn(adapter, "read");
+    adapter.readAll = vi.fn(async () => [{ ref: file, content: "batched" }]);
+
+    const files = await readAllNoteVaultFiles(adapter, { root });
+
+    expect(adapter.readAll).toHaveBeenCalledWith({ root, recursive: undefined });
+    expect(list).not.toHaveBeenCalled();
+    expect(read).not.toHaveBeenCalled();
+    expect(files).toEqual([{ ref: file, content: "batched" }]);
+  });
+
+  it("falls back to bounded parallel reads when no batch reader is available", async () => {
+    const files = Array.from({ length: 40 }, (_, index): NoteVaultFileRef => ({
+      providerId: "parallel",
+      id: `/note-${index}.md`,
+      kind: "file",
+    }));
+    let activeReads = 0;
+    let maxActiveReads = 0;
+    const adapter: NoteVaultAdapter = {
+      id: "parallel",
+      label: "Parallel vault",
+      capabilities: {},
+      async list() {
+        return files.map((ref) => ({
+          ref,
+          name: ref.id,
+          kind: "file",
+        }));
+      },
+      async read(ref) {
+        activeReads += 1;
+        maxActiveReads = Math.max(maxActiveReads, activeReads);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        activeReads -= 1;
+        return { ref: ref as NoteVaultFileRef, content: ref.id };
+      },
+      async write(ref) {
+        return { ref: ref as NoteVaultFileRef };
+      },
+      async createFile() {
+        return files[0];
+      },
+      async createFolder() {
+        return { providerId: "parallel", id: "/", kind: "folder" };
+      },
+      async rename(ref) {
+        return ref as AnyNoteVaultRef;
+      },
+      async delete() {},
+    };
+
+    const result = await readAllNoteVaultFiles(adapter);
+
+    expect(result).toHaveLength(files.length);
+    expect(maxActiveReads).toBeGreaterThan(1);
+    expect(maxActiveReads).toBeLessThanOrEqual(32);
   });
 
   it("reports typed conflicts for stale optimistic writes", async () => {


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal for Roadmap #23 cloud storage interface
- Define NoteVault/storage adapter goals, non-goals, design boundary, and validation plan
- Mark Roadmap #23 as in progress with OpenSpec linkage

## Scope
- Proposal/design/spec only
- No runtime implementation in this PR
- No cloud provider SDKs or storage dependencies added

## Changes

| Package | File | Change |
|---|---|---|
| openspec | `changes/add-cloud-storage-interface/proposal.md` | Define goals, non-goals, files, and impact |
| openspec | `changes/add-cloud-storage-interface/design.md` | Document adapter shape, boundaries, risks, and test plan |
| openspec | `changes/add-cloud-storage-interface/specs/storage-interface/spec.md` | Add storage-interface requirements and scenarios |
| openspec | `changes/add-cloud-storage-interface/tasks.md` | Add proposal, future implementation, and verification checklist |
| docs | `ROADMAP.md`, `ROADMAP.zh.md` | Mark Roadmap #23 as `in-progress` |

## Tasks
- [x] Review existing Electron vault IPC surface
- [x] Define proposal goals and non-goals
- [x] Define storage adapter boundary and future interface shape
- [x] Add storage-interface requirements and scenarios
- [x] Add implementation and test task list
- [x] Link Roadmap #23 to the OpenSpec change
- [x] Run OpenSpec strict validation
- [ ] Proposal reviewed
- [ ] Implementation PR opened after approval

## Validation
- [x] openspec validate add-cloud-storage-interface --strict

OpenSpec change: add-cloud-storage-interface
Roadmap: #23 Cloud storage interface