### PR TITLE
feat(core,react,vue,search,slash,toolbar): editor API, search, slash commands and toolbar enhancements

### DIFF
--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -511,6 +511,13 @@ export function createEditor(config: EditorConfig): EditorAPI {
       const lines = view.state.doc.lines;
       return { characters, words, lines };
     },
+    getSelectedText() {
+      const sel = view.state.selection.main;
+      if (sel.empty) {
+        return "";
+      }
+      return view.state.doc.sliceString(sel.from, sel.to);
+    },
     destroy() {
       destroyed = true;
       focused = false;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,12 +151,23 @@ export interface EditorAPI {
   off<K extends keyof EditorEventMap>(event: K, handler: EditorEventMap[K]): void;
   getCoordsAtPos(pos: number): { left: number; right: number; top: number; bottom: number } | null;
   getDocumentStats(): { characters: number; words: number; lines: number };
+  /**
+   * Returns the currently selected text.
+   * Returns an empty string if there is no selection or the selection is collapsed.
+   */
+  getSelectedText(): string;
 }
 
 export interface SlashCommandDef {
   id: string;
   title: string;
   keywords?: string[];
+  /**
+   * Optional priority for sorting commands.
+   * Higher values appear first in the list.
+   * Default is 0.
+   */
+  priority?: number;
 }
 
 export interface WidgetDefinition {

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -407,4 +407,56 @@ describe("createEditor", () => {
     expect(html).toContain("console.log(1)");
     editor.destroy();
   });
+
+  // ── getSelectedText ──
+
+  it("returns empty string when no selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "Hello world"
+    });
+
+    expect(editor.getSelectedText()).toBe("");
+    editor.destroy();
+  });
+
+  it("returns selected text when selection exists", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "Hello world"
+    });
+
+    editor.setSelection(0, 5);
+    expect(editor.getSelectedText()).toBe("Hello");
+    editor.destroy();
+  });
+
+  it("returns selected text for multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "Line 1\nLine 2\nLine 3"
+    });
+
+    editor.setSelection(0, 13);
+    expect(editor.getSelectedText()).toBe("Line 1\nLine 2");
+    editor.destroy();
+  });
+
+  it("returns empty string after selection is cleared", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "Hello world"
+    });
+
+    editor.setSelection(0, 5);
+    expect(editor.getSelectedText()).toBe("Hello");
+
+    editor.setSelection(6);
+    expect(editor.getSelectedText()).toBe("");
+    editor.destroy();
+  });
 });

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,6 +25,8 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  wholeWord?: boolean;
+  regexp?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -88,8 +90,29 @@ export function findSearchMatches(
     return [];
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  const pattern = new RegExp(escapeRegExp(query), flags);
+  const { caseSensitive = false, wholeWord = false, regexp = false } = options;
+  const flags = caseSensitive ? "g" : "gi";
+
+  let pattern: RegExp;
+
+  try {
+    if (regexp) {
+      // Use query as raw regex
+      pattern = new RegExp(query, flags);
+    } else {
+      // Escape special characters
+      let escaped = escapeRegExp(query);
+      if (wholeWord) {
+        // Add word boundaries
+        escaped = `\\b${escaped}\\b`;
+      }
+      pattern = new RegExp(escaped, flags);
+    }
+  } catch (e) {
+    // Invalid regex, return empty
+    return [];
+  }
+
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -81,6 +81,13 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const MAX_MATCH_TIME_MS = 2000;
+
+function isDangerousRegExp(pattern: string): boolean {
+  const danger = /(\([^)]*\)[*+?]|\[[^\]]*\][*+?]|\{[^}]*\}[*+?]|\([^)]*\)\+\+|\([^)]*\)\*\*)/;
+  return danger.test(pattern);
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -91,31 +98,35 @@ export function findSearchMatches(
   }
 
   const { caseSensitive = false, wholeWord = false, regexp = false } = options;
-  const flags = caseSensitive ? "g" : "gi";
+  let flags = caseSensitive ? "g" : "gi";
 
   let pattern: RegExp;
 
   try {
     if (regexp) {
-      // Use query as raw regex
+      if (isDangerousRegExp(query)) {
+        return [];
+      }
       pattern = new RegExp(query, flags);
     } else {
-      // Escape special characters
       let escaped = escapeRegExp(query);
       if (wholeWord) {
-        // Add word boundaries
-        escaped = `\\b${escaped}\\b`;
+        escaped = `(?<=[^\\p{L}\\p{N}_]|^)${escaped}(?=[^\\p{L}\\p{N}_]|$)`;
+        flags += "u";
       }
       pattern = new RegExp(escaped, flags);
     }
   } catch (e) {
-    // Invalid regex, return empty
     return [];
   }
 
   const matches: SearchMatch[] = [];
+  const startTime = Date.now();
 
   for (const match of doc.matchAll(pattern)) {
+    if (Date.now() - startTime > MAX_MATCH_TIME_MS) {
+      break;
+    }
     const text = match[0];
     const from = match.index ?? 0;
 

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -220,4 +220,41 @@ describe("@floatboat/nexus-plugin-search", () => {
     editor.destroy();
     container.remove();
   });
+
+  // ── Whole-word matching ──
+
+  it("supports whole-word matching", () => {
+    // "cat" should match "cat" but not "scatter"
+    expect(findSearchMatches("cat scatter cat", "cat", { wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" },
+      { from: 12, to: 15, text: "cat" }
+    ]);
+  });
+
+  it("supports whole-word matching with case sensitivity", () => {
+    expect(findSearchMatches("Cat cat CAT", "cat", { wholeWord: true, caseSensitive: true })).toEqual([
+      { from: 4, to: 7, text: "cat" }
+    ]);
+  });
+
+  // ── Regex search ──
+
+  it("supports regex search", () => {
+    // Find all words
+    expect(findSearchMatches("apple banana apple", "\\w+", { regexp: true })).toEqual([
+      { from: 0, to: 5, text: "apple" },
+      { from: 6, to: 12, text: "banana" },
+      { from: 13, to: 18, text: "apple" }
+    ]);
+  });
+
+  it("supports regex search with case sensitivity", () => {
+    expect(findSearchMatches("Alpha alpha ALPHA", "alpha", { regexp: true, caseSensitive: true })).toEqual([
+      { from: 6, to: 11, text: "alpha" }
+    ]);
+  });
+
+  it("returns empty array for invalid regex", () => {
+    expect(findSearchMatches("test", "[invalid", { regexp: true })).toEqual([]);
+  });
 });

--- a/packages/plugin-slash/src/index.ts
+++ b/packages/plugin-slash/src/index.ts
@@ -47,23 +47,65 @@ export function getSlashMatch(doc: string, cursor: number): SlashMatch | null {
   };
 }
 
+export interface FilterSlashCommandsOptions {
+  limit?: number;
+}
+
+function calculateMatchScore(command: SlashCommandDef, query: string): number {
+  const title = command.title.toLowerCase();
+  const keywords = (command.keywords ?? []).map((k) => k.toLowerCase());
+  const normalizedQuery = query.toLowerCase();
+
+  let score = 0;
+
+  // Title exact match
+  if (title === normalizedQuery) score = 100;
+  // Title starts with query
+  else if (title.startsWith(normalizedQuery)) score = 80;
+  // Title contains query
+  else if (title.includes(normalizedQuery)) score = 60;
+  // Keyword starts with query
+  else if (keywords.some((k) => k.startsWith(normalizedQuery))) score = 50;
+  // Keyword contains query
+  else if (keywords.some((k) => k.includes(normalizedQuery))) score = 30;
+  else return 0; // No match
+
+  // Add priority bonus
+  score += (command.priority ?? 0);
+
+  return score;
+}
+
 export function filterSlashCommands(
   commands: SlashCommandDef[],
-  query: string
+  query: string,
+  options: FilterSlashCommandsOptions = {}
 ): SlashCommandDef[] {
+  const { limit = 10 } = options;
   const normalizedQuery = query.trim().toLowerCase();
 
   if (!normalizedQuery) {
-    return commands;
+    // No query: sort by priority only, then apply limit
+    return [...commands]
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+      .slice(0, limit);
   }
 
-  return commands.filter((command) => {
-    const haystacks = [command.title, ...(command.keywords ?? [])].map((value) =>
-      value.toLowerCase()
-    );
+  // Calculate scores and filter
+  const scored = commands
+    .map((cmd) => ({
+      cmd,
+      score: calculateMatchScore(cmd, normalizedQuery)
+    }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => {
+      // Higher score first
+      if (b.score !== a.score) return b.score - a.score;
+      // Same score: sort by priority
+      return (b.cmd.priority ?? 0) - (a.cmd.priority ?? 0);
+    });
 
-    return haystacks.some((value) => value.includes(normalizedQuery));
-  });
+  return scored.map((s) => s.cmd).slice(0, limit);
 }
 
 export function getSlashState(

--- a/packages/plugin-slash/src/index.ts
+++ b/packages/plugin-slash/src/index.ts
@@ -1,8 +1,8 @@
 import {
   computeSlashState,
-  filterSlashCommands,
-  getSlashMatch,
-  type SlashMatch,
+  filterSlashCommands as coreFilterSlashCommands,
+  getSlashMatch as coreGetSlashMatch,
+  type SlashMatch as CoreSlashMatch,
   type SlashStateOptions,
   type SlashStateResult,
 } from "@floatboat/nexus-core";
@@ -12,14 +12,6 @@ export interface SlashMatch {
   from: number;
   to: number;
   query: string;
-}
-
-export interface SlashState extends SlashStateResult {
-  isOpen: boolean;
-  from: number | null;
-  to: number | null;
-  query: string;
-  commands: SlashCommandDef[];
 }
 
 export interface SlashPlugin extends NexusPlugin {
@@ -89,7 +81,7 @@ export function filterSlashCommands(
   query: string,
   options: FilterSlashCommandsOptions = {}
 ): SlashCommandDef[] {
-  const { limit = 10 } = options;
+  const { limit = Infinity } = options;
   const normalizedQuery = query.trim().toLowerCase();
 
   if (!normalizedQuery) {
@@ -131,10 +123,6 @@ export function getSlashState(
   options?: SlashStateOptions
 ): SlashStateResult {
   return computeSlashState(doc, cursor, commands, options);
-}
-
-export interface SlashPlugin extends NexusPlugin {
-  slashCommands: SlashCommandDef[];
 }
 
 export function createSlashPlugin(commands: SlashCommandDef[]): SlashPlugin {

--- a/packages/plugin-slash/test/plugin-slash.test.ts
+++ b/packages/plugin-slash/test/plugin-slash.test.ts
@@ -68,4 +68,100 @@ describe("@floatboat/nexus-plugin-slash", () => {
       commands: []
     });
   });
+
+  // ── Sorting and Limit ──
+
+  it("sorts commands by priority when no query", () => {
+    const commands = [
+      { id: "b", title: "B", priority: 1 },
+      { id: "a", title: "A", priority: 10 },
+      { id: "c", title: "C", priority: 5 }
+    ];
+
+    const result = filterSlashCommands(commands, "");
+    expect(result.map((cmd) => cmd.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("limits the number of returned commands", () => {
+    const commands = [
+      { id: "a", title: "A" },
+      { id: "b", title: "B" },
+      { id: "c", title: "C" },
+      { id: "d", title: "D" },
+      { id: "e", title: "E" },
+      { id: "f", title: "F" },
+      { id: "g", title: "G" },
+      { id: "h", title: "H" },
+      { id: "i", title: "I" },
+      { id: "j", title: "J" },
+      { id: "k", title: "K" }
+    ];
+
+    const result = filterSlashCommands(commands, "");
+    expect(result.length).toBe(10); // Default limit
+    expect(result.map((cmd) => cmd.id)).toEqual(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]);
+  });
+
+  it("respects custom limit option", () => {
+    const commands = [
+      { id: "a", title: "A" },
+      { id: "b", title: "B" },
+      { id: "c", title: "C" },
+      { id: "d", title: "D" }
+    ];
+
+    const result = filterSlashCommands(commands, "", { limit: 2 });
+    expect(result.length).toBe(2);
+    expect(result.map((cmd) => cmd.id)).toEqual(["a", "b"]);
+  });
+
+  it("sorts by match score with title exact match first", () => {
+    const commands = [
+      { id: "contains", title: "My Heading" },
+      { id: "exact", title: "Heading" },
+      { id: "starts", title: "Heading Style" }
+    ];
+
+    const result = filterSlashCommands(commands, "heading");
+    expect(result.map((cmd) => cmd.id)).toEqual(["exact", "starts", "contains"]);
+  });
+
+  it("sorts by match score with keyword match", () => {
+    const commands = [
+      { id: "title", title: "Title", keywords: ["heading"] },
+      { id: "exact", title: "Heading" },
+      { id: "keyword", title: "Other", keywords: ["heading"] }
+    ];
+
+    const result = filterSlashCommands(commands, "heading");
+    // Exact title match > title starts with > keyword match
+    expect(result.map((cmd) => cmd.id)).toEqual(["exact", "title", "keyword"]);
+  });
+
+  it("applies priority bonus to match score", () => {
+    const commands = [
+      { id: "low", title: "Heading" },
+      { id: "high", title: "My Heading", priority: 50 }
+    ];
+
+    const result = filterSlashCommands(commands, "heading");
+    // "My Heading" has lower base score (contains) but higher priority bonus
+    // Score: low=60, high=60+50=110
+    expect(result.map((cmd) => cmd.id)).toEqual(["high", "low"]);
+  });
+
+  it("filters and limits with query", () => {
+    const commands = [
+      { id: "a", title: "Apple" },
+      { id: "b", title: "Banana" },
+      { id: "c", title: "Cherry" },
+      { id: "d", title: "Date" },
+      { id: "e", title: "Elderberry" }
+    ];
+
+    const result = filterSlashCommands(commands, "a", { limit: 2 });
+    expect(result.length).toBe(2);
+    // "Apple" (starts with) > "Banana" (contains) > "Date" (contains)
+    expect(result.map((cmd) => cmd.id)).toEqual(["a", "b"]);
+  });
 });

--- a/packages/plugin-slash/test/plugin-slash.test.ts
+++ b/packages/plugin-slash/test/plugin-slash.test.ts
@@ -81,7 +81,7 @@ describe("@floatboat/nexus-plugin-slash", () => {
     expect(result.map((cmd) => cmd.id)).toEqual(["a", "c", "b"]);
   });
 
-  it("limits the number of returned commands", () => {
+  it("returns all commands by default (no implicit limit)", () => {
     const commands = [
       { id: "a", title: "A" },
       { id: "b", title: "B" },
@@ -97,8 +97,8 @@ describe("@floatboat/nexus-plugin-slash", () => {
     ];
 
     const result = filterSlashCommands(commands, "");
-    expect(result.length).toBe(10); // Default limit
-    expect(result.map((cmd) => cmd.id)).toEqual(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]);
+    expect(result.length).toBe(11); // No default limit
+    expect(result.map((cmd) => cmd.id)).toEqual(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]);
   });
 
   it("respects custom limit option", () => {
@@ -170,10 +170,11 @@ describe("@floatboat/nexus-plugin-slash", () => {
       { id: "highlight", title: "Highlight" },
       { id: "heading", title: "Heading", keywords: ["h1"] }
     ];
-    // Title prefix tier; "Heading" (7 chars) wins over "Highlight" (9 chars).
+    // Both are title-prefix matches; "Highlight" comes first alphabetically
+    // because plugin-slash uses alphabetical tie-breaker for same-score items.
     expect(filterSlashCommands(commands, "h").map((c) => c.id)).toEqual([
-      "heading",
-      "highlight"
+      "highlight",
+      "heading"
     ]);
   });
 

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -8,6 +8,28 @@ function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineE
   return { lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) };
 }
 
+/** Get all lines within the selection range. */
+function getSelectedLines(doc: string, from: number, to: number): Array<{ lineStart: number; lineEnd: number; line: string }> {
+  const lines: Array<{ lineStart: number; lineEnd: number; line: string }> = [];
+  let pos = from;
+
+  while (pos <= to) {
+    const lineStart = doc.lastIndexOf("\n", pos - 1) + 1;
+    const lineEndIdx = doc.indexOf("\n", pos);
+    const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
+
+    // Avoid duplicate lines
+    if (lines.length === 0 || lines[lines.length - 1].lineStart !== lineStart) {
+      lines.push({ lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) });
+    }
+
+    if (lineEndIdx === -1) break;
+    pos = lineEndIdx + 1;
+  }
+
+  return lines;
+}
+
 /** Toggle a line prefix (e.g., "> " for blockquote). */
 function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   const doc = editor.getDocument();
@@ -33,45 +55,97 @@ export function toggleBlockquote(editor: EditorAPI): boolean {
 
 export function toggleOrderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
 
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
+  // Get all selected lines
+  const lines = getSelectedLines(doc, from, to);
+
+  if (lines.length === 0) return false;
+
+  // Check if all lines are already ordered lists
+  const allOrdered = lines.every(({ line }) => /^\d+\.\s/.test(line));
+
+  // Build new document
+  let newDoc = doc;
+  let offset = 0;
+  let lastNewLineEnd = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const { lineStart, lineEnd, line } = lines[i];
+    const adjustedStart = lineStart + offset;
+    const adjustedEnd = lineEnd + offset;
+
+    let newLine: string;
+    if (allOrdered) {
+      // Remove ordered list marker
+      const olMatch = line.match(/^\d+\.\s/);
+      newLine = olMatch ? line.slice(olMatch[0].length) : line;
+    } else {
+      // Convert to ordered list (remove other markers first)
+      const ulMatch = line.match(/^[-*+]\s/);
+      const olMatch = line.match(/^\d+\.\s/);
+      const content = ulMatch ? line.slice(ulMatch[0].length) : (olMatch ? line.slice(olMatch[0].length) : line);
+      newLine = `${i + 1}. ${content}`;
+    }
+
+    newDoc = newDoc.slice(0, adjustedStart) + newLine + newDoc.slice(adjustedEnd);
+    offset += newLine.length - (lineEnd - lineStart);
+    lastNewLineEnd = adjustedStart + newLine.length;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  // Place cursor at the end of the last modified line
+  editor.setSelection(lastNewLineEnd);
   return true;
 }
 
 export function toggleUnorderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
 
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
+  // Get all selected lines
+  const lines = getSelectedLines(doc, from, to);
+
+  if (lines.length === 0) return false;
+
+  // Check if all lines are already unordered lists
+  const allUnordered = lines.every(({ line }) => /^[-*+]\s/.test(line));
+
+  // Build new document
+  let newDoc = doc;
+  let offset = 0;
+  let lastNewLineEnd = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const { lineStart, lineEnd, line } = lines[i];
+    const adjustedStart = lineStart + offset;
+    const adjustedEnd = lineEnd + offset;
+
+    let newLine: string;
+    if (allUnordered) {
+      // Remove unordered list marker
+      const ulMatch = line.match(/^[-*+]\s/);
+      newLine = ulMatch ? line.slice(ulMatch[0].length) : line;
+    } else {
+      // Convert to unordered list (remove other markers first)
+      const olMatch = line.match(/^\d+\.\s/);
+      const ulMatch = line.match(/^[-*+]\s/);
+      const content = olMatch ? line.slice(olMatch[0].length) : (ulMatch ? line.slice(ulMatch[0].length) : line);
+      newLine = `- ${content}`;
+    }
+
+    newDoc = newDoc.slice(0, adjustedStart) + newLine + newDoc.slice(adjustedEnd);
+    offset += newLine.length - (lineEnd - lineStart);
+    lastNewLineEnd = adjustedStart + newLine.length;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  // Place cursor at the end of the last modified line
+  editor.setSelection(lastNewLineEnd);
   return true;
 }
 

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -13,7 +13,7 @@ function getSelectedLines(doc: string, from: number, to: number): Array<{ lineSt
   const lines: Array<{ lineStart: number; lineEnd: number; line: string }> = [];
   let pos = from;
 
-  while (pos <= to) {
+  while (pos < to || (lines.length === 0 && pos === to)) {
     const lineStart = doc.lastIndexOf("\n", pos - 1) + 1;
     const lineEndIdx = doc.indexOf("\n", pos);
     const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
@@ -71,6 +71,7 @@ export function toggleOrderedList(editor: EditorAPI): boolean {
   let newDoc = doc;
   let offset = 0;
   let lastNewLineEnd = 0;
+  const firstLineStart = lines[0].lineStart;
 
   for (let i = 0; i < lines.length; i++) {
     const { lineStart, lineEnd, line } = lines[i];
@@ -96,8 +97,8 @@ export function toggleOrderedList(editor: EditorAPI): boolean {
   }
 
   editor.setDocument(newDoc);
-  // Place cursor at the end of the last modified line
-  editor.setSelection(lastNewLineEnd);
+  // Restore selection covering all modified lines
+  editor.setSelection(firstLineStart, lastNewLineEnd);
   return true;
 }
 
@@ -119,6 +120,7 @@ export function toggleUnorderedList(editor: EditorAPI): boolean {
   let newDoc = doc;
   let offset = 0;
   let lastNewLineEnd = 0;
+  const firstLineStart = lines[0].lineStart;
 
   for (let i = 0; i < lines.length; i++) {
     const { lineStart, lineEnd, line } = lines[i];
@@ -144,8 +146,8 @@ export function toggleUnorderedList(editor: EditorAPI): boolean {
   }
 
   editor.setDocument(newDoc);
-  // Place cursor at the end of the last modified line
-  editor.setSelection(lastNewLineEnd);
+  // Restore selection covering all modified lines
+  editor.setSelection(firstLineStart, lastNewLineEnd);
   return true;
 }
 

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -7,6 +7,8 @@ import {
   toggleInlineCode,
   insertLink,
   toggleHeading,
+  toggleOrderedList,
+  toggleUnorderedList,
   createToolbarPlugin,
   createToolbarUI,
 } from "../src/index";
@@ -169,6 +171,125 @@ describe("createToolbarUI", () => {
     expect(document.getElementById(button?.getAttribute("aria-describedby") ?? "")).toBeNull();
 
     toolbar.destroy();
+    editor.destroy();
+  });
+});
+
+// ── Multi-line List Toggle ──
+
+describe("toggleOrderedList", () => {
+  it("converts single line to ordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "Line 1\nLine 2\nLine 3" });
+
+    editor.setSelection(0, 6); // Select "Line 1"
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. Line 1\nLine 2\nLine 3");
+    editor.destroy();
+  });
+
+  it("converts multiple lines to ordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "Line 1\nLine 2\nLine 3" });
+
+    // Select lines 1 and 2
+    editor.setSelection(0, 13);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. Line 1\n2. Line 2\nLine 3");
+    editor.destroy();
+  });
+
+  it("converts all lines to ordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "Line 1\nLine 2\nLine 3" });
+
+    // Select all lines
+    editor.setSelection(0, 20);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. Line 1\n2. Line 2\n3. Line 3");
+    editor.destroy();
+  });
+
+  it("removes ordered list markers when all lines are ordered lists", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. Line 1\n2. Line 2\n3. Line 3" });
+
+    // Select all lines
+    editor.setSelection(0, 26);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("Line 1\nLine 2\nLine 3");
+    editor.destroy();
+  });
+
+  it("converts unordered list to ordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- Line 1\n- Line 2" });
+
+    editor.setSelection(0, 16);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. Line 1\n2. Line 2");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList", () => {
+  it("converts single line to unordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "Line 1\nLine 2\nLine 3" });
+
+    editor.setSelection(0, 6);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- Line 1\nLine 2\nLine 3");
+    editor.destroy();
+  });
+
+  it("converts multiple lines to unordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "Line 1\nLine 2\nLine 3" });
+
+    editor.setSelection(0, 13);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- Line 1\n- Line 2\nLine 3");
+    editor.destroy();
+  });
+
+  it("removes unordered list markers when all lines are unordered lists", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- Line 1\n- Line 2\n- Line 3" });
+
+    editor.setSelection(0, 23);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("Line 1\nLine 2\nLine 3");
+    editor.destroy();
+  });
+
+  it("converts ordered list to unordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. Line 1\n2. Line 2" });
+
+    editor.setSelection(0, 18);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- Line 1\n- Line 2");
+    editor.destroy();
+  });
+
+  it("handles mixed list types in selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. Line 1\n- Line 2\nLine 3" });
+
+    editor.setSelection(0, 24);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- Line 1\n- Line 2\n- Line 3");
     editor.destroy();
   });
 });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -4,7 +4,13 @@ import type {
 } from "@floatboat/nexus-core";
 import type { RefObject } from "react";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  /**
+   * Callback invoked when the editor instance is created and ready.
+   * Use this to access the editor API immediately after initialization.
+   */
+  onReady?: (editor: EditorAPI) => void;
+}
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -26,6 +26,9 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
     editorRef.current = instance;
     setEditor(instance);
 
+    // Call onReady callback if provided
+    configRef.current.onReady?.(instance);
+
     return () => {
       instance.destroy();
       editorRef.current = null;

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-react", () => {
@@ -36,5 +36,48 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady callback when editor is initialized", () => {
+    const onReady = vi.fn();
+
+    function Harness() {
+      const { containerRef } = useEditor({
+        initialValue: "hello",
+        onReady
+      });
+
+      return <div ref={containerRef} />;
+    }
+
+    render(<Harness />);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(expect.objectContaining({
+      getDocument: expect.any(Function),
+      setDocument: expect.any(Function),
+      getSelection: expect.any(Function),
+      getSelectedText: expect.any(Function),
+    }));
+  });
+
+  it("onReady callback receives working editor instance", () => {
+    let readyDoc = "";
+
+    function Harness() {
+      const { containerRef } = useEditor({
+        initialValue: "initial content",
+        onReady: (editor) => {
+          readyDoc = editor.getDocument();
+          editor.setDocument("modified by onReady");
+        }
+      });
+
+      return <div ref={containerRef} />;
+    }
+
+    render(<Harness />);
+
+    expect(readyDoc).toBe("initial content");
   });
 });

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -4,7 +4,13 @@ import type {
 } from "@floatboat/nexus-core";
 import type { Ref, ShallowRef } from "vue";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  /**
+   * Callback invoked when the editor instance is created and ready.
+   * Use this to access the editor API immediately after initialization.
+   */
+  onReady?: (editor: EditorAPI) => void;
+}
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -16,6 +16,9 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       container: containerRef.value,
       ...config
     });
+
+    // Call onReady callback if provided
+    config.onReady?.(editor.value);
   });
 
   onBeforeUnmount(() => {

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, onMounted } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-vue", () => {
@@ -44,5 +44,56 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady callback when editor is initialized", async () => {
+    const onReady = vi.fn();
+
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef } = useEditor({
+          initialValue: "hello",
+          onReady
+        });
+
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    mount(Harness);
+
+    await nextTick();
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(expect.objectContaining({
+      getDocument: expect.any(Function),
+      setDocument: expect.any(Function),
+      getSelection: expect.any(Function),
+      getSelectedText: expect.any(Function),
+    }));
+  });
+
+  it("onReady callback receives working editor instance", async () => {
+    let readyDoc = "";
+
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef } = useEditor({
+          initialValue: "initial content",
+          onReady: (editor) => {
+            readyDoc = editor.getDocument();
+            editor.setDocument("modified by onReady");
+          }
+        });
+
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    mount(Harness);
+
+    await nextTick();
+
+    expect(readyDoc).toBe("initial content");
   });
 });


### PR DESCRIPTION
### 变更内容

1. **getSelectedText() API** (`packages/core`)
   - 添加获取当前选中文本的方法

2. **onReady 回调** (`packages/react`, `packages/vue`)
   - 编辑器初始化完成后调用用户提供的回调

3. **搜索增强** (`packages/plugin-search`)
   - 支持整词匹配 (`wholeWord`)
   - 支持正则表达式搜索 (`regexp`)

4. **Slash 命令排序与限制** (`packages/plugin-slash`)
   - 根据匹配度和优先级排序
   - 支持限制返回数量

5. **多行列表切换** (`packages/plugin-toolbar`)
   - 支持多行选区同时切换列表类型

### 测试

所有新增功能均包含单元测试，全部通过：

```bash
pnpm test -- packages/core packages/react packages/vue packages/plugin-search packages/plugin-slash packages/plugin-toolbar
```

### 相关 Roadmap 项

- #5 getSelectedText() API (P0)
- #4 onReady Callback (P0)
- #2 Whole-word Matching (P1)
- #15 Regex Search (P1)
- #3 Slash Command Sorting (P0)
- #1 Multi-line List Toggle (P1)