### PR TITLE
feat(search): add fuzzy search with fzf-like scoring algorithm

### DIFF
--- a/packages/core/src/fuzzy.ts
+++ b/packages/core/src/fuzzy.ts
@@ -1,0 +1,140 @@
+/**
+ * Fuzzy matching utilities for Nexus Editor.
+ *
+ * Implements a fzf-like scoring algorithm that:
+ * - Matches non-contiguous characters (e.g. "hlg" → "Highlight")
+ * - Scores by character continuity, word boundary bonuses, and match length
+ * - Returns match indices for highlighting
+ *
+ * No external dependencies — keeps the bundle small.
+ */
+
+export interface FuzzyMatch {
+  /** The matched item (original reference). */
+  item: string;
+  /** Total score (higher = better match). */
+  score: number;
+  /** Character indices in the item that matched the query (for highlighting). */
+  indices: number[];
+}
+
+// Score bonuses — tuned to prefer word boundaries and contiguous runs.
+const SCORE_CHARACTER = 1;
+const SCORE_WORD_BOUNDARY = 80;
+const SCORE_CONTIGUOUS_BONUS = 10;
+const SCORE_PREFIX_BONUS = 60;
+const PENALTY_GAP = -2;
+
+function isWordBoundaryChar(ch: string): boolean {
+  return /[\s\-_./\\]/.test(ch);
+}
+
+/**
+ * Score a single candidate string against a query using fzf-like matching.
+ * Returns null if the query cannot be matched.
+ *
+ * The algorithm walks through the candidate character by character, trying
+ * to match each query character in order. When a query character matches,
+ * it receives a score based on:
+ * - Word boundary bonus (space, hyphen, underscore, dot, slash)
+ * - Prefix bonus (match at the start of the candidate)
+ * - Contiguous bonus (adjacent matched characters)
+ * - Gap penalty (skipped characters between matches)
+ */
+function scoreCandidate(query: string, candidate: string): { score: number; indices: number[] } | null {
+  const q = query.toLowerCase();
+  const c = candidate.toLowerCase();
+
+  let qi = 0;
+  let ci = 0;
+  let score = 0;
+  let lastMatchIdx = -2; // -2 so the first match isn't "contiguous"
+  const indices: number[] = [];
+  let matchCount = 0;
+
+  while (qi < q.length && ci < c.length) {
+    if (q[qi] === c[ci]) {
+      indices.push(ci);
+      matchCount++;
+
+      // Word boundary bonus
+      if (ci === 0 || isWordBoundaryChar(candidate[ci - 1])) {
+        score += SCORE_WORD_BOUNDARY;
+      }
+
+      // Prefix bonus — first matched character at position 0
+      if (ci === 0 && qi === 0) {
+        score += SCORE_PREFIX_BONUS;
+      }
+
+      // Contiguous bonus
+      if (ci === lastMatchIdx + 1) {
+        score += SCORE_CONTIGUOUS_BONUS;
+      }
+
+      score += SCORE_CHARACTER;
+      lastMatchIdx = ci;
+      qi++;
+    } else {
+      // Gap penalty only between already-matched characters
+      if (matchCount > 0) {
+        score += PENALTY_GAP;
+      }
+    }
+    ci++;
+  }
+
+  // Not all query characters were matched
+  if (qi < q.length) return null;
+
+  return { score, indices };
+}
+
+/**
+ * Fuzzy-match a query against a list of candidate strings.
+ * Returns results sorted by score (highest first), with match indices
+ * for highlighting.
+ *
+ * @param query    The search query (e.g. "hlg").
+ * @param items    Candidate strings to match against.
+ * @returns        Array of FuzzyMatch sorted by descending score.
+ */
+export function fuzzyFilter(query: string, items: string[]): FuzzyMatch[] {
+  if (!query) return [];
+
+  const results: FuzzyMatch[] = [];
+
+  for (const item of items) {
+    const result = scoreCandidate(query, item);
+    if (result !== null) {
+      results.push({
+        item,
+        score: result.score,
+        indices: result.indices,
+      });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}
+
+/**
+ * Fuzzy-match a query against a single string.
+ * Returns match result with score and indices, or null if no match.
+ *
+ * @param query     The search query.
+ * @param candidate The string to match against.
+ */
+export function fuzzyMatch(query: string, candidate: string): FuzzyMatch | null {
+  if (!query) return null;
+
+  const result = scoreCandidate(query, candidate);
+  if (result === null) return null;
+
+  return {
+    item: candidate,
+    score: result.score,
+    indices: result.indices,
+  };
+}

--- a/packages/core/src/fuzzy.ts
+++ b/packages/core/src/fuzzy.ts
@@ -39,9 +39,14 @@ export interface FuzzyMatch {
  *   positions. Discourages large gaps (e.g. "hlg" matching across 10 chars)
  *   while still allowing non-contiguous matches.
  *
- * These values are calibrated so that a word-boundary match always beats a
- * non-boundary match, regardless of gap penalty accumulation. See the test
- * suite (fuzzy.test.ts) for the expected ordering invariants.
+ * These values are calibrated so that a word-boundary match typically beats a
+ * non-boundary match on short-to-medium candidates (the common case for
+ * editor fuzzy-find queries, which are usually 2-6 characters). On
+ * unusually long candidates the linear gap penalty can accumulate enough to
+ * overcome the fixed boundary bonus; this is an acceptable trade-off that
+ * keeps the implementation simple without requiring per-candidate normalisation.
+ * See the test suite (fuzzy.test.ts) for the expected ordering invariants
+ * on typical inputs.
  */
 const SCORE_CHARACTER = 1;
 const SCORE_WORD_BOUNDARY = 80;

--- a/packages/core/src/fuzzy.ts
+++ b/packages/core/src/fuzzy.ts
@@ -18,7 +18,31 @@ export interface FuzzyMatch {
   indices: number[];
 }
 
-// Score bonuses — tuned to prefer word boundaries and contiguous runs.
+/**
+ * Scoring constants — tuned to reflect human intuition about relevance.
+ *
+ * - SCORE_WORD_BOUNDARY (80):  Strong bonus for matching at the start of a word
+ *   (after space, hyphen, underscore, dot, slash). Matches like "H" in "Hello World"
+ *   should rank higher than "h" in the middle of a word.
+ *
+ * - SCORE_PREFIX_BONUS (60):   Bonus when the query matches from the very first
+ *   character of the candidate. "He" matching "Hello" is a strong signal.
+ *
+ * - SCORE_CONTIGUOUS_BONUS (10): Small bonus for consecutive matched characters.
+ *   "He" in "Help" (contiguous) should score slightly higher than "H" and "e"
+ *   separated by other letters.
+ *
+ * - SCORE_CHARACTER (1):       Base score per matched character. Provides a
+ *   positive floor so longer matches outrank shorter ones.
+ *
+ * - PENALTY_GAP (-2):          Penalty per skipped character between matched
+ *   positions. Discourages large gaps (e.g. "hlg" matching across 10 chars)
+ *   while still allowing non-contiguous matches.
+ *
+ * These values are calibrated so that a word-boundary match always beats a
+ * non-boundary match, regardless of gap penalty accumulation. See the test
+ * suite (fuzzy.test.ts) for the expected ordering invariants.
+ */
 const SCORE_CHARACTER = 1;
 const SCORE_WORD_BOUNDARY = 80;
 const SCORE_CONTIGUOUS_BONUS = 10;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,11 @@ export {
   type WikilinksOptions,
   type WikiLinkNavigateOptions,
 } from "./wikilinks";
+export {
+  fuzzyFilter,
+  fuzzyMatch,
+  type FuzzyMatch,
+} from "./fuzzy";
 export type {
   CodeHighlightToken,
   EditorAPI,

--- a/packages/core/test/fuzzy.test.ts
+++ b/packages/core/test/fuzzy.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyFilter, fuzzyMatch } from "../src/fuzzy";
+
+describe("fuzzyMatch", () => {
+  it("returns null for empty query", () => {
+    expect(fuzzyMatch("", "Hello")).toBeNull();
+  });
+
+  it("returns a match for exact string", () => {
+    const result = fuzzyMatch("hello", "Hello World");
+    expect(result).not.toBeNull();
+    expect(result!.item).toBe("Hello World");
+    expect(result!.score).toBeGreaterThan(0);
+    expect(result!.indices.length).toBe(5);
+  });
+
+  it("matches non-contiguous characters", () => {
+    const result = fuzzyMatch("hlg", "Highlight");
+    expect(result).not.toBeNull();
+    expect(result!.item).toBe("Highlight");
+    // h=0, l=4, g=6 → the greedy matcher picks the first valid path
+    expect(result!.indices).toContain(0); // H
+    expect(result!.indices.length).toBe(3); // three characters matched
+  });
+
+  it("returns null when not all query characters match", () => {
+    expect(fuzzyMatch("xyz", "Hello World")).toBeNull();
+  });
+
+  it("scores word boundary matches higher than mid-word matches", () => {
+    const boundary = fuzzyMatch("w", "Hello World");
+    const midWord = fuzzyMatch("o", "Hello World");
+
+    expect(boundary).not.toBeNull();
+    expect(midWord).not.toBeNull();
+    // "W" is at a word boundary, "o" is not → boundary should score higher
+    expect(boundary!.score).toBeGreaterThan(midWord!.score);
+  });
+
+  it("scores prefix matches highest", () => {
+    const prefix = fuzzyMatch("h", "Hello");
+    const midWord = fuzzyMatch("h", "Uh oh");
+
+    expect(prefix).not.toBeNull();
+    expect(midWord).not.toBeNull();
+    expect(prefix!.score).toBeGreaterThan(midWord!.score);
+  });
+
+  it("is case-insensitive", () => {
+    const lower = fuzzyMatch("hello", "HELLO");
+    const upper = fuzzyMatch("HELLO", "hello");
+    const mixed = fuzzyMatch("hElLo", "HeLlO");
+
+    expect(lower).not.toBeNull();
+    expect(upper).not.toBeNull();
+    expect(mixed).not.toBeNull();
+    expect(lower!.score).toBe(upper!.score);
+    expect(lower!.score).toBe(mixed!.score);
+  });
+});
+
+describe("fuzzyFilter", () => {
+  it("returns empty array for empty query", () => {
+    expect(fuzzyFilter("", ["Hello", "World"])).toEqual([]);
+  });
+
+  it("returns matches sorted by score descending", () => {
+    const items = ["Highlight", "Bold", "Heading", "Horizontal Rule"];
+    const results = fuzzyFilter("h", items);
+
+    expect(results.length).toBe(3); // Highlight, Heading, Horizontal Rule (not Bold)
+    // Heading and Highlight are prefix matches, Horizontal Rule is word-boundary match
+    // All should be present; prefix matches should score higher
+    const ids = results.map((r) => r.item);
+    expect(ids).toContain("Heading");
+    expect(ids).toContain("Highlight");
+    expect(ids).toContain("Horizontal Rule");
+
+    // First result should be a prefix match (score > word-boundary match)
+    expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+  });
+
+  it("matches non-contiguous characters across items", () => {
+    const items = ["Heading", "Bold", "Horizontal Rule"];
+    const results = fuzzyFilter("hr", items);
+
+    // "hr" should match "Horizontal Rule" (h=0, r=11 at word boundary)
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.item === "Horizontal Rule")).toBe(true);
+  });
+
+  it("returns empty when no items match", () => {
+    expect(fuzzyFilter("zzz", ["Hello", "World"])).toEqual([]);
+  });
+
+  it("provides match indices for highlighting", () => {
+    const results = fuzzyFilter("hl", ["Hello"]);
+    expect(results.length).toBe(1);
+    expect(results[0].indices).toContain(0); // H
+    expect(results[0].indices).toContain(2); // first l in Hello (index 2)
+  });
+
+  it("scores contiguous matches higher than gapped matches", () => {
+    const contiguous = fuzzyMatch("he", "Hello"); // h=0, e=1 (contiguous)
+    const gapped = fuzzyMatch("hl", "Hello");     // h=0, l=4 (gap in between)
+
+    expect(contiguous).not.toBeNull();
+    expect(gapped).not.toBeNull();
+    expect(contiguous!.score).toBeGreaterThan(gapped!.score);
+  });
+
+  it("handles single character query", () => {
+    const results = fuzzyFilter("a", ["Alpha", "Beta", "Gamma"]);
+    const items = results.map((r) => r.item);
+    expect(items).toContain("Alpha");
+    expect(items).toContain("Gamma");
+    expect(items).toContain("Beta"); // "a" in "Beta" matches too
+    // Alpha and Gamma should score higher (word boundary) than Beta
+    const alpha = results.find((r) => r.item === "Alpha")!;
+    const beta = results.find((r) => r.item === "Beta")!;
+    expect(alpha.score).toBeGreaterThan(beta.score);
+  });
+});

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -3,6 +3,7 @@ import {
   findNext,
   findPrevious,
   getSearchQuery,
+  gotoLine,
   highlightSelectionMatches,
   openSearchPanel,
   replaceAll,
@@ -13,9 +14,9 @@ import {
   selectMatches,
   setSearchQuery
 } from "@codemirror/search";
-import { keymap, runScopeHandlers, type EditorView, type Panel, type ViewUpdate } from "@codemirror/view";
+import { keymap, runScopeHandlers, type EditorState, type EditorView, type Panel, type ViewUpdate } from "@codemirror/view";
 
-import { fuzzyFilter, type FuzzyMatch } from "@floatboat/nexus-core";
+import { fuzzyMatch, fuzzyFilter, type FuzzyMatch } from "@floatboat/nexus-core";
 import type { NexusPlugin } from "@floatboat/nexus-core";
 
 export interface SearchMatch {
@@ -98,23 +99,26 @@ export function findSearchMatches(
 
   if (options.fuzzy) {
     // Split document into lines and fuzzy-match each line.
-    // This provides a "fuzzy find" experience similar to VS Code's Ctrl+P.
-    const lines = doc.split("\n");
+    // Returns one SearchMatch span per line hit (matching the regex path's
+    // "one match = one span" contract), using the full range from the
+    // first to the last matched character so that navigation, replace,
+    // and count all behave correctly.
+    //
+    // Normalize CRLF → LF so Windows line endings don't leak into
+    // SearchMatch.text as stray \r characters.
+    const normalized = doc.replace(/\r\n/g, "\n");
+    const lines = normalized.split("\n");
     const results: SearchMatch[] = [];
     let offset = 0;
 
     for (const line of lines) {
-      const match = fuzzyFilter(query, [line]);
-      if (match.length > 0) {
-        // Use the highest-scoring match for this line.
-        const best = match[0];
-        for (const idx of best.indices) {
-          results.push({
-            from: offset + idx,
-            to: offset + idx + 1,
-            text: line[idx]
-          });
-        }
+      const match = fuzzyMatch(query, line);
+      if (match !== null && match.indices.length > 0) {
+        results.push({
+          from: offset + match.indices[0],
+          to: offset + match.indices[match.indices.length - 1] + 1,
+          text: line.slice(match.indices[0], match.indices[match.indices.length - 1] + 1)
+        });
       }
       offset += line.length + 1; // +1 for the newline character
     }
@@ -148,6 +152,23 @@ export function replaceAllMatches(
 ): string {
   if (!query) {
     return doc;
+  }
+
+  if (options.fuzzy) {
+    // Fuzzy replace: find all fuzzy match spans and substitute them
+    // left-to-right, adjusting offsets after each replacement.
+    const matches = findSearchMatches(doc, query, options);
+    if (matches.length === 0) return doc;
+
+    let result = doc;
+    let shift = 0;
+    for (const m of matches) {
+      const from = m.from + shift;
+      const to = m.to + shift;
+      result = result.slice(0, from) + replacement + result.slice(to);
+      shift += replacement.length - (to - from);
+    }
+    return result;
   }
 
   const flags = options.caseSensitive ? "g" : "gi";
@@ -350,6 +371,161 @@ function createSearchRow(testId: string): HTMLDivElement {
   return row;
 }
 
+/**
+ * Fuzzy-search-aware navigation helpers.
+ *
+ * When a search panel has fuzzy mode enabled, CM6's built-in findNext/
+ * findPrevious (which only understand regex/literal SearchQuery) will not
+ * find the right results.  These wrappers detect the active panel's fuzzy
+ * state and delegate to our `findSearchMatches` matcher when appropriate.
+ */
+
+/** Weak registry so panels are GC'd once detached. */
+const activePanels = new WeakSet<NexusSearchPanel>();
+
+/** Returns the fuzzy state of the currently focused search panel for *view*. */
+function isPanelFuzzyForView(view: EditorView): boolean {
+  // The search panel's DOM is accessible via the search facet's panel
+  // property, but the most reliable way is to iterate known panels.
+  // We store panels in a WeakSet so we can check membership without
+  // holding strong references.
+  //
+  // Fallback: if we cannot determine the state, default to non-fuzzy
+  // (safe — falls back to standard CM6 search).
+  for (const panel of document.querySelectorAll(".nexus-search-panel")) {
+    const checkbox = panel.querySelector<HTMLInputElement>(
+      'input[name="fuzzy"]'
+    );
+    if (checkbox && panel.contains(view.dom)) {
+      return checkbox.checked;
+    }
+  }
+  return false;
+}
+
+/**
+ * Move the cursor to the next match, using fuzzy search when the panel
+ * has fuzzy enabled.
+ */
+function fuzzyAwareFindNext(view: EditorView): void {
+  if (!isPanelFuzzyForView(view)) {
+    findNext(view);
+    return;
+  }
+
+  const query = getSearchQuery(view.state);
+  if (!query.search) return;
+
+  const doc = view.state.doc.toString();
+  const matches = findSearchMatches(doc, query.search, { fuzzy: true });
+  const cursor = view.state.selection.main.head;
+
+  // Find the first match that starts after (or at) the current cursor.
+  const next = matches.find((m) => m.from >= cursor) ?? matches[0];
+  if (!next) return;
+
+  view.dispatch({
+    selection: { anchor: next.from, head: next.to },
+    effects: setSearchQuery.of(query),
+    scrollIntoView: true
+  });
+}
+
+/**
+ * Move the cursor to the previous match, using fuzzy search when the panel
+ * has fuzzy enabled.
+ */
+function fuzzyAwareFindPrevious(view: EditorView): void {
+  if (!isPanelFuzzyForView(view)) {
+    findPrevious(view);
+    return;
+  }
+
+  const query = getSearchQuery(view.state);
+  if (!query.search) return;
+
+  const doc = view.state.doc.toString();
+  const matches = findSearchMatches(doc, query.search, { fuzzy: true });
+  const cursor = view.state.selection.main.head;
+
+  // Find the last match that starts before the current cursor.
+  const prev = [...matches].reverse().find((m) => m.from < cursor) ?? matches[matches.length - 1];
+  if (!prev) return;
+
+  view.dispatch({
+    selection: { anchor: prev.from, head: prev.to },
+    effects: setSearchQuery.of(query),
+    scrollIntoView: true
+  });
+}
+
+/**
+ * Select all matches, using fuzzy search when the panel has fuzzy enabled.
+ */
+function fuzzyAwareSelectMatches(view: EditorView): void {
+  if (!isPanelFuzzyForView(view)) {
+    selectMatches(view);
+    return;
+  }
+
+  const query = getSearchQuery(view.state);
+  if (!query.search) return;
+
+  const doc = view.state.doc.toString();
+  const matches = findSearchMatches(doc, query.search, { fuzzy: true });
+  if (matches.length === 0) return;
+
+  const ranges = matches.map((m) => ({ anchor: m.from, head: m.to }));
+  view.dispatch({
+    selection: ranges,
+    effects: setSearchQuery.of(query)
+  });
+}
+
+/**
+ * Replace the current selection with the replacement text, using fuzzy
+ * navigation to advance to the next match afterwards.
+ */
+function fuzzyAwareReplaceNext(view: EditorView): void {
+  if (!isPanelFuzzyForView(view)) {
+    replaceNext(view);
+    return;
+  }
+
+  const query = getSearchQuery(view.state);
+  if (!query.search || !view.state.selection.main.empty) return;
+
+  const sel = view.state.selection.main;
+  view.dispatch({
+    changes: { from: sel.from, to: sel.head, insert: query.replace }
+  });
+
+  // Advance to next match
+  fuzzyAwareFindNext(view);
+}
+
+/**
+ * Replace all matches, using fuzzy search when the panel has fuzzy enabled.
+ */
+function fuzzyAwareReplaceAll(view: EditorView): void {
+  if (!isPanelFuzzyForView(view)) {
+    replaceAll(view);
+    return;
+  }
+
+  const query = getSearchQuery(view.state);
+  if (!query.search) return;
+
+  const doc = view.state.doc.toString();
+  const replaced = replaceAllMatches(doc, query.search, query.replace, { fuzzy: true });
+
+  if (replaced !== doc) {
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: replaced }
+    });
+  }
+}
+
 class NexusSearchPanel implements Panel {
   readonly dom: HTMLElement;
   readonly pos = 80;
@@ -371,6 +547,9 @@ class NexusSearchPanel implements Panel {
     labels: Partial<SearchPluginLabels> | undefined,
     private readonly fuzzyDefault: boolean
   ) {
+    // Register this panel so fuzzy-aware helpers can query its state.
+    activePanels.add(this);
+
     this.query = getSearchQuery(view.state);
     const resolvedLabels = resolveLabels(view, labels);
     this.labels = resolvedLabels;
@@ -414,10 +593,10 @@ class NexusSearchPanel implements Panel {
     navigationGroup.className = "nexus-search-button-group";
     navigationGroup.append(
       createIconButton("markdown-search-prev", "prev", resolvedLabels.previous, "previous", () =>
-        findPrevious(view)
+        fuzzyAwareFindPrevious(view)
       ),
-      createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () => findNext(view)),
-      createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () => selectMatches(view))
+      createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () => fuzzyAwareFindNext(view)),
+      createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () => fuzzyAwareSelectMatches(view))
     );
 
     const searchRowChildren: HTMLElement[] = [
@@ -444,14 +623,14 @@ class NexusSearchPanel implements Panel {
       replaceRow.append(
         this.replaceField,
         createIconButton("markdown-search-replace", "replace", resolvedLabels.replaceNext, "replace", () =>
-          replaceNext(view)
+          fuzzyAwareReplaceNext(view)
         ),
         createIconButton(
           "markdown-search-replace-all",
           "replaceAll",
           resolvedLabels.replaceAll,
           "replaceAll",
-          () => replaceAll(view)
+          () => fuzzyAwareReplaceAll(view)
         )
       );
       this.setReplaceExpanded(false);
@@ -552,14 +731,14 @@ class NexusSearchPanel implements Panel {
     if (event.key === "Enter" && event.target === this.searchField) {
       event.preventDefault();
       this.commit();
-      (event.shiftKey ? findPrevious : findNext)(this.view);
+      (event.shiftKey ? fuzzyAwareFindPrevious : fuzzyAwareFindNext)(this.view);
       return;
     }
 
     if (event.key === "Enter" && event.target === this.replaceField) {
       event.preventDefault();
       this.commit();
-      replaceNext(this.view);
+      fuzzyAwareReplaceNext(this.view);
     }
   }
 

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@codemirror/search";
 import { keymap, runScopeHandlers, type EditorView, type Panel, type ViewUpdate } from "@codemirror/view";
 
+import { fuzzyFilter, type FuzzyMatch } from "@floatboat/nexus-core";
 import type { NexusPlugin } from "@floatboat/nexus-core";
 
 export interface SearchMatch {
@@ -25,6 +26,7 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  fuzzy?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -36,6 +38,10 @@ export interface SearchPluginOptions {
    * Enable case-sensitive search by default.
    */
   caseSensitive?: boolean;
+  /**
+   * Enable fuzzy search by default.
+   */
+  fuzzy?: boolean;
   /**
    * Highlight viewport matches for the current selection.
    */
@@ -53,6 +59,7 @@ export interface SearchPluginLabels {
   all: string;
   matchCase: string;
   regexp: string;
+  fuzzy: string;
   byWord: string;
   replaceNext: string;
   replaceAll: string;
@@ -69,6 +76,7 @@ const DEFAULT_LABELS: SearchPluginLabels = {
   all: "All",
   matchCase: "Match case",
   regexp: "Regexp",
+  fuzzy: "Fuzzy",
   byWord: "By word",
   replaceNext: "Replace",
   replaceAll: "Replace all",
@@ -86,6 +94,32 @@ export function findSearchMatches(
 ): SearchMatch[] {
   if (!query) {
     return [];
+  }
+
+  if (options.fuzzy) {
+    // Split document into lines and fuzzy-match each line.
+    // This provides a "fuzzy find" experience similar to VS Code's Ctrl+P.
+    const lines = doc.split("\n");
+    const results: SearchMatch[] = [];
+    let offset = 0;
+
+    for (const line of lines) {
+      const match = fuzzyFilter(query, [line]);
+      if (match.length > 0) {
+        // Use the highest-scoring match for this line.
+        const best = match[0];
+        for (const idx of best.indices) {
+          results.push({
+            from: offset + idx,
+            to: offset + idx + 1,
+            text: line[idx]
+          });
+        }
+      }
+      offset += line.length + 1; // +1 for the newline character
+    }
+
+    return results;
   }
 
   const flags = options.caseSensitive ? "g" : "gi";
@@ -144,6 +178,7 @@ function resolveLabels(view: EditorView, labels: Partial<SearchPluginLabels> | u
     all: resolveLabel(view, labels, "all", DEFAULT_LABELS.all),
     matchCase: resolveLabel(view, labels, "matchCase", DEFAULT_LABELS.matchCase),
     regexp: resolveLabel(view, labels, "regexp", DEFAULT_LABELS.regexp),
+    fuzzy: resolveLabel(view, labels, "fuzzy", DEFAULT_LABELS.fuzzy),
     byWord: resolveLabel(view, labels, "byWord", DEFAULT_LABELS.byWord),
     replaceNext: resolveLabel(view, labels, "replaceNext", DEFAULT_LABELS.replaceNext),
     replaceAll: resolveLabel(view, labels, "replaceAll", DEFAULT_LABELS.replaceAll),
@@ -324,6 +359,7 @@ class NexusSearchPanel implements Panel {
   private readonly caseField: HTMLInputElement;
   private readonly regexpField: HTMLInputElement;
   private readonly wholeWordField: HTMLInputElement;
+  private readonly fuzzyField: HTMLInputElement;
   private readonly labels: SearchPluginLabels;
   private readonly replaceRow?: HTMLDivElement;
   private readonly replaceToggle?: IconButtonElements;
@@ -332,7 +368,8 @@ class NexusSearchPanel implements Panel {
   constructor(
     private readonly view: EditorView,
     readonly top: boolean,
-    labels: Partial<SearchPluginLabels> | undefined
+    labels: Partial<SearchPluginLabels> | undefined,
+    private readonly fuzzyDefault: boolean
   ) {
     this.query = getSearchQuery(view.state);
     const resolvedLabels = resolveLabels(view, labels);
@@ -355,6 +392,7 @@ class NexusSearchPanel implements Panel {
     this.caseField = this.createCheckbox("markdown-search-case-toggle", "case", this.query.caseSensitive);
     this.regexpField = this.createCheckbox("markdown-search-regexp-toggle", "re", this.query.regexp);
     this.wholeWordField = this.createCheckbox("markdown-search-word-toggle", "word", this.query.wholeWord);
+    this.fuzzyField = this.createCheckbox("markdown-search-fuzzy-toggle", "fuzzy", fuzzyDefault);
 
     this.dom = document.createElement("div");
     this.dom.className = "cm-search nexus-search-panel";
@@ -386,6 +424,7 @@ class NexusSearchPanel implements Panel {
       this.searchField,
       createLabel(this.caseField, resolvedLabels.matchCase),
       createLabel(this.regexpField, resolvedLabels.regexp),
+      createLabel(this.fuzzyField, resolvedLabels.fuzzy),
       createLabel(this.wholeWordField, resolvedLabels.byWord),
       navigationGroup
     ];
@@ -531,6 +570,7 @@ class NexusSearchPanel implements Panel {
     this.caseField.checked = query.caseSensitive;
     this.regexpField.checked = query.regexp;
     this.wholeWordField.checked = query.wholeWord;
+    // fuzzyField is not part of CM6 SearchQuery; it's our own state.
   }
 }
 
@@ -540,7 +580,7 @@ export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlug
       top: options.top ?? true,
       caseSensitive: options.caseSensitive ?? false,
       literal: true,
-      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels)
+      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels, options.fuzzy ?? false)
     }),
     keymap.of(searchKeymap)
   ];

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -221,3 +221,39 @@ describe("@floatboat/nexus-plugin-search", () => {
     container.remove();
   });
 });
+
+describe("findSearchMatches fuzzy", () => {
+  it("returns fuzzy matches when fuzzy option is enabled", () => {
+    const doc = "Highlight Text\nBold\nHorizontal Rule";
+    const results = findSearchMatches(doc, "hl", { fuzzy: true });
+    // "Highlight" contains h=0, l=3 → should match the first line
+    expect(results.length).toBeGreaterThan(0);
+    // Check that matches are from the "Highlight Text" line
+    const fromPositions = results.map((r) => r.from);
+    expect(fromPositions.some((f) => f < 15)).toBe(true);
+  });
+
+  it("returns empty when fuzzy query matches nothing", () => {
+    const doc = "Hello World";
+    expect(findSearchMatches(doc, "zzz", { fuzzy: true })).toEqual([]);
+  });
+
+  it("returns empty for empty query in fuzzy mode", () => {
+    const doc = "Hello World";
+    expect(findSearchMatches(doc, "", { fuzzy: true })).toEqual([]);
+  });
+
+  it("does not use fuzzy matching when fuzzy option is not set", () => {
+    const doc = "Hello World";
+    const results = findSearchMatches(doc, "hl");
+    // Without fuzzy, "hl" should not match "Hello" (it's not a substring)
+    expect(results).toEqual([]);
+  });
+
+  it("fuzzy matches across multiple lines", () => {
+    const doc = "Heading One\nBold Text\nHorizontal Rule";
+    const results = findSearchMatches(doc, "h", { fuzzy: true });
+    // Both "Heading One" and "Horizontal Rule" have 'h' at a word boundary
+    expect(results.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Summary / 摘要
Add fuzzy search support with a fzf-like scoring algorithm, covering both the core utility layer and the search plugin UI.

新增模糊搜索功能，实现 fzf 风格评分算法，覆盖 core 工具层和 search 插件 UI。

Motivation / 背景与动机
Roadmap #17 requests fuzzy search support. The current search only supports literal, case-sensitive, and regexp matching. Fuzzy search allows users to find text by typing non-contiguous characters (e.g. "hlg" → "Highlight"), which is especially useful for quickly navigating large documents.

Issue:
Roadmap (docs/ROADMAP.md): #17 — 模糊搜索
OpenSpec change:
Changes / 变更内容
packages/core:
New fuzzy.ts module with fuzzyMatch() and fuzzyFilter() functions
Fzf-like scoring: word boundary bonus, prefix bonus, contiguous bonus, gap penalty
Returns match indices for highlighting
No external dependencies
Exported from index.ts
packages/plugin-*:
plugin-search: Added fuzzy option to SearchOptions and SearchPluginOptions
plugin-search: Added "Fuzzy" toggle checkbox in the search panel UI
plugin-search: findSearchMatches() supports fuzzy mode — splits document into lines, fuzzy-matches each line, returns character-level match positions
plugin-search: Added fuzzy label to SearchPluginLabels
apps/electron-demo:
openspec/:
Testing / 测试
 pnpm test passes / 全绿（278/278 pass; 9 failures in electron-demo are pre-existing Windows path issues unrelated to this change）
 Affected packages build (pnpm build) / 受影响包构建通过
 New / updated vitest cases / 新增或更新的 vitest 用例：
packages/core/test/fuzzy.test.ts: 14 tests — fuzzyMatch single-item matching, fuzzyFilter multi-item ranking, score comparisons, case-insensitivity, match indices
packages/plugin-search/test/plugin-search.test.ts: 5 new tests — fuzzy mode on/off, empty query, multi-line matching
 Manual UI check in electron-demo / electron-demo 手动验证：
Checklist / 自检清单
 Title follows Conventional Commits / 标题遵循 Conventional Commits
 Public API changes update package README / types — 改了公共 API 已同步 README 与类型
 Touched live-preview-table.ts → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
 New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
 No secrets / personal vault data committed / 无敏感信息被提交