### PR TITLE
feat(electron): add snapshot history for draft restore and reuse

### DIFF
--- a/apps/electron-demo/dist-electron/main.js
+++ b/apps/electron-demo/dist-electron/main.js
@@ -29,8 +29,88 @@ module.exports = __toCommonJS(main_exports);
 var import_electron = require("electron");
 var import_promises = require("fs/promises");
 var import_node_fs = require("fs");
-var import_node_path = __toESM(require("path"));
+var import_node_path2 = __toESM(require("path"));
 var import_node_url = require("url");
+
+// electron/snapshots.ts
+var import_node_path = __toESM(require("path"));
+var DEFAULT_SNAPSHOT_LIMIT = 20;
+var DEFAULT_SNAPSHOT_CONTENT_BYTES = 512 * 1024;
+function createEmptySnapshotStore() {
+  return { byDocument: {} };
+}
+function createSnapshotDocumentRef(filePath) {
+  return {
+    documentId: filePath ? documentIdFromPath(filePath) : "untitled",
+    filePath
+  };
+}
+function assertSnapshotContentSize(content, limitBytes = DEFAULT_SNAPSHOT_CONTENT_BYTES) {
+  const size = Buffer.byteLength(content, "utf-8");
+  if (size > limitBytes) {
+    throw new Error(`Snapshot content exceeds ${limitBytes} bytes`);
+  }
+}
+function summarizeSnapshot(content) {
+  const lines = content.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0);
+  if (lines.length === 0) return "(empty document)";
+  const preferred = lines.find((line) => !line.startsWith("#")) ?? lines[0];
+  return preferred.length > 96 ? `${preferred.slice(0, 93)}...` : preferred;
+}
+function createSnapshotEntry(input) {
+  const createdAt = input.createdAt ?? (/* @__PURE__ */ new Date()).toISOString();
+  const baseTitle = input.title?.trim() || summarizeSnapshot(input.content);
+  return {
+    id: `${createdAt}-${Math.random().toString(36).slice(2, 10)}`,
+    docKey: input.docKey,
+    filePath: input.filePath,
+    title: baseTitle,
+    content: input.content,
+    createdAt,
+    summary: summarizeSnapshot(input.content)
+  };
+}
+function listSnapshots(store, docKey) {
+  return [...store.byDocument[docKey] ?? []];
+}
+function addSnapshot(store, entry, limit = DEFAULT_SNAPSHOT_LIMIT) {
+  const current = store.byDocument[entry.docKey] ?? [];
+  const next = [entry, ...current].sort((a, b) => b.createdAt.localeCompare(a.createdAt)).slice(0, limit);
+  return {
+    byDocument: {
+      ...store.byDocument,
+      [entry.docKey]: next
+    }
+  };
+}
+function parseSnapshotStore(raw) {
+  const parsed = JSON.parse(raw);
+  if (!parsed.byDocument || typeof parsed.byDocument !== "object") {
+    throw new Error("Invalid snapshot store shape");
+  }
+  const byDocument = {};
+  for (const [docKey, value] of Object.entries(parsed.byDocument)) {
+    if (!Array.isArray(value)) continue;
+    byDocument[docKey] = value.filter(isSnapshotEntryLike).sort((a, b) => {
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+  }
+  return { byDocument };
+}
+function isSnapshotEntryLike(value) {
+  if (!value || typeof value !== "object") return false;
+  const entry = value;
+  return typeof entry.id === "string" && typeof entry.docKey === "string" && (typeof entry.filePath === "string" || entry.filePath === null) && typeof entry.title === "string" && typeof entry.content === "string" && typeof entry.createdAt === "string" && typeof entry.summary === "string";
+}
+function isCaseInsensitiveFileSystem() {
+  return process.platform === "darwin" || process.platform === "win32";
+}
+function documentIdFromPath(filePath) {
+  const resolved = import_node_path.default.resolve(filePath).replace(/\\/g, "/");
+  return isCaseInsensitiveFileSystem() ? resolved.toLowerCase() : resolved;
+}
+
+// electron/main.ts
 import_electron.protocol.registerSchemesAsPrivileged([
   {
     scheme: "nexus-vault",
@@ -56,7 +136,7 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      preload: import_node_path.default.join(__dirname, "preload.js")
+      preload: import_node_path2.default.join(__dirname, "preload.js")
     }
   });
   mainWindow.once("ready-to-show", () => {
@@ -66,7 +146,7 @@ function createWindow() {
   if (devUrl) {
     mainWindow.loadURL(devUrl);
   } else {
-    mainWindow.loadFile(import_node_path.default.join(__dirname, "../dist/index.html"));
+    mainWindow.loadFile(import_node_path2.default.join(__dirname, "../dist/index.html"));
   }
   mainWindow.webContents.on("before-input-event", (_event, input) => {
     const meta = input.meta || input.control;
@@ -117,10 +197,10 @@ function assertInsideVault(target) {
   if (!activeVault) {
     throw new Error("No active vault");
   }
-  const resolved = import_node_path.default.resolve(target);
-  const rel = import_node_path.default.relative(activeVault, resolved);
+  const resolved = import_node_path2.default.resolve(target);
+  const rel = import_node_path2.default.relative(activeVault, resolved);
   if (rel === "" || rel === ".") return resolved;
-  if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
+  if (rel.startsWith("..") || import_node_path2.default.isAbsolute(rel)) {
     throw new Error(`Path escapes vault: ${target}`);
   }
   return resolved;
@@ -132,7 +212,7 @@ async function scanDirectory(dir) {
     if (entry.name.startsWith(".") && SKIP_DIRS.has(entry.name)) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
     if (entry.name.startsWith(".")) continue;
-    const childPath = import_node_path.default.join(dir, entry.name);
+    const childPath = import_node_path2.default.join(dir, entry.name);
     if (entry.isDirectory()) {
       const children = await scanDirectory(childPath);
       if (children.length > 0) {
@@ -146,7 +226,7 @@ async function scanDirectory(dir) {
       continue;
     }
     if (entry.isFile()) {
-      const ext = import_node_path.default.extname(entry.name).toLowerCase();
+      const ext = import_node_path2.default.extname(entry.name).toLowerCase();
       if (!SUPPORTED_EXT.has(ext)) continue;
       nodes.push({ name: entry.name, path: childPath, kind: "file" });
     }
@@ -190,7 +270,7 @@ function startWatcher(vaultPath) {
   }
 }
 function vaultStatePath() {
-  return import_node_path.default.join(import_electron.app.getPath("userData"), "vault.json");
+  return import_node_path2.default.join(import_electron.app.getPath("userData"), "vault.json");
 }
 async function readVaultState() {
   const file = vaultStatePath();
@@ -209,6 +289,37 @@ async function readVaultState() {
 async function writeVaultState(state) {
   await (0, import_promises.writeFile)(vaultStatePath(), JSON.stringify(state, null, 2), "utf-8");
 }
+function snapshotStorePath() {
+  return import_node_path2.default.join(import_electron.app.getPath("userData"), "snapshots.json");
+}
+function snapshotTempPath() {
+  return `${snapshotStorePath()}.tmp`;
+}
+async function readSnapshotStore() {
+  const file = snapshotStorePath();
+  if (!(0, import_node_fs.existsSync)(file)) return createEmptySnapshotStore();
+  try {
+    const raw = await (0, import_promises.readFile)(file, "utf-8");
+    return parseSnapshotStore(raw);
+  } catch (err) {
+    console.warn("[snapshot] failed to read store:", err);
+    if ((0, import_node_fs.existsSync)(file)) {
+      const corruptPath = `${file}.corrupt-${Date.now()}`;
+      try {
+        await (0, import_promises.copyFile)(file, corruptPath);
+      } catch (copyErr) {
+        console.warn("[snapshot] failed to preserve corrupt store:", copyErr);
+      }
+    }
+    return createEmptySnapshotStore();
+  }
+}
+async function writeSnapshotStore(store) {
+  const target = snapshotStorePath();
+  const temp = snapshotTempPath();
+  await (0, import_promises.writeFile)(temp, JSON.stringify(store, null, 2), "utf-8");
+  await (0, import_promises.rename)(temp, target);
+}
 import_electron.ipcMain.handle("vault:pick", async () => {
   if (!mainWindow) return null;
   const result = await import_electron.dialog.showOpenDialog(mainWindow, {
@@ -218,7 +329,7 @@ import_electron.ipcMain.handle("vault:pick", async () => {
   return { path: result.filePaths[0] };
 });
 import_electron.ipcMain.handle("vault:list", async (_event, vaultPath) => {
-  const abs = import_node_path.default.resolve(vaultPath);
+  const abs = import_node_path2.default.resolve(vaultPath);
   const info = await (0, import_promises.stat)(abs);
   if (!info.isDirectory()) throw new Error(`Not a directory: ${abs}`);
   activeVault = abs;
@@ -235,12 +346,12 @@ async function collectFiles(dir, acc) {
   for (const entry of entries) {
     if (entry.name.startsWith(".")) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
-    const childPath = import_node_path.default.join(dir, entry.name);
+    const childPath = import_node_path2.default.join(dir, entry.name);
     if (entry.isDirectory()) {
       await collectFiles(childPath, acc);
       continue;
     }
-    if (entry.isFile() && SUPPORTED_EXT.has(import_node_path.default.extname(entry.name).toLowerCase())) {
+    if (entry.isFile() && SUPPORTED_EXT.has(import_node_path2.default.extname(entry.name).toLowerCase())) {
       acc.push(childPath);
     }
   }
@@ -282,19 +393,19 @@ import_electron.ipcMain.handle(
     const baseNameRaw = segments.pop();
     const subDirs = segments.join("/");
     const parent = assertInsideVault(
-      subDirs ? import_node_path.default.join(parentDir, subDirs) : parentDir
+      subDirs ? import_node_path2.default.join(parentDir, subDirs) : parentDir
     );
     if (subDirs) {
       await (0, import_promises.mkdir)(parent, { recursive: true });
     }
-    const hasExt = SUPPORTED_EXT.has(import_node_path.default.extname(baseNameRaw).toLowerCase());
+    const hasExt = SUPPORTED_EXT.has(import_node_path2.default.extname(baseNameRaw).toLowerCase());
     const baseName = hasExt ? baseNameRaw : `${baseNameRaw}.md`;
-    const ext = import_node_path.default.extname(baseName);
+    const ext = import_node_path2.default.extname(baseName);
     const stem = baseName.slice(0, baseName.length - ext.length);
-    let candidate = import_node_path.default.join(parent, baseName);
+    let candidate = import_node_path2.default.join(parent, baseName);
     let suffix = 1;
     while ((0, import_node_fs.existsSync)(candidate)) {
-      candidate = import_node_path.default.join(parent, `${stem}-${suffix}${ext}`);
+      candidate = import_node_path2.default.join(parent, `${stem}-${suffix}${ext}`);
       suffix += 1;
     }
     const finalPath = assertInsideVault(candidate);
@@ -307,7 +418,7 @@ import_electron.ipcMain.handle(
   async (_event, parentDir, name) => {
     const parent = assertInsideVault(parentDir);
     const safeName = name.trim() || "new-folder";
-    const target = assertInsideVault(import_node_path.default.join(parent, safeName));
+    const target = assertInsideVault(import_node_path2.default.join(parent, safeName));
     if ((0, import_node_fs.existsSync)(target)) {
       throw new Error(`Folder already exists: ${safeName}`);
     }
@@ -319,13 +430,13 @@ import_electron.ipcMain.handle(
   "vault:rename",
   async (_event, oldPath, newName) => {
     const src = assertInsideVault(oldPath);
-    const parent = import_node_path.default.dirname(src);
+    const parent = import_node_path2.default.dirname(src);
     const trimmed = newName.trim();
     if (!trimmed) throw new Error("New name cannot be empty");
     if (trimmed.includes("/") || trimmed.includes("\\")) {
       throw new Error("New name cannot contain path separators");
     }
-    const target = assertInsideVault(import_node_path.default.join(parent, trimmed));
+    const target = assertInsideVault(import_node_path2.default.join(parent, trimmed));
     if ((0, import_node_fs.existsSync)(target) && target !== src) {
       throw new Error(`Target already exists: ${trimmed}`);
     }
@@ -356,6 +467,27 @@ import_electron.ipcMain.handle("vault:set-last", async (_event, vaultPath) => {
   await writeVaultState({ lastVault: vaultPath, recents });
   return { ok: true };
 });
+import_electron.ipcMain.handle(
+  "snapshot:create",
+  async (_event, input) => {
+    assertSnapshotContentSize(input.content);
+    const store = await readSnapshotStore();
+    const documentRef = createSnapshotDocumentRef(input.filePath);
+    const entry = createSnapshotEntry({
+      docKey: documentRef.documentId,
+      filePath: documentRef.filePath,
+      content: input.content,
+      title: input.title
+    });
+    const nextStore = addSnapshot(store, entry, DEFAULT_SNAPSHOT_LIMIT);
+    await writeSnapshotStore(nextStore);
+    return entry;
+  }
+);
+import_electron.ipcMain.handle("snapshot:list", async (_event, filePath) => {
+  const store = await readSnapshotStore();
+  return listSnapshots(store, createSnapshotDocumentRef(filePath).documentId);
+});
 import_electron.app.whenReady().then(() => {
   import_electron.protocol.handle("nexus-vault", async (request) => {
     try {
@@ -363,9 +495,9 @@ import_electron.app.whenReady().then(() => {
       const url = new URL(request.url);
       const relPath = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
       if (!relPath) return new Response("Empty path", { status: 400 });
-      const abs = import_node_path.default.resolve(activeVault, relPath);
-      const rel = import_node_path.default.relative(activeVault, abs);
-      if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
+      const abs = import_node_path2.default.resolve(activeVault, relPath);
+      const rel = import_node_path2.default.relative(activeVault, abs);
+      if (rel.startsWith("..") || import_node_path2.default.isAbsolute(rel)) {
         return new Response("Path escapes vault", { status: 403 });
       }
       if (!(0, import_node_fs.existsSync)(abs)) return new Response("Not found", { status: 404 });

--- a/apps/electron-demo/dist-electron/preload.js
+++ b/apps/electron-demo/dist-electron/preload.js
@@ -69,6 +69,14 @@ var bridge = {
   saveFileAs(content) {
     return import_electron.ipcRenderer.invoke("demo:save-file-as", content);
   },
-  vault: vaultBridge
+  vault: vaultBridge,
+  snapshots: {
+    create(input) {
+      return import_electron.ipcRenderer.invoke("snapshot:create", input);
+    },
+    list(filePath) {
+      return import_electron.ipcRenderer.invoke("snapshot:list", filePath);
+    }
+  }
 };
 import_electron.contextBridge.exposeInMainWorld("nexusDemo", bridge);

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -3,6 +3,17 @@ import { readFile, writeFile, readdir, mkdir, rename, stat } from "node:fs/promi
 import { existsSync, watch, type FSWatcher } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  addSnapshot,
+  createEmptySnapshotStore,
+  createSnapshotEntry,
+  DEFAULT_SNAPSHOT_LIMIT,
+  listSnapshots,
+  normalizeDocKey,
+  parseSnapshotStore,
+  type SnapshotEntry,
+  type SnapshotStore,
+} from "./snapshots";
 
 // Must be called before app ready — declares our custom scheme as privileged
 // so images served via nexus-vault:// pass fetch/<img> with credentials / CORS.
@@ -238,6 +249,25 @@ async function writeVaultState(state: VaultState): Promise<void> {
   await writeFile(vaultStatePath(), JSON.stringify(state, null, 2), "utf-8");
 }
 
+function snapshotStorePath(): string {
+  return path.join(app.getPath("userData"), "snapshots.json");
+}
+
+async function readSnapshotStore(): Promise<SnapshotStore> {
+  const file = snapshotStorePath();
+  if (!existsSync(file)) return createEmptySnapshotStore();
+  try {
+    const raw = await readFile(file, "utf-8");
+    return parseSnapshotStore(raw);
+  } catch {
+    return createEmptySnapshotStore();
+  }
+}
+
+async function writeSnapshotStore(store: SnapshotStore): Promise<void> {
+  await writeFile(snapshotStorePath(), JSON.stringify(store, null, 2), "utf-8");
+}
+
 // -- vault IPC handlers -------------------------------------------------------
 
 ipcMain.handle("vault:pick", async () => {
@@ -412,6 +442,28 @@ ipcMain.handle("vault:set-last", async (_event, vaultPath: string) => {
   const recents = [vaultPath, ...current.recents.filter((r) => r !== vaultPath)].slice(0, 10);
   await writeVaultState({ lastVault: vaultPath, recents });
   return { ok: true };
+});
+
+ipcMain.handle(
+  "snapshot:create",
+  async (_event, input: { filePath: string | null; content: string; title?: string }): Promise<SnapshotEntry> => {
+    const store = await readSnapshotStore();
+    const docKey = normalizeDocKey(input.filePath);
+    const entry = createSnapshotEntry({
+      docKey,
+      filePath: input.filePath,
+      content: input.content,
+      title: input.title,
+    });
+    const nextStore = addSnapshot(store, entry, DEFAULT_SNAPSHOT_LIMIT);
+    await writeSnapshotStore(nextStore);
+    return entry;
+  }
+);
+
+ipcMain.handle("snapshot:list", async (_event, filePath: string | null): Promise<SnapshotEntry[]> => {
+  const store = await readSnapshotStore();
+  return listSnapshots(store, normalizeDocKey(filePath));
 });
 
 app.whenReady().then(() => {

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -1,15 +1,16 @@
 import { app, BrowserWindow, dialog, ipcMain, net, protocol, shell } from "electron";
-import { readFile, writeFile, readdir, mkdir, rename, stat } from "node:fs/promises";
+import { readFile, writeFile, readdir, mkdir, rename, stat, copyFile } from "node:fs/promises";
 import { existsSync, watch, type FSWatcher } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   addSnapshot,
+  assertSnapshotContentSize,
+  createSnapshotDocumentRef,
   createEmptySnapshotStore,
   createSnapshotEntry,
   DEFAULT_SNAPSHOT_LIMIT,
   listSnapshots,
-  normalizeDocKey,
   parseSnapshotStore,
   type SnapshotEntry,
   type SnapshotStore,
@@ -253,19 +254,35 @@ function snapshotStorePath(): string {
   return path.join(app.getPath("userData"), "snapshots.json");
 }
 
+function snapshotTempPath(): string {
+  return `${snapshotStorePath()}.tmp`;
+}
+
 async function readSnapshotStore(): Promise<SnapshotStore> {
   const file = snapshotStorePath();
   if (!existsSync(file)) return createEmptySnapshotStore();
   try {
     const raw = await readFile(file, "utf-8");
     return parseSnapshotStore(raw);
-  } catch {
+  } catch (err) {
+    console.warn("[snapshot] failed to read store:", err);
+    if (existsSync(file)) {
+      const corruptPath = `${file}.corrupt-${Date.now()}`;
+      try {
+        await copyFile(file, corruptPath);
+      } catch (copyErr) {
+        console.warn("[snapshot] failed to preserve corrupt store:", copyErr);
+      }
+    }
     return createEmptySnapshotStore();
   }
 }
 
 async function writeSnapshotStore(store: SnapshotStore): Promise<void> {
-  await writeFile(snapshotStorePath(), JSON.stringify(store, null, 2), "utf-8");
+  const target = snapshotStorePath();
+  const temp = snapshotTempPath();
+  await writeFile(temp, JSON.stringify(store, null, 2), "utf-8");
+  await rename(temp, target);
 }
 
 // -- vault IPC handlers -------------------------------------------------------
@@ -447,11 +464,12 @@ ipcMain.handle("vault:set-last", async (_event, vaultPath: string) => {
 ipcMain.handle(
   "snapshot:create",
   async (_event, input: { filePath: string | null; content: string; title?: string }): Promise<SnapshotEntry> => {
+    assertSnapshotContentSize(input.content);
     const store = await readSnapshotStore();
-    const docKey = normalizeDocKey(input.filePath);
+    const documentRef = createSnapshotDocumentRef(input.filePath);
     const entry = createSnapshotEntry({
-      docKey,
-      filePath: input.filePath,
+      docKey: documentRef.documentId,
+      filePath: documentRef.filePath,
       content: input.content,
       title: input.title,
     });
@@ -463,7 +481,7 @@ ipcMain.handle(
 
 ipcMain.handle("snapshot:list", async (_event, filePath: string | null): Promise<SnapshotEntry[]> => {
   const store = await readSnapshotStore();
-  return listSnapshots(store, normalizeDocKey(filePath));
+  return listSnapshots(store, createSnapshotDocumentRef(filePath).documentId);
 });
 
 app.whenReady().then(() => {

--- a/apps/electron-demo/electron/preload.ts
+++ b/apps/electron-demo/electron/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { SnapshotEntry } from "./snapshots";
 
 export interface DemoFileHandle {
   path: string;
@@ -32,11 +33,21 @@ export interface VaultBridge {
   onChanged(cb: (payload: { vault: string }) => void): () => void;
 }
 
+export interface SnapshotBridge {
+  create(input: {
+    filePath: string | null;
+    content: string;
+    title?: string;
+  }): Promise<SnapshotEntry>;
+  list(filePath: string | null): Promise<SnapshotEntry[]>;
+}
+
 export interface DemoBridge {
   openFile(): Promise<DemoFileHandle | null>;
   saveFile(path: string, content: string): Promise<{ path: string }>;
   saveFileAs(content: string): Promise<{ path: string } | null>;
   vault: VaultBridge;
+  snapshots: SnapshotBridge;
 }
 
 const vaultBridge: VaultBridge = {
@@ -93,6 +104,14 @@ const bridge: DemoBridge = {
     return ipcRenderer.invoke("demo:save-file-as", content);
   },
   vault: vaultBridge,
+  snapshots: {
+    create(input) {
+      return ipcRenderer.invoke("snapshot:create", input);
+    },
+    list(filePath) {
+      return ipcRenderer.invoke("snapshot:list", filePath);
+    },
+  },
 };
 
 contextBridge.exposeInMainWorld("nexusDemo", bridge);

--- a/apps/electron-demo/electron/snapshots.ts
+++ b/apps/electron-demo/electron/snapshots.ts
@@ -1,0 +1,108 @@
+export interface SnapshotEntry {
+  id: string;
+  docKey: string;
+  filePath: string | null;
+  title: string;
+  content: string;
+  createdAt: string;
+  summary: string;
+}
+
+export interface SnapshotStore {
+  byDocument: Record<string, SnapshotEntry[]>;
+}
+
+export interface CreateSnapshotInput {
+  docKey: string;
+  filePath: string | null;
+  content: string;
+  title?: string;
+  createdAt?: string;
+}
+
+export const DEFAULT_SNAPSHOT_LIMIT = 20;
+
+export function createEmptySnapshotStore(): SnapshotStore {
+  return { byDocument: {} };
+}
+
+export function normalizeDocKey(filePath: string | null): string {
+  if (!filePath) return "untitled";
+  return filePath.replace(/\\/g, "/");
+}
+
+export function summarizeSnapshot(content: string): string {
+  const firstLine = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return "(empty document)";
+  return firstLine.length > 96 ? `${firstLine.slice(0, 93)}...` : firstLine;
+}
+
+export function createSnapshotEntry(input: CreateSnapshotInput): SnapshotEntry {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const baseTitle = input.title?.trim() || summarizeSnapshot(input.content);
+  return {
+    id: `${createdAt}-${Math.random().toString(36).slice(2, 10)}`,
+    docKey: input.docKey,
+    filePath: input.filePath,
+    title: baseTitle,
+    content: input.content,
+    createdAt,
+    summary: summarizeSnapshot(input.content),
+  };
+}
+
+export function listSnapshots(store: SnapshotStore, docKey: string): SnapshotEntry[] {
+  return [...(store.byDocument[docKey] ?? [])];
+}
+
+export function addSnapshot(
+  store: SnapshotStore,
+  entry: SnapshotEntry,
+  limit = DEFAULT_SNAPSHOT_LIMIT
+): SnapshotStore {
+  const current = store.byDocument[entry.docKey] ?? [];
+  const next = [entry, ...current]
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .slice(0, limit);
+
+  return {
+    byDocument: {
+      ...store.byDocument,
+      [entry.docKey]: next,
+    },
+  };
+}
+
+export function parseSnapshotStore(raw: string): SnapshotStore {
+  try {
+    const parsed = JSON.parse(raw) as Partial<SnapshotStore>;
+    if (!parsed.byDocument || typeof parsed.byDocument !== "object") {
+      return createEmptySnapshotStore();
+    }
+    const byDocument: Record<string, SnapshotEntry[]> = {};
+    for (const [docKey, value] of Object.entries(parsed.byDocument)) {
+      if (!Array.isArray(value)) continue;
+      byDocument[docKey] = value.filter(isSnapshotEntryLike).sort((a, b) => {
+        return b.createdAt.localeCompare(a.createdAt);
+      });
+    }
+    return { byDocument };
+  } catch {
+    return createEmptySnapshotStore();
+  }
+}
+
+function isSnapshotEntryLike(value: unknown): value is SnapshotEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.id === "string"
+    && typeof entry.docKey === "string"
+    && (typeof entry.filePath === "string" || entry.filePath === null)
+    && typeof entry.title === "string"
+    && typeof entry.content === "string"
+    && typeof entry.createdAt === "string"
+    && typeof entry.summary === "string";
+}

--- a/apps/electron-demo/electron/snapshots.ts
+++ b/apps/electron-demo/electron/snapshots.ts
@@ -32,12 +32,15 @@ export function normalizeDocKey(filePath: string | null): string {
 }
 
 export function summarizeSnapshot(content: string): string {
-  const firstLine = content
+  const lines = content
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .find((line) => line.length > 0);
-  if (!firstLine) return "(empty document)";
-  return firstLine.length > 96 ? `${firstLine.slice(0, 93)}...` : firstLine;
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) return "(empty document)";
+
+  const preferred = lines.find((line) => !line.startsWith("#")) ?? lines[0];
+  return preferred.length > 96 ? `${preferred.slice(0, 93)}...` : preferred;
 }
 
 export function createSnapshotEntry(input: CreateSnapshotInput): SnapshotEntry {

--- a/apps/electron-demo/electron/snapshots.ts
+++ b/apps/electron-demo/electron/snapshots.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 export interface SnapshotEntry {
   id: string;
   docKey: string;
@@ -12,6 +14,11 @@ export interface SnapshotStore {
   byDocument: Record<string, SnapshotEntry[]>;
 }
 
+export interface SnapshotDocumentRef {
+  documentId: string;
+  filePath: string | null;
+}
+
 export interface CreateSnapshotInput {
   docKey: string;
   filePath: string | null;
@@ -21,14 +28,31 @@ export interface CreateSnapshotInput {
 }
 
 export const DEFAULT_SNAPSHOT_LIMIT = 20;
+export const DEFAULT_SNAPSHOT_CONTENT_BYTES = 512 * 1024;
 
 export function createEmptySnapshotStore(): SnapshotStore {
   return { byDocument: {} };
 }
 
+export function createSnapshotDocumentRef(filePath: string | null): SnapshotDocumentRef {
+  return {
+    documentId: filePath ? documentIdFromPath(filePath) : "untitled",
+    filePath,
+  };
+}
+
 export function normalizeDocKey(filePath: string | null): string {
-  if (!filePath) return "untitled";
-  return filePath.replace(/\\/g, "/");
+  return createSnapshotDocumentRef(filePath).documentId;
+}
+
+export function assertSnapshotContentSize(
+  content: string,
+  limitBytes = DEFAULT_SNAPSHOT_CONTENT_BYTES
+): void {
+  const size = Buffer.byteLength(content, "utf-8");
+  if (size > limitBytes) {
+    throw new Error(`Snapshot content exceeds ${limitBytes} bytes`);
+  }
 }
 
 export function summarizeSnapshot(content: string): string {
@@ -80,22 +104,18 @@ export function addSnapshot(
 }
 
 export function parseSnapshotStore(raw: string): SnapshotStore {
-  try {
-    const parsed = JSON.parse(raw) as Partial<SnapshotStore>;
-    if (!parsed.byDocument || typeof parsed.byDocument !== "object") {
-      return createEmptySnapshotStore();
-    }
-    const byDocument: Record<string, SnapshotEntry[]> = {};
-    for (const [docKey, value] of Object.entries(parsed.byDocument)) {
-      if (!Array.isArray(value)) continue;
-      byDocument[docKey] = value.filter(isSnapshotEntryLike).sort((a, b) => {
-        return b.createdAt.localeCompare(a.createdAt);
-      });
-    }
-    return { byDocument };
-  } catch {
-    return createEmptySnapshotStore();
+  const parsed = JSON.parse(raw) as Partial<SnapshotStore>;
+  if (!parsed.byDocument || typeof parsed.byDocument !== "object") {
+    throw new Error("Invalid snapshot store shape");
   }
+  const byDocument: Record<string, SnapshotEntry[]> = {};
+  for (const [docKey, value] of Object.entries(parsed.byDocument)) {
+    if (!Array.isArray(value)) continue;
+    byDocument[docKey] = value.filter(isSnapshotEntryLike).sort((a, b) => {
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+  }
+  return { byDocument };
 }
 
 function isSnapshotEntryLike(value: unknown): value is SnapshotEntry {
@@ -108,4 +128,13 @@ function isSnapshotEntryLike(value: unknown): value is SnapshotEntry {
     && typeof entry.content === "string"
     && typeof entry.createdAt === "string"
     && typeof entry.summary === "string";
+}
+
+function isCaseInsensitiveFileSystem(): boolean {
+  return process.platform === "darwin" || process.platform === "win32";
+}
+
+function documentIdFromPath(filePath: string): string {
+  const resolved = path.resolve(filePath).replace(/\\/g, "/");
+  return isCaseInsensitiveFileSystem() ? resolved.toLowerCase() : resolved;
 }

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -6,7 +6,9 @@ import { createSearchBar, type SearchBar } from "./search-bar";
 import { createVaultPanel, type VaultPanel } from "./vault-panel";
 import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
 import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
+import { createHistoryPanel, type HistoryPanel } from "./history-panel";
 import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
+import type { SnapshotEntry } from "../../electron/snapshots";
 
 installLongTaskWatch(50);
 
@@ -17,6 +19,7 @@ let outline: OutlinePanel;
 let searchBar: SearchBar;
 let vault: VaultPanel;
 let backlinks: BacklinksPanel;
+let historyPanel: HistoryPanel;
 
 const linkIndex = new LinkIndex();
 state.linkIndex = linkIndex;
@@ -71,6 +74,19 @@ function createAppToolbar(): HTMLElement {
   searchBtn.style.fontSize = "14px";
   searchBtn.addEventListener("click", () => searchBar.open());
 
+  const snapshotBtn = document.createElement("button");
+  snapshotBtn.textContent = "Snapshot";
+  snapshotBtn.title = "Create a manual snapshot";
+  snapshotBtn.addEventListener("click", () => {
+    void createSnapshot();
+  });
+
+  const historyBtn = document.createElement("button");
+  historyBtn.textContent = "\u23F2"; // ⏲
+  historyBtn.title = "Toggle history";
+  historyBtn.style.fontSize = "14px";
+  historyBtn.addEventListener("click", toggleHistory);
+
   const settingsBtn = document.createElement("button");
   settingsBtn.textContent = "\u2699"; // ⚙
   settingsBtn.title = "Settings";
@@ -87,6 +103,8 @@ function createAppToolbar(): HTMLElement {
     outlineBtn,
     backlinksBtn,
     searchBtn,
+    snapshotBtn,
+    historyBtn,
     settingsBtn
   );
   return toolbar;
@@ -119,6 +137,17 @@ async function confirmDiscardIfDirty(): Promise<boolean> {
   return window.confirm("You have unsaved changes. Discard them and switch files?");
 }
 
+async function refreshSnapshots(): Promise<void> {
+  try {
+    state.snapshots = await window.nexusDemo.snapshots.list(state.activeFile ?? state.filePath);
+  } catch (err) {
+    state.error = err instanceof Error ? err.message : String(err);
+    state.snapshots = [];
+  }
+  historyPanel?.update();
+  renderStatus();
+}
+
 async function handleOpen(): Promise<void> {
   try {
     state.error = null;
@@ -131,6 +160,7 @@ async function handleOpen(): Promise<void> {
     shell.loadDocument(result.content);
     vault.setActiveFile(result.path);
     backlinks.refresh();
+    await refreshSnapshots();
   } catch (err) {
     state.error = err instanceof Error ? err.message : String(err);
   }
@@ -168,6 +198,7 @@ async function handleSaveAs(): Promise<void> {
     state.activeFile = result.path;
     state.dirty = false;
     vault.setActiveFile(result.path);
+    await refreshSnapshots();
   } catch (err) {
     state.error = err instanceof Error ? err.message : String(err);
   }
@@ -202,6 +233,59 @@ function toggleBacklinks(): void {
   togglePanel(backlinks.element, () => backlinks.refresh());
 }
 
+function toggleHistory(): void {
+  togglePanel(historyPanel.element, () => historyPanel.update());
+}
+
+async function createSnapshot(): Promise<void> {
+  try {
+    state.error = null;
+    await window.nexusDemo.snapshots.create({
+      filePath: state.activeFile ?? state.filePath,
+      content: state.content,
+    });
+    await refreshSnapshots();
+  } catch (err) {
+    state.error = err instanceof Error ? err.message : String(err);
+    renderStatus();
+  }
+}
+
+async function restoreSnapshot(snapshot: SnapshotEntry): Promise<void> {
+  try {
+    state.error = null;
+    if (!(await confirmDiscardIfDirty())) return;
+    shell.loadDocument(snapshot.content);
+    if (snapshot.filePath) {
+      state.filePath = snapshot.filePath;
+      state.activeFile = snapshot.filePath;
+      vault.setActiveFile(snapshot.filePath);
+    } else {
+      state.filePath = null;
+      state.activeFile = null;
+      vault.setActiveFile(null);
+    }
+    backlinks.refresh();
+    await refreshSnapshots();
+    renderStatus();
+  } catch (err) {
+    state.error = err instanceof Error ? err.message : String(err);
+    renderStatus();
+  }
+}
+
+function reuseSnapshot(snapshot: SnapshotEntry): void {
+  state.error = null;
+  shell.loadDocument(snapshot.content);
+  state.filePath = null;
+  state.activeFile = null;
+  state.dirty = true;
+  vault.setActiveFile(null);
+  backlinks.refresh();
+  void refreshSnapshots();
+  renderStatus();
+}
+
 async function handleVaultFileOpen(filePath: string): Promise<void> {
   const total = perfStart("open-file", { filePath });
   try {
@@ -226,6 +310,7 @@ async function handleVaultFileOpen(filePath: string): Promise<void> {
     const bl = perfStart("open-file.backlinks.refresh");
     backlinks.refresh();
     perfEnd(bl);
+    await refreshSnapshots();
   } catch (err) {
     state.error = err instanceof Error ? err.message : String(err);
   }
@@ -406,9 +491,18 @@ function boot(): void {
     onOpenFile: (filePath) => void handleVaultFileOpen(filePath),
     getActiveFile: () => state.activeFile,
   });
+  historyPanel = createHistoryPanel({
+    getSnapshots: () => state.snapshots,
+    onRestore: (snapshot) => {
+      void restoreSnapshot(snapshot);
+    },
+    onReuse: (snapshot) => {
+      reuseSnapshot(snapshot);
+    },
+  });
 
   editorColumn.append(searchBar.element, editorContainer);
-  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element);
+  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element, historyPanel.element);
 
   // External file changes → re-seed the index (cheap for typical vaults).
   window.nexusDemo.vault.onChanged(() => {
@@ -423,6 +517,7 @@ function boot(): void {
   });
 
   renderStatus();
+  void refreshSnapshots();
   perfEnd(bootScope);
 
   // Defer vault restore until after first paint so the window pops open with

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -234,17 +234,26 @@ function toggleBacklinks(): void {
 }
 
 function toggleHistory(): void {
+  if (historyPanel.element.style.display === "none" && backlinks.element.style.display !== "none") {
+    backlinks.element.style.display = "none";
+  }
+  if (historyPanel.element.style.display === "none" && outline.element.style.display !== "none") {
+    outline.element.style.display = "none";
+  }
   togglePanel(historyPanel.element, () => historyPanel.update());
 }
 
 async function createSnapshot(): Promise<void> {
   try {
     state.error = null;
+    const currentDoc = shell.editor.getDocument();
     await window.nexusDemo.snapshots.create({
       filePath: state.activeFile ?? state.filePath,
-      content: state.content,
+      content: currentDoc,
     });
     await refreshSnapshots();
+    state.error = `Snapshot created (${new Date().toLocaleTimeString()})`;
+    renderStatus();
   } catch (err) {
     state.error = err instanceof Error ? err.message : String(err);
     renderStatus();
@@ -267,6 +276,9 @@ async function restoreSnapshot(snapshot: SnapshotEntry): Promise<void> {
     }
     backlinks.refresh();
     await refreshSnapshots();
+    historyPanel.element.style.display = "none";
+    shell.editor.focus();
+    state.error = `Restored snapshot: ${snapshot.title}`;
     renderStatus();
   } catch (err) {
     state.error = err instanceof Error ? err.message : String(err);
@@ -282,7 +294,10 @@ function reuseSnapshot(snapshot: SnapshotEntry): void {
   state.dirty = true;
   vault.setActiveFile(null);
   backlinks.refresh();
+  historyPanel.element.style.display = "none";
+  shell.editor.focus();
   void refreshSnapshots();
+  state.error = `Reused snapshot as new draft: ${snapshot.title}`;
   renderStatus();
 }
 
@@ -500,6 +515,7 @@ function boot(): void {
       reuseSnapshot(snapshot);
     },
   });
+  historyPanel.element.style.display = "none";
 
   editorColumn.append(searchBar.element, editorContainer);
   mainArea.append(vault.element, editorColumn, outline.element, backlinks.element, historyPanel.element);

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -8,7 +8,7 @@ import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
 import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
 import { createHistoryPanel, type HistoryPanel } from "./history-panel";
 import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
-import type { SnapshotEntry } from "../../electron/snapshots";
+import type { SnapshotEntry } from "./snapshot-entry";
 
 installLongTaskWatch(50);
 
@@ -128,8 +128,9 @@ function renderStatus(): void {
   const vaultLabel = state.vaultPath
     ? ` | Vault: ${state.vaultPath.split(/[\\/]/).pop()}`
     : "";
+  const statusText = state.statusMessage ? ` | ${state.statusMessage}` : "";
   const errorText = state.error ? ` — Error: ${state.error}` : "";
-  el.textContent = `${pathLabel}${dirtyMark}${statsText}${vaultLabel}${errorText}`;
+  el.textContent = `${pathLabel}${dirtyMark}${statsText}${vaultLabel}${statusText}${errorText}`;
 }
 
 async function confirmDiscardIfDirty(): Promise<boolean> {
@@ -246,15 +247,17 @@ function toggleHistory(): void {
 async function createSnapshot(): Promise<void> {
   try {
     state.error = null;
+    state.statusMessage = null;
     const currentDoc = shell.editor.getDocument();
     await window.nexusDemo.snapshots.create({
       filePath: state.activeFile ?? state.filePath,
       content: currentDoc,
     });
     await refreshSnapshots();
-    state.error = `Snapshot created (${new Date().toLocaleTimeString()})`;
+    state.statusMessage = `Snapshot created (${new Date().toLocaleTimeString()})`;
     renderStatus();
   } catch (err) {
+    state.statusMessage = null;
     state.error = err instanceof Error ? err.message : String(err);
     renderStatus();
   }
@@ -263,6 +266,7 @@ async function createSnapshot(): Promise<void> {
 async function restoreSnapshot(snapshot: SnapshotEntry): Promise<void> {
   try {
     state.error = null;
+    state.statusMessage = null;
     if (!(await confirmDiscardIfDirty())) return;
     shell.loadDocument(snapshot.content);
     if (snapshot.filePath) {
@@ -278,16 +282,19 @@ async function restoreSnapshot(snapshot: SnapshotEntry): Promise<void> {
     await refreshSnapshots();
     historyPanel.element.style.display = "none";
     shell.editor.focus();
-    state.error = `Restored snapshot: ${snapshot.title}`;
+    state.statusMessage = `Restored snapshot: ${snapshot.title}`;
     renderStatus();
   } catch (err) {
+    state.statusMessage = null;
     state.error = err instanceof Error ? err.message : String(err);
     renderStatus();
   }
 }
 
-function reuseSnapshot(snapshot: SnapshotEntry): void {
+async function reuseSnapshot(snapshot: SnapshotEntry): Promise<void> {
   state.error = null;
+  state.statusMessage = null;
+  if (!(await confirmDiscardIfDirty())) return;
   shell.loadDocument(snapshot.content);
   state.filePath = null;
   state.activeFile = null;
@@ -297,7 +304,7 @@ function reuseSnapshot(snapshot: SnapshotEntry): void {
   historyPanel.element.style.display = "none";
   shell.editor.focus();
   void refreshSnapshots();
-  state.error = `Reused snapshot as new draft: ${snapshot.title}`;
+  state.statusMessage = `Reused snapshot as new draft: ${snapshot.title}`;
   renderStatus();
 }
 
@@ -512,7 +519,7 @@ function boot(): void {
       void restoreSnapshot(snapshot);
     },
     onReuse: (snapshot) => {
-      reuseSnapshot(snapshot);
+      void reuseSnapshot(snapshot);
     },
   });
   historyPanel.element.style.display = "none";

--- a/apps/electron-demo/src/renderer/bridge.d.ts
+++ b/apps/electron-demo/src/renderer/bridge.d.ts
@@ -15,6 +15,16 @@ interface VaultState {
   recents: string[];
 }
 
+interface SnapshotEntry {
+  id: string;
+  docKey: string;
+  filePath: string | null;
+  title: string;
+  content: string;
+  createdAt: string;
+  summary: string;
+}
+
 interface VaultBridge {
   pick(): Promise<{ path: string } | null>;
   list(vaultPath: string): Promise<VaultNode[]>;
@@ -30,11 +40,21 @@ interface VaultBridge {
   onChanged(cb: (payload: { vault: string }) => void): () => void;
 }
 
+interface SnapshotBridge {
+  create(input: {
+    filePath: string | null;
+    content: string;
+    title?: string;
+  }): Promise<SnapshotEntry>;
+  list(filePath: string | null): Promise<SnapshotEntry[]>;
+}
+
 interface DemoBridge {
   openFile(): Promise<DemoFileHandle | null>;
   saveFile(path: string, content: string): Promise<{ path: string }>;
   saveFileAs(content: string): Promise<{ path: string } | null>;
   vault: VaultBridge;
+  snapshots: SnapshotBridge;
 }
 
 interface Window {

--- a/apps/electron-demo/src/renderer/history-panel.ts
+++ b/apps/electron-demo/src/renderer/history-panel.ts
@@ -1,4 +1,4 @@
-import type { SnapshotEntry } from "../../electron/snapshots";
+import type { SnapshotEntry } from "./snapshot-entry";
 
 export interface HistoryPanelOptions {
   getSnapshots(): SnapshotEntry[];

--- a/apps/electron-demo/src/renderer/history-panel.ts
+++ b/apps/electron-demo/src/renderer/history-panel.ts
@@ -1,0 +1,174 @@
+import type { SnapshotEntry } from "../../electron/snapshots";
+
+export interface HistoryPanelOptions {
+  getSnapshots(): SnapshotEntry[];
+  onRestore(snapshot: SnapshotEntry): void;
+  onReuse(snapshot: SnapshotEntry): void;
+}
+
+export interface HistoryPanel {
+  element: HTMLElement;
+  update(): void;
+  destroy(): void;
+}
+
+const PANEL_STYLES = `
+  width: 280px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--nexus-border, #eee);
+  background: var(--nexus-bg, #fff);
+  display: flex;
+  flex-direction: column;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  overflow: hidden;
+`;
+
+const HEADER_STYLES = `
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--nexus-border, #eee);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--nexus-text-muted, #888);
+  flex-shrink: 0;
+`;
+
+const LIST_STYLES = `
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+`;
+
+const EMPTY_STYLES = `
+  padding: 16px 12px;
+  color: var(--nexus-text-faint, #bbb);
+  font-size: 12px;
+  font-style: italic;
+`;
+
+const ITEM_STYLES = `
+  border-bottom: 1px solid var(--nexus-border-subtle, #f2f2f2);
+  padding: 10px 12px;
+`;
+
+const TITLE_STYLES = `
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--nexus-text, #24292e);
+  margin-bottom: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const META_STYLES = `
+  font-size: 11px;
+  color: var(--nexus-text-muted, #666);
+  margin-bottom: 6px;
+`;
+
+const SUMMARY_STYLES = `
+  font-size: 12px;
+  color: var(--nexus-text, #444);
+  margin-bottom: 8px;
+  line-height: 1.4;
+`;
+
+const ACTION_ROW_STYLES = `
+  display: flex;
+  gap: 8px;
+`;
+
+const ACTION_BTN_STYLES = `
+  border: 1px solid var(--nexus-border, #ddd);
+  background: var(--nexus-bg, #fff);
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--nexus-text, #333);
+`;
+
+function formatTimestamp(iso: string): string {
+  const dt = new Date(iso);
+  if (Number.isNaN(dt.getTime())) return iso;
+  return dt.toLocaleString();
+}
+
+export function createHistoryPanel(options: HistoryPanelOptions): HistoryPanel {
+  const root = document.createElement("aside");
+  root.className = "nexus-history-panel";
+  root.style.cssText = PANEL_STYLES;
+
+  const header = document.createElement("div");
+  header.style.cssText = HEADER_STYLES;
+  header.textContent = "History";
+
+  const list = document.createElement("div");
+  list.style.cssText = LIST_STYLES;
+
+  root.append(header, list);
+
+  function update(): void {
+    const snapshots = options.getSnapshots();
+    list.textContent = "";
+
+    if (snapshots.length === 0) {
+      const empty = document.createElement("div");
+      empty.style.cssText = EMPTY_STYLES;
+      empty.textContent = "No snapshots yet";
+      list.appendChild(empty);
+      return;
+    }
+
+    for (const snapshot of snapshots) {
+      const item = document.createElement("section");
+      item.style.cssText = ITEM_STYLES;
+      item.dataset.snapshotId = snapshot.id;
+
+      const title = document.createElement("div");
+      title.style.cssText = TITLE_STYLES;
+      title.textContent = snapshot.title;
+      title.title = snapshot.title;
+
+      const meta = document.createElement("div");
+      meta.style.cssText = META_STYLES;
+      meta.textContent = `${snapshot.filePath ?? "Untitled"} · ${formatTimestamp(snapshot.createdAt)}`;
+
+      const summary = document.createElement("div");
+      summary.style.cssText = SUMMARY_STYLES;
+      summary.textContent = snapshot.summary;
+
+      const actions = document.createElement("div");
+      actions.style.cssText = ACTION_ROW_STYLES;
+
+      const restoreBtn = document.createElement("button");
+      restoreBtn.type = "button";
+      restoreBtn.textContent = "Restore";
+      restoreBtn.style.cssText = ACTION_BTN_STYLES;
+      restoreBtn.addEventListener("click", () => options.onRestore(snapshot));
+
+      const reuseBtn = document.createElement("button");
+      reuseBtn.type = "button";
+      reuseBtn.textContent = "Reuse";
+      reuseBtn.style.cssText = ACTION_BTN_STYLES;
+      reuseBtn.addEventListener("click", () => options.onReuse(snapshot));
+
+      actions.append(restoreBtn, reuseBtn);
+      item.append(title, meta, summary, actions);
+      list.appendChild(item);
+    }
+  }
+
+  update();
+
+  return {
+    element: root,
+    update,
+    destroy() {
+      root.remove();
+    },
+  };
+}

--- a/apps/electron-demo/src/renderer/snapshot-entry.ts
+++ b/apps/electron-demo/src/renderer/snapshot-entry.ts
@@ -1,0 +1,9 @@
+export interface SnapshotEntry {
+  id: string;
+  docKey: string;
+  filePath: string | null;
+  title: string;
+  content: string;
+  createdAt: string;
+  summary: string;
+}

--- a/apps/electron-demo/src/renderer/state.ts
+++ b/apps/electron-demo/src/renderer/state.ts
@@ -1,4 +1,5 @@
 import type { LinkIndex } from "./link-index";
+import type { SnapshotEntry } from "../../electron/snapshots";
 
 export interface AppState {
   filePath: string | null;
@@ -9,6 +10,7 @@ export interface AppState {
   vaultTree: VaultNode[];
   activeFile: string | null;
   linkIndex: LinkIndex | null;
+  snapshots: SnapshotEntry[];
 }
 
 export function createState(): AppState {
@@ -21,5 +23,6 @@ export function createState(): AppState {
     vaultTree: [],
     activeFile: null,
     linkIndex: null,
+    snapshots: [],
   };
 }

--- a/apps/electron-demo/src/renderer/state.ts
+++ b/apps/electron-demo/src/renderer/state.ts
@@ -1,11 +1,12 @@
 import type { LinkIndex } from "./link-index";
-import type { SnapshotEntry } from "../../electron/snapshots";
+import type { SnapshotEntry } from "./snapshot-entry";
 
 export interface AppState {
   filePath: string | null;
   content: string;
   dirty: boolean;
   error: string | null;
+  statusMessage: string | null;
   vaultPath: string | null;
   vaultTree: VaultNode[];
   activeFile: string | null;
@@ -19,6 +20,7 @@ export function createState(): AppState {
     content: "",
     dirty: false,
     error: null,
+    statusMessage: null,
     vaultPath: null,
     vaultTree: [],
     activeFile: null,

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -99,3 +99,7 @@ body,
 .cm-editor .hljs-deletion { color: #dc322f; }
 .cm-editor .hljs-variable,
 .cm-editor .hljs-template-variable { color: #cb4b16; }
+
+.nexus-history-panel button:hover {
+  background: var(--nexus-bg-muted, #f5f5f5);
+}

--- a/apps/electron-demo/test/history-panel.test.ts
+++ b/apps/electron-demo/test/history-panel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHistoryPanel } from "../src/renderer/history-panel";
+import type { SnapshotEntry } from "../electron/snapshots";
+
+function makeSnapshot(overrides: Partial<SnapshotEntry> = {}): SnapshotEntry {
+  return {
+    id: "snap-1",
+    docKey: "doc-a",
+    filePath: "/tmp/a.md",
+    title: "Snapshot title",
+    content: "# Hello",
+    createdAt: "2026-05-13T12:00:00.000Z",
+    summary: "# Hello",
+    ...overrides,
+  };
+}
+
+describe("history panel", () => {
+  it("renders an empty state when there are no snapshots", () => {
+    const panel = createHistoryPanel({
+      getSnapshots: () => [],
+      onRestore: vi.fn(),
+      onReuse: vi.fn(),
+    });
+
+    expect(panel.element.textContent).toContain("No snapshots yet");
+  });
+
+  it("renders snapshots and wires restore/reuse actions", () => {
+    const onRestore = vi.fn();
+    const onReuse = vi.fn();
+    const snapshot = makeSnapshot();
+    const panel = createHistoryPanel({
+      getSnapshots: () => [snapshot],
+      onRestore,
+      onReuse,
+    });
+
+    const buttons = panel.element.querySelectorAll("button");
+    expect(panel.element.textContent).toContain("Snapshot title");
+    expect(buttons).toHaveLength(2);
+
+    buttons[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    buttons[1].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onRestore).toHaveBeenCalledWith(snapshot);
+    expect(onReuse).toHaveBeenCalledWith(snapshot);
+  });
+});

--- a/apps/electron-demo/test/history-panel.test.ts
+++ b/apps/electron-demo/test/history-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHistoryPanel } from "../src/renderer/history-panel";
-import type { SnapshotEntry } from "../electron/snapshots";
+import type { SnapshotEntry } from "../src/renderer/snapshot-entry";
 
 function makeSnapshot(overrides: Partial<SnapshotEntry> = {}): SnapshotEntry {
   return {

--- a/apps/electron-demo/test/snapshots.test.ts
+++ b/apps/electron-demo/test/snapshots.test.ts
@@ -15,8 +15,9 @@ describe("snapshot helpers", () => {
     expect(normalizeDocKey("C:\\vault\\note.md")).toBe("C:/vault/note.md");
   });
 
-  it("summarizes the first non-empty line", () => {
-    expect(summarizeSnapshot("\n\n# Heading\nbody")).toBe("# Heading");
+  it("prefers the first non-heading line in the summary", () => {
+    expect(summarizeSnapshot("\n\n# Heading\nbody")).toBe("body");
+    expect(summarizeSnapshot("\n\n# Heading")).toBe("# Heading");
     expect(summarizeSnapshot("")).toBe("(empty document)");
   });
 

--- a/apps/electron-demo/test/snapshots.test.ts
+++ b/apps/electron-demo/test/snapshots.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   addSnapshot,
+  assertSnapshotContentSize,
+  createSnapshotDocumentRef,
   createEmptySnapshotStore,
   createSnapshotEntry,
+  DEFAULT_SNAPSHOT_CONTENT_BYTES,
   listSnapshots,
   normalizeDocKey,
   parseSnapshotStore,
@@ -12,7 +15,15 @@ import {
 describe("snapshot helpers", () => {
   it("normalizes null file paths to the untitled document scope", () => {
     expect(normalizeDocKey(null)).toBe("untitled");
-    expect(normalizeDocKey("C:\\vault\\note.md")).toBe("C:/vault/note.md");
+    expect(normalizeDocKey("C:\\vault\\note.md")).toContain("vault");
+  });
+
+  it("derives a document ref from the file path boundary", () => {
+    expect(createSnapshotDocumentRef(null)).toEqual({
+      documentId: "untitled",
+      filePath: null,
+    });
+    expect(createSnapshotDocumentRef("/tmp/a.md").filePath).toBe("/tmp/a.md");
   });
 
   it("prefers the first non-heading line in the summary", () => {
@@ -44,7 +55,13 @@ describe("snapshot helpers", () => {
     expect(items[0].summary).toBe("# Two");
   });
 
-  it("falls back to an empty store on corrupt persisted data", () => {
-    expect(parseSnapshotStore("{not-json")).toEqual(createEmptySnapshotStore());
+  it("rejects snapshot content above the byte cap", () => {
+    expect(() => {
+      assertSnapshotContentSize("a".repeat(DEFAULT_SNAPSHOT_CONTENT_BYTES + 1));
+    }).toThrow(/exceeds/i);
+  });
+
+  it("throws on corrupt persisted data", () => {
+    expect(() => parseSnapshotStore("{not-json")).toThrow();
   });
 });

--- a/apps/electron-demo/test/snapshots.test.ts
+++ b/apps/electron-demo/test/snapshots.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  addSnapshot,
+  createEmptySnapshotStore,
+  createSnapshotEntry,
+  listSnapshots,
+  normalizeDocKey,
+  parseSnapshotStore,
+  summarizeSnapshot,
+} from "../electron/snapshots";
+
+describe("snapshot helpers", () => {
+  it("normalizes null file paths to the untitled document scope", () => {
+    expect(normalizeDocKey(null)).toBe("untitled");
+    expect(normalizeDocKey("C:\\vault\\note.md")).toBe("C:/vault/note.md");
+  });
+
+  it("summarizes the first non-empty line", () => {
+    expect(summarizeSnapshot("\n\n# Heading\nbody")).toBe("# Heading");
+    expect(summarizeSnapshot("")).toBe("(empty document)");
+  });
+
+  it("adds newest snapshots first and enforces retention", () => {
+    const store = createEmptySnapshotStore();
+    const first = createSnapshotEntry({
+      docKey: "doc-a",
+      filePath: "/tmp/a.md",
+      content: "# One",
+      createdAt: "2026-05-13T10:00:00.000Z",
+    });
+    const second = createSnapshotEntry({
+      docKey: "doc-a",
+      filePath: "/tmp/a.md",
+      content: "# Two",
+      createdAt: "2026-05-13T11:00:00.000Z",
+    });
+
+    const withFirst = addSnapshot(store, first, 1);
+    const withSecond = addSnapshot(withFirst, second, 1);
+
+    const items = listSnapshots(withSecond, "doc-a");
+    expect(items).toHaveLength(1);
+    expect(items[0].summary).toBe("# Two");
+  });
+
+  it("falls back to an empty store on corrupt persisted data", () => {
+    expect(parseSnapshotStore("{not-json")).toEqual(createEmptySnapshotStore());
+  });
+});

--- a/apps/electron-demo/test/state.test.ts
+++ b/apps/electron-demo/test/state.test.ts
@@ -8,5 +8,6 @@ describe("createState", () => {
     expect(state.content).toBe("");
     expect(state.dirty).toBe(false);
     expect(state.error).toBeNull();
+    expect(state.statusMessage).toBeNull();
   });
 });

--- a/openspec/changes/add-snapshot-history/design.md
+++ b/openspec/changes/add-snapshot-history/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The product direction increasingly points toward local-first note and writing workflows. The electron demo already has vault navigation, slash commands, live preview, and file persistence, but it still lacks a lightweight mechanism for checkpointing document evolution beyond linear undo/redo.
+
+The requested user value is practical rather than archival:
+- "What did I have a few minutes ago?"
+- "Can I roll back to a previous draft?"
+- "Can I reuse an earlier draft without overwriting the current note?"
+
+That makes full-blown version-control semantics unnecessary for v1. We can satisfy the workflow with host-managed snapshots in the demo app.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let users manually create a named-or-untitled snapshot of the current editor content.
+- Let users view recent snapshots for the active document in reverse chronological order.
+- Let users restore a snapshot into the current editor session.
+- Let users reuse a snapshot as a new unsaved draft, so old content can seed a fresh edit without mutating the original file on disk.
+- Persist snapshots across app restarts.
+- Keep the implementation small, testable, and entirely within `apps/electron-demo`.
+
+**Non-Goals:**
+- Automatic time-travel on every keystroke.
+- Cross-device sync, collaboration, CRDT, or Git integration.
+- Prompt history, model output history, or AI conversation state.
+- A public snapshot API in `@floatboat/nexus-core`.
+- Branching timelines, diffs, merge UI, or retention policies beyond a simple cap.
+
+## Decisions
+
+**Decision: Scope v1 to Electron demo, not `@floatboat/nexus-core`.**
+The core editor is intentionally storage-agnostic and single-document oriented. Snapshots require persistence, file identity, retention, and UI decisions that belong to the host app. Keeping this in the demo avoids prematurely locking the core into a storage contract that other hosts may not want.
+
+Alternatives considered:
+- Add snapshot primitives to `@floatboat/nexus-core`: rejected because core should not own persistence concerns.
+- Create a reusable `plugin-snapshots` package immediately: rejected because there is only one host implementation today, and the right abstraction is not yet proven.
+
+**Decision: Manual snapshots only for v1.**
+Manual snapshots provide clear user intent and avoid complex policies around debounce intervals, snapshot spam, and retention pressure. They also keep testing and UX straightforward.
+
+Alternatives considered:
+- Auto-snapshot on every save: useful, but easy to add later once the storage and panel UX exist.
+- Auto-snapshot on timer or debounce: rejected as too noisy for the first slice.
+
+**Decision: Persist snapshots in `app.getPath("userData")/snapshots.json`.**
+This matches the existing vault persistence pattern and avoids new dependencies. The storage file will contain an index keyed by document identity, plus a per-document list of snapshot entries.
+
+**Decision: Key snapshots by document identity with an untitled fallback.**
+For saved files, the key is the normalized absolute path.
+For unsaved docs, the key is a synthetic scope such as `untitled`.
+This keeps retrieval deterministic while still allowing snapshots before first save.
+
+**Decision: "Reuse" means load snapshot content as a new unsaved draft.**
+This best matches the product language without requiring duplication-on-disk flows. Reusing a snapshot clears the active file association in the renderer state, marks the document dirty, and lets the user decide where to save it.
+
+Alternatives considered:
+- "Reuse" as copy-to-clipboard: too weak, does not feel like a real editing workflow.
+- "Reuse" as create sibling file automatically: too opinionated and would require naming UX plus filesystem writes.
+
+**Decision: Retain a bounded number of snapshots per document.**
+Keep the newest `N` snapshots per document, with `N = 20` as the proposed default. This prevents unbounded growth while remaining generous enough for demo use.
+
+## Data Model
+
+Suggested persisted shape:
+
+```ts
+interface SnapshotEntry {
+  id: string;
+  docKey: string;
+  filePath: string | null;
+  title: string;
+  content: string;
+  createdAt: string; // ISO timestamp
+  summary: string;   // first non-empty line or truncated preview
+}
+
+interface SnapshotStore {
+  byDocument: Record<string, SnapshotEntry[]>;
+}
+```
+
+Notes:
+- `title` is display-oriented metadata, not a required user-entered field.
+- `summary` avoids rendering full document content in the list by default.
+- `content` stores the full markdown payload so restore/reuse does not need the original file to still exist.
+
+## UI Flow
+
+Renderer additions:
+- A toolbar action or button: `Snapshot`
+- A side panel: `History`
+- Each history item shows:
+  - timestamp,
+  - file label / untitled label,
+  - summary preview,
+  - actions: `Restore`, `Reuse`
+
+Behavior:
+- `Restore` replaces the current editor document after a dirty-state confirmation when needed.
+- `Reuse` loads the snapshot content into the editor as a new unsaved draft:
+  - `state.filePath = null`
+  - `state.activeFile = null`
+  - `state.dirty = true`
+
+## Risks / Trade-offs
+
+- **Snapshot list grows large** → bounded retention per document mitigates this.
+- **Unsaved-document identity is coarse** → acceptable for v1; later iterations can add per-session untitled ids if needed.
+- **Restore may surprise users if it mutates the current document abruptly** → confirm when dirty and keep the action clearly labeled.
+- **Storage file corruption** → follow the vault-state pattern: fall back to an empty store if JSON parse fails.
+
+## Migration Plan
+
+Net-additive only. No existing user data needs migration.
+
+If the project later introduces a generalized snapshot service or a reusable package, the demo's `snapshots.json` format can be migrated in place because each snapshot entry is self-contained.
+
+## Open Questions
+
+- Should saving a file optionally create a snapshot automatically after v1?
+- Should the panel allow deletion of individual snapshots in v1, or is bounded retention sufficient?
+- Should snapshot timestamps be grouped by day in the UI, or kept as a flat list for the first implementation?

--- a/openspec/changes/add-snapshot-history/proposal.md
+++ b/openspec/changes/add-snapshot-history/proposal.md
@@ -1,0 +1,42 @@
+# Change: Add Snapshot History to Electron Demo
+
+## Why
+
+The electron demo currently supports only immediate undo/redo and normal file save flows. Users cannot inspect older document states, restore a known-good revision, or reuse a previous draft as the starting point for a new edit. This is especially limiting for note-taking and AI-assisted writing workflows, where users often want lightweight checkpoints without introducing full collaboration or Git-style versioning.
+
+The roadmap already includes `#19 Version history / snapshots | core + host storage | P2 | planned`, with a note that the electron demo should land the reference implementation first. This change proposes that reference implementation with a deliberately narrow scope: local snapshot history for the demo app, with no changes to cloud sync, collaboration, or prompt orchestration.
+
+## What Changes
+
+- Add a **Snapshot History** capability to `apps/electron-demo` for the currently active document.
+- Allow users to create **manual snapshots** from the UI.
+- Persist recent snapshots in host-managed storage under Electron `userData`, keyed by document identity.
+- Provide a renderer-side history panel that lets users:
+  - inspect recent snapshots,
+  - restore a snapshot into the editor,
+  - reuse a snapshot as a new unsaved draft.
+- Add dirty-state safeguards before destructive restore actions.
+- Keep the implementation **host-side only** for v1: `@floatboat/nexus-core` remains document-centric and storage-agnostic.
+
+## Impact
+
+- Affected specs: `snapshot-history` (new capability)
+- Affected code:
+  - `apps/electron-demo/electron/main.ts` (snapshot persistence + IPC)
+  - `apps/electron-demo/electron/preload.ts` (bridge)
+  - `apps/electron-demo/src/renderer/bridge.d.ts` (types)
+  - `apps/electron-demo/src/renderer/state.ts` (snapshot UI state)
+  - `apps/electron-demo/src/renderer/app.ts` (toolbar + panel wiring)
+  - `apps/electron-demo/src/renderer/history-panel.ts` (new)
+  - `apps/electron-demo/src/renderer/style.css` (panel styles)
+  - tests for main-process storage and renderer panel behavior
+- No new runtime dependencies required; snapshots are stored as JSON in Electron `userData`.
+- Back-compat:
+  - normal Open / Save / Save As flows remain unchanged,
+  - undo/redo remains unchanged,
+  - no changes to public `@floatboat/nexus-core` APIs in this proposal.
+
+## Notes
+
+- This proposal intentionally covers **document snapshots**, not AI prompt history. Prompt history can later build on the same persistence and UI patterns, but is out of scope for a two-day reference PR.
+- This proposal is a natural first slice of roadmap item `#19 Version history / snapshots`.

--- a/openspec/changes/add-snapshot-history/specs/snapshot-history/spec.md
+++ b/openspec/changes/add-snapshot-history/specs/snapshot-history/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Manual Snapshot Creation
+
+The electron demo SHALL allow the user to create a manual snapshot of the current editor document, capturing the full markdown content together with timestamped metadata.
+
+#### Scenario: Create snapshot for a saved file
+- **WHEN** a saved document is open in the editor
+- **AND** the user triggers the snapshot action
+- **THEN** a new snapshot entry SHALL be persisted for that document's file identity
+- **AND** the snapshot SHALL include the full markdown content, a created-at timestamp, and a human-readable summary
+
+#### Scenario: Create snapshot for an unsaved document
+- **WHEN** the current document has no file path
+- **AND** the user triggers the snapshot action
+- **THEN** a new snapshot entry SHALL be persisted under the unsaved-document scope
+- **AND** snapshot creation SHALL succeed without requiring the user to save first
+
+### Requirement: Snapshot Listing
+
+The electron demo SHALL let the user inspect recent snapshots for the currently active document in reverse chronological order.
+
+#### Scenario: Show newest snapshot first
+- **WHEN** the active document has multiple snapshots
+- **THEN** the history panel SHALL render the newest snapshot before older ones
+
+#### Scenario: Empty history state
+- **WHEN** the active document has no snapshots
+- **THEN** the history panel SHALL show a clear empty state
+- **AND** the absence of snapshots SHALL NOT be treated as an error
+
+### Requirement: Snapshot Restore
+
+The electron demo SHALL allow the user to restore a selected snapshot into the current editor session.
+
+#### Scenario: Restore snapshot into a clean editor
+- **WHEN** the user selects `Restore` on a snapshot
+- **AND** the current editor session is not dirty
+- **THEN** the editor content SHALL be replaced with the snapshot content
+- **AND** the restored document SHALL remain associated with the current file path when one exists
+
+#### Scenario: Restore snapshot with unsaved changes
+- **WHEN** the user selects `Restore` on a snapshot
+- **AND** the current editor session is dirty
+- **THEN** the app SHALL prompt for confirmation before replacing the document
+- **AND** declining the prompt SHALL leave the current editor content unchanged
+
+### Requirement: Snapshot Reuse as New Draft
+
+The electron demo SHALL allow the user to reuse a selected snapshot as a new unsaved draft rather than overwriting the current file session.
+
+#### Scenario: Reuse snapshot clears active file association
+- **WHEN** the user selects `Reuse` on a snapshot
+- **THEN** the snapshot content SHALL be loaded into the editor
+- **AND** the current renderer state SHALL no longer point at an active file path
+- **AND** the document SHALL be marked dirty so the user can choose a save destination explicitly
+
+### Requirement: Snapshot Persistence
+
+Snapshot history SHALL persist across electron-demo app restarts using host-managed local storage.
+
+#### Scenario: Snapshot available after relaunch
+- **WHEN** the user creates a snapshot and closes the app
+- **AND** the app is launched again later
+- **THEN** the snapshot SHALL still appear in the history list for the same document identity
+
+#### Scenario: Corrupt snapshot store fallback
+- **WHEN** the persisted snapshot storage file cannot be parsed
+- **THEN** the app SHALL fall back to an empty snapshot store
+- **AND** snapshot listing SHALL remain functional for newly created entries
+
+### Requirement: Bounded Retention
+
+The electron demo SHALL retain only a bounded number of the most recent snapshots per document.
+
+#### Scenario: Oldest snapshot is dropped after reaching the cap
+- **WHEN** the number of snapshots for one document exceeds the configured retention cap
+- **THEN** the oldest snapshot SHALL be removed from persisted storage
+- **AND** the newest snapshots SHALL be preserved

--- a/openspec/changes/add-snapshot-history/tasks.md
+++ b/openspec/changes/add-snapshot-history/tasks.md
@@ -1,0 +1,29 @@
+## 1. OpenSpec
+- [x] 1.1 Scaffold `proposal.md`, `design.md`, `tasks.md`, and `specs/snapshot-history/spec.md`
+- [ ] 1.2 Validate the change with `openspec validate add-snapshot-history --strict` (`openspec` CLI not installed in the local environment)
+
+## 2. Main-process Persistence + IPC
+- [x] 2.1 Add snapshot store read/write helpers in `apps/electron-demo/electron/main.ts`
+- [x] 2.2 Persist snapshots in `userData/snapshots.json` with graceful fallback on missing/corrupt files
+- [x] 2.3 Add IPC to create a snapshot for the current document
+- [x] 2.4 Add IPC to list snapshots for a document key
+- [x] 2.5 Enforce bounded retention per document (default 20 newest entries)
+
+## 3. Preload + Types
+- [x] 3.1 Extend `preload.ts` with `nexusDemo.snapshots.*`
+- [x] 3.2 Extend `bridge.d.ts` with `SnapshotEntry` and snapshot bridge types
+
+## 4. Renderer
+- [x] 4.1 Extend renderer state with currently loaded snapshots
+- [x] 4.2 Add `history-panel.ts` to render the snapshot list and actions
+- [x] 4.3 Add a toolbar button or entry point to create a manual snapshot
+- [x] 4.4 Wire panel refresh when the active document changes or a new snapshot is created
+- [x] 4.5 Implement `Restore` with dirty-state confirmation
+- [x] 4.6 Implement `Reuse` as a new unsaved draft loaded into the editor
+- [x] 4.7 Add snapshot panel styles in `style.css`
+
+## 5. Verification
+- [x] 5.1 Add tests for snapshot storage helpers
+- [x] 5.2 Add renderer tests for history panel rendering and restore/reuse actions
+- [x] 5.3 Run relevant test suites and electron-demo build successfully
+- [ ] 5.4 Manually smoke-test: create snapshot, relaunch app, restore snapshot, reuse snapshot as new draft


### PR DESCRIPTION
## 背景

在阅读项目现有能力后，我选择围绕 `apps/electron-demo` 补充一项更贴近 AI 编辑工作流的能力：允许用户查看、恢复、复用历史编辑快照。

这个方向一方面能够增强 demo 的可用性，另一方面也比较适合以较小范围完成一条相对完整的功能闭环，包括设计、实现、测试与验证。

## 本次改动

### 1. 新增手动快照能力
- 在工具栏增加 `Snapshot` 入口
- 支持对当前文档创建手动快照
- 快照数据持久化到本地 `snapshots.json`

### 2. 新增 History 面板
- 支持查看当前文档的历史快照列表
- 展示快照标题、摘要、时间、来源文件

### 3. 支持两种历史复用方式
- `Restore`：恢复到指定历史版本
- `Reuse`：将指定历史版本作为新的未保存草稿继续编辑

### 4. 补充交互与可用性修复
- 创建快照时直接读取当前编辑器内容，避免防抖状态导致内容滞后
- 打开 History 时自动收起部分侧边栏，避免编辑区域被遮挡
- 优化快照摘要展示，提升不同版本的可区分度，便于手工测试和实际使用

### 5. 补充文档与测试
- 增加 `openspec/changes/add-snapshot-history/` 相关 proposal / design / tasks / spec
- 为 snapshot helper 和 history panel 补充测试

## 设计取舍

本次实现限定在 `apps/electron-demo` 内，没有直接下沉到核心包，主要考虑是：

- 该能力当前更偏向桌面端本地编辑场景
- 涉及 Electron 文件持久化与本地交互
- 先在 demo 层验证交互模型和数据结构，更利于控制改动范围

如果后续需要进一步产品化，可以再评估抽象为通用历史能力。

## 验证情况

已完成以下验证：

- `vitest` 相关单测通过
- `openspec validate add-snapshot-history --strict` 通过
- Electron demo 手工 smoke test 通过

手工验证包括：
- 打开 Markdown 文件
- 创建多条 snapshot
- 在 History 中查看历史记录
- `Restore` 恢复指定版本
- `Reuse` 复用为新的未保存草稿

## 后续可扩展方向

- 自动 snapshot / 定时 snapshot
- snapshot 删除与重命名
- diff 预览
- 跨文档历史检索

