### PR TITLE
feat(editor): add getSelectedText(), multi-line list toggle, and atomic replaceRange

### DIFF
--- a/openspec/changes/add-selection-api/proposal.md
+++ b/openspec/changes/add-selection-api/proposal.md
@@ -1,0 +1,14 @@
+# Change: Add getSelectedText, replaceRange, and range-aware list toggles
+
+## Why
+The EditorAPI lacked a primitive for reading the current selection as a string, and had no atomic way to replace a document range while also repositioning the cursor. Without `replaceRange`, callers had to call `setDocument` then `setSelection` as two separate CM6 transactions — producing two undo entries, which caused Ctrl+Z to leave the document in a half-reverted state. The toolbar list-toggle commands were also selection-unaware: they read only `anchor`, silently collapsing multi-line selections to a single line.
+
+## What Changes
+- **ADDED** `getSelectedText(): string` to EditorAPI — returns the selected text, normalizing reversed selections; returns empty string when collapsed
+- **ADDED** `replaceRange(from, to, insert, selection?, opts?)` to EditorAPI — replaces `[from, to)` and optionally repositions selection in one CM6 transaction (one undo entry); supports `silent` to mirror `setDocument` semantics
+- **MODIFIED** `toggleOrderedList` and `toggleUnorderedList` in plugin-toolbar — now read the full selection range and apply markers to every line in the range; all-marked → remove, any-unmarked → add (mixed → on); column-0 boundary: line at `to` column 0 is excluded; reversed selections are normalized
+
+## Impact
+- Affected specs: editor-core, plugin-toolbar
+- Affected code: `packages/core/src/types.ts`, `packages/core/src/editor.ts`, `packages/plugin-toolbar/src/formatting.ts`
+- **No breaking changes** to existing API

--- a/openspec/changes/add-selection-api/specs/editor-core/spec.md
+++ b/openspec/changes/add-selection-api/specs/editor-core/spec.md
@@ -1,0 +1,53 @@
+# Editor Core Spec
+
+## ADDED Requirements
+
+### Requirement: provide getSelectedText on EditorAPI
+
+`editor.getSelectedText()` SHALL return the text currently selected in the editor. When the selection is collapsed (anchor === head) it SHALL return an empty string. Reversed selections (head < anchor) SHALL be normalized so the returned string is always the span between the lower and higher position.
+
+#### Scenario: Collapsed selection returns empty string
+- **WHEN** `setSelection(5)` is called (collapsed cursor)
+- **THEN** `getSelectedText()` SHALL return `""`
+
+#### Scenario: Forward selection returns selected slice
+- **WHEN** `setSelection(6, 11)` is called on document `"hello world"`
+- **THEN** `getSelectedText()` SHALL return `"world"`
+
+#### Scenario: Reversed selection is normalized
+- **WHEN** `setSelection(11, 6)` is called (anchor=11, head=6)
+- **THEN** `getSelectedText()` SHALL return `"world"` (same as forward selection)
+
+#### Scenario: Multi-line selection preserves newlines
+- **WHEN** `setSelection(0, 17)` is called on document `"line one\nline two\nline three"`
+- **THEN** `getSelectedText()` SHALL return `"line one\nline two"` with the embedded newline intact
+
+### Requirement: provide replaceRange on EditorAPI
+
+`editor.replaceRange(from, to, insert, selection?, opts?)` SHALL replace the substring `[from, to)` with `insert` and — optionally — reposition the cursor/selection, **all in a single CM6 transaction**. One transaction SHALL produce exactly one undo entry: a single Ctrl+Z SHALL revert both the text change and the cursor move together.
+
+- `selection` is optional. When omitted, CM6 maps the existing selection through the change using its default position mapping.
+- `opts.silent` mirrors `setDocument`: when `true`, the `onChange` event SHALL NOT fire, but `getAst()` SHALL remain consistent for immediate callers.
+- `from`, `to`, and `selection` offsets are in pre-edit document coordinates (same space as `getSelection()` returns).
+- Callers are responsible for valid offsets; CM6 throws `RangeError` on out-of-bounds values.
+
+#### Scenario: Basic range replacement changes document content
+- **WHEN** `replaceRange(6, 11, "earth")` is called on document `"hello world"`
+- **THEN** `getDocument()` SHALL return `"hello earth"`
+
+#### Scenario: Selection is repositioned in the same dispatch
+- **WHEN** `replaceRange(0, 5, "hi", { anchor: 0, head: 2 })` is called
+- **THEN** `getDocument()` SHALL return `"hi world"` AND `getSelection()` SHALL return `{ anchor: 0, head: 2 }`
+
+#### Scenario: Collapsed range inserts without deleting
+- **WHEN** `replaceRange(5, 5, ",")` is called on document `"hello world"`
+- **THEN** `getDocument()` SHALL return `"hello, world"`
+
+#### Scenario: silent option suppresses onChange but keeps AST consistent
+- **WHEN** `replaceRange(0, 5, "# Title", undefined, { silent: true })` is called
+- **THEN** the `onChange` handler SHALL NOT be called AND `getAst().type` SHALL equal `"root"`
+
+#### Scenario: replaceRange produces exactly one undo entry
+- **WHEN** `replaceRange` is called and then `undo()` is called once
+- **THEN** the document SHALL be fully restored to its state before `replaceRange`
+- **AND** a second `undo()` SHALL return `false` (no further history entry exists)

--- a/openspec/changes/add-selection-api/specs/plugin-toolbar/spec.md
+++ b/openspec/changes/add-selection-api/specs/plugin-toolbar/spec.md
@@ -1,0 +1,52 @@
+# Plugin Toolbar Spec
+
+## MODIFIED Requirements
+
+### Requirement: toggleOrderedList and toggleUnorderedList operate on all lines in the selection range
+
+`toggleOrderedList` and `toggleUnorderedList` SHALL read the full selection range (both `anchor` and `head`) and apply or remove markers on every line that overlaps `[min(anchor,head), max(anchor,head))`. The toggle decision SHALL follow mixed-state-on semantics: if **all** lines already carry the marker the markers SHALL be removed; if **any** line is unmarked the marker SHALL be added to every line.
+
+Toggle state detection:
+- Ordered list marker: `/^\d+\.\s/`
+- Unordered list marker: `/^[-*+]\s/`
+- Cross-marker replacement: toggling ordered on a line with an unordered marker (or vice versa) SHALL strip the existing marker and apply the new one in the same operation.
+
+Column-0 boundary: when the selection ends exactly at column 0 of a line (i.e. `to` equals the start of that line), that line SHALL be excluded from the range.
+
+Reversed selection: when `head < anchor` the range SHALL be normalized using `Math.min`/`Math.max` before line enumeration.
+
+All line transformations SHALL be written back in **one atomic CM6 transaction** via `replaceRange` so that a single Ctrl+Z fully restores the pre-toggle state.
+
+#### Scenario: Multi-line add — all lines unmarked
+- **WHEN** selection spans two unmarked lines and `toggleUnorderedList` is called
+- **THEN** both lines SHALL have `"- "` prepended
+- **AND** the change SHALL be reversible with a single `undo()`
+
+#### Scenario: Multi-line remove — all lines marked
+- **WHEN** selection spans two lines that both have `"- "` markers and `toggleUnorderedList` is called
+- **THEN** both markers SHALL be removed
+
+#### Scenario: Mixed state toggles on
+- **WHEN** selection spans two lines where one has a marker and one does not
+- **THEN** `toggleUnorderedList` SHALL add a marker to the unmarked line (mixed → on)
+
+#### Scenario: Reversed selection is normalized
+- **WHEN** `head < anchor` and the range spans two lines
+- **THEN** both lines SHALL be toggled as if the selection were forward
+
+#### Scenario: Column-0 boundary excludes trailing line
+- **WHEN** selection ends at the start of a line (column 0)
+- **THEN** that trailing line SHALL NOT receive a marker
+
+#### Scenario: Cross-marker replacement ordered → unordered
+- **WHEN** lines have `"1. "` markers and `toggleUnorderedList` is called
+- **THEN** the ordered markers SHALL be replaced with `"- "` markers
+
+#### Scenario: Sequential numbering for ordered list
+- **WHEN** `toggleOrderedList` is called on a multi-line selection
+- **THEN** lines SHALL be numbered sequentially starting at `1.`
+
+#### Scenario: Atomic undo for multi-line toggle
+- **WHEN** `toggleOrderedList` or `toggleUnorderedList` is called on a multi-line selection
+- **THEN** a single `undo()` SHALL fully restore the pre-toggle document
+- **AND** a second `undo()` SHALL return `false` (exactly one history entry was created)

--- a/openspec/changes/add-selection-api/tasks.md
+++ b/openspec/changes/add-selection-api/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: add-selection-api
+
+## Phase 1: Core API
+
+- [x] 1.1 Add `getSelectedText(): string` to `EditorAPI` interface in `packages/core/src/types.ts`
+- [x] 1.2 Implement `getSelectedText()` in `packages/core/src/editor.ts` — normalize with `Math.min/max`, slice doc
+- [x] 1.3 Add `replaceRange()` signature to `EditorAPI` interface in `packages/core/src/types.ts`
+- [x] 1.4 Implement `replaceRange()` in `packages/core/src/editor.ts` — single `view.dispatch` with `changes` + `selection`; inline AST resync when `silent: true`
+- [x] 1.5 Add focused core tests for `getSelectedText` in `packages/core/test/editor.test.ts`
+- [x] 1.6 Add focused core tests for `replaceRange` in `packages/core/test/editor.test.ts`
+
+## Phase 2: Toolbar list toggles
+
+- [x] 2.1 Add `getLinesInRange()` helper to `packages/plugin-toolbar/src/formatting.ts` — returns every line overlapping `[from, to)`, excludes column-0 boundary line
+- [x] 2.2 Add `applyLines()` helper — writes transformed lines back via `replaceRange` in one atomic transaction
+- [x] 2.3 Migrate `toggleOrderedList` to use `getLinesInRange` + `applyLines`
+- [x] 2.4 Migrate `toggleUnorderedList` to use `getLinesInRange` + `applyLines`
+- [x] 2.5 Add multi-line and atomic-undo tests in `packages/plugin-toolbar/test/plugin-toolbar.test.ts`

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -409,6 +409,12 @@ export function createEditor(config: EditorConfig): EditorAPI {
       const sel = view.state.selection.main;
       return { anchor: sel.anchor, head: sel.head };
     },
+    getSelectedText() {
+      const sel = view.state.selection.main;
+      const from = Math.min(sel.anchor, sel.head);
+      const to = Math.max(sel.anchor, sel.head);
+      return view.state.doc.sliceString(from, to);
+    },
     getSlashCommands() {
       return slashCommands;
     },
@@ -459,6 +465,26 @@ export function createEditor(config: EditorConfig): EditorAPI {
     replaceSelection(text) {
       if (destroyed) return;
       view.dispatch(view.state.replaceSelection(text));
+    },
+    replaceRange(from, to, insert, selection, opts) {
+      if (destroyed) return;
+      const silent = opts?.silent === true;
+      view.dispatch({
+        changes: { from, to, insert },
+        selection: selection
+          ? { anchor: selection.anchor, head: selection.head ?? selection.anchor }
+          : undefined,
+        scrollIntoView: true,
+        annotations: silent ? silentDocChange.of(true) : undefined,
+      });
+      if (silent) {
+        const next = view.state.doc.toString();
+        if (customParser) {
+          currentAst = parseDocument(customParser, next);
+        } else {
+          currentAst = transformAst(lezerAstFromAnywhere(viewRef, next));
+        }
+      }
     },
     undo() {
       if (destroyed) return false;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -135,6 +135,8 @@ export interface EditorAPI {
   exportHTML(): string;
   setTheme(theme: import("./theme").NexusTheme): void;
   getSelection(): { anchor: number; head: number };
+  /** Returns the text currently selected in the editor. Returns an empty string when the selection is collapsed. */
+  getSelectedText(): string;
   getSlashCommands(): SlashCommandDef[];
   uploadAsset(file: File): Promise<string | null>;
   setSelection(anchor: number, head?: number): void;
@@ -147,6 +149,39 @@ export interface EditorAPI {
    */
   setDocument(next: string, opts?: { silent?: boolean }): void;
   replaceSelection(text: string): void;
+  /**
+   * Replace the substring `[from, to)` with `insert` and — optionally —
+   * move the selection, all in a single CM6 transaction.
+   *
+   * **One transaction = one undo entry.** A single Ctrl+Z will revert both
+   * the edit and the cursor/selection move together. Do NOT emulate this
+   * with a separate `setDocument`/`setSelection` pair — that dispatches two
+   * transactions, produces two undo entries, and leaves the document mangled
+   * after the first Ctrl+Z.
+   *
+   * - `selection` is optional. When omitted CM6 maps the existing selection
+   *   through the change using its default position mapping — callers that
+   *   don't care where the cursor lands after the edit can skip this.
+   * - `silent` mirrors `setDocument`: skips `onChange` / the `change` event.
+   *   The AST is still resynced inline so `getAst()` stays consistent for
+   *   immediate callers. Intended for non-user edits only (file-open, seeding).
+   *   Plugin code should leave `silent` unset.
+   * - Positions (`from`, `to`, and `selection` offsets) are in pre-edit doc
+   *   coordinates — the same coordinate space as `getSelection()` returns.
+   * - Bounds: callers are responsible for valid offsets. CM6 throws
+   *   `RangeError` on out-of-bounds values — identical trust model to
+   *   `setSelection`. No double validation is performed in this layer.
+   *
+   * Use this instead of `setDocument` when you are editing a range, not
+   * replacing the whole document.
+   */
+  replaceRange(
+    from: number,
+    to: number,
+    insert: string,
+    selection?: { anchor: number; head?: number },
+    opts?: { silent?: boolean }
+  ): void;
   undo(): boolean;
   redo(): boolean;
   focus(): void;

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -3,6 +3,7 @@ import { EditorView } from "@codemirror/view";
 import type { Plugin } from "unified";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEditor } from "../src/index";
+import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -388,6 +389,98 @@ describe("createEditor", () => {
     const editor = createEditor({ container, initialValue: "Just text." });
 
     expect(editor.getTableOfContents()).toEqual([]);
+    editor.destroy();
+  });
+
+  // ── getSelectedText ──
+
+  it("returns empty string when selection is collapsed", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(5);
+    expect(editor.getSelectedText()).toBe("");
+    editor.destroy();
+  });
+
+  it("returns the selected slice of the document", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(6, 11);
+    expect(editor.getSelectedText()).toBe("world");
+    editor.destroy();
+  });
+
+  it("normalizes reversed selection (head < anchor)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(11, 6); // anchor=11, head=6
+    expect(editor.getSelectedText()).toBe("world");
+    editor.destroy();
+  });
+
+  it("preserves newlines in multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "line one\nline two\nline three" });
+
+    editor.setSelection(0, 17); // "line one\nline two"
+    expect(editor.getSelectedText()).toBe("line one\nline two");
+    editor.destroy();
+  });
+
+  // ── replaceRange ──
+
+  it("replaceRange: replaces document content in the given range", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.replaceRange(6, 11, "earth");
+    expect(editor.getDocument()).toBe("hello earth");
+    editor.destroy();
+  });
+
+  it("replaceRange: repositions selection in the same dispatch", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.replaceRange(0, 5, "hi", { anchor: 0, head: 2 });
+    expect(editor.getDocument()).toBe("hi world");
+    expect(editor.getSelection()).toMatchObject({ anchor: 0, head: 2 });
+    editor.destroy();
+  });
+
+  it("replaceRange: collapsed range (from === to) inserts without deleting", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.replaceRange(5, 5, ",");
+    expect(editor.getDocument()).toBe("hello, world");
+    editor.destroy();
+  });
+
+  it("replaceRange: silent suppresses onChange but getAst() stays consistent", () => {
+    const container = document.createElement("div");
+    const onChange = vi.fn();
+    const editor = createEditor({ container, initialValue: "hello world", onChange });
+
+    onChange.mockClear();
+    editor.replaceRange(0, 11, "# Title", undefined, { silent: true });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(editor.getAst().type).toBe("root");
+    editor.destroy();
+  });
+
+  it("replaceRange: produces exactly one undo entry", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world", plugins: [createHistoryPlugin()] });
+
+    editor.replaceRange(6, 11, "earth");
+    expect(editor.getDocument()).toBe("hello earth");
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("hello world");
+    expect(editor.undo()).toBe(false);
     editor.destroy();
   });
 

--- a/packages/plugin-toolbar/package.json
+++ b/packages/plugin-toolbar/package.json
@@ -21,6 +21,9 @@
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.36.1"
   },
+  "devDependencies": {
+    "@floatboat/nexus-plugin-history": "workspace:*"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -1,26 +1,74 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
 
-/** Get the current line containing the anchor position. */
-function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineEnd: number; line: string } {
-  const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
-  const lineEndIdx = doc.indexOf("\n", anchor);
-  const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
-  return { lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) };
+interface LineRange {
+  lineStart: number;
+  lineEnd: number;
+  line: string;
+}
+
+/**
+ * Returns every line that overlaps the half-open range [from, to).
+ * When from === to (collapsed cursor) the single anchor line is returned.
+ * A line whose start equals `to` exactly is excluded — this matches the
+ * standard editor convention where selecting to column 0 of the next line
+ * does not include that line.
+ */
+function getLinesInRange(doc: string, from: number, to: number): LineRange[] {
+  const results: LineRange[] = [];
+  let pos = doc.lastIndexOf("\n", from - 1) + 1; // start of the first covered line
+
+  while (true) {
+    const lineEndIdx = doc.indexOf("\n", pos);
+    const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
+
+    if (pos < to || results.length === 0) {
+      results.push({ lineStart: pos, lineEnd, line: doc.slice(pos, lineEnd) });
+    }
+
+    if (lineEndIdx === -1 || lineEndIdx >= to) break;
+    pos = lineEndIdx + 1;
+  }
+
+  return results;
+}
+
+/**
+ * Writes `newLines` back over the span covered by `lines` in ONE atomic
+ * transaction, then sets the selection in the same dispatch so a single
+ * undo reverts both the edit and the cursor move.
+ *
+ *   Single-line  → collapsed cursor at end of the transformed line
+ *                  (preserves existing single-cursor toggle behaviour)
+ *   Multi-line   → selection covers the entire transformed block, so the
+ *                  user can immediately chain another toggle on the same
+ *                  range without re-selecting.
+ *
+ * Do NOT split this into separate replaceRange + setSelection calls —
+ * that would re-introduce the two-dispatch undo bug this function was
+ * extracted to fix. Case 4 of the atomic-undo test suite is the
+ * load-bearing regression guard for this constraint.
+ */
+function applyLines(editor: EditorAPI, lines: LineRange[], newLines: string[]): boolean {
+  const first = lines[0];
+  const last = lines[lines.length - 1];
+  const newBlock = newLines.join("\n");
+  const selection = lines.length === 1
+    ? { anchor: first.lineStart + newLines[0].length }
+    : { anchor: first.lineStart, head: first.lineStart + newBlock.length };
+  editor.replaceRange(first.lineStart, last.lineEnd, newBlock, selection);
+  return true;
 }
 
 /** Toggle a line prefix (e.g., "> " for blockquote). */
 function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   const doc = editor.getDocument();
   const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
+  const lineEndIdx = doc.indexOf("\n", anchor);
+  const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
+  const line = doc.slice(lineStart, lineEnd);
 
-  let newLine: string;
-  if (line.startsWith(prefix)) {
-    newLine = line.slice(prefix.length);
-  } else {
-    newLine = prefix + line;
-  }
-
+  const newLine = line.startsWith(prefix) ? line.slice(prefix.length) : prefix + line;
   const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
   editor.setDocument(newDoc);
   editor.setSelection(lineStart + newLine.length);
@@ -33,46 +81,43 @@ export function toggleBlockquote(editor: EditorAPI): boolean {
 
 export function toggleOrderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+  const lines = getLinesInRange(doc, from, to);
 
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
-  }
+  const allMarked = lines.every(({ line }) => /^\d+\.\s/.test(line));
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
-  return true;
+  let counter = 1;
+  const newLines = lines.map(({ line }) => {
+    if (allMarked) {
+      return line.replace(/^\d+\.\s/, "");
+    }
+    const content = line.replace(/^(?:\d+\.\s|[-*+]\s)/, "");
+    return `${counter++}. ${content}`;
+  });
+
+  return applyLines(editor, lines, newLines);
 }
 
 export function toggleUnorderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+  const lines = getLinesInRange(doc, from, to);
 
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
-  }
+  const allMarked = lines.every(({ line }) => /^[-*+]\s/.test(line));
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
-  return true;
+  const newLines = lines.map(({ line }) => {
+    if (allMarked) {
+      return line.replace(/^[-*+]\s/, "");
+    }
+    const content = line.replace(/^(?:\d+\.\s|[-*+]\s)/, "");
+    return `- ${content}`;
+  });
+
+  return applyLines(editor, lines, newLines);
 }
 
 export function insertCodeBlock(editor: EditorAPI): boolean {

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import { createEditor } from "@floatboat/nexus-core";
+import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
 import {
   toggleBold,
   toggleItalic,
   toggleInlineCode,
   insertLink,
   toggleHeading,
+  toggleOrderedList,
+  toggleUnorderedList,
   createToolbarPlugin,
   createToolbarUI,
 } from "../src/index";
@@ -120,6 +123,298 @@ describe("toggleHeading", () => {
   });
 });
 
+describe("toggleUnorderedList — single line (existing behaviour)", () => {
+  it("adds bullet marker to current line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello" });
+
+    editor.setSelection(2);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- hello");
+    editor.destroy();
+  });
+
+  it("removes bullet marker when already present", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- hello" });
+
+    editor.setSelection(4);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("hello");
+    editor.destroy();
+  });
+
+  it("replaces ordered-list marker with bullet", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. hello" });
+
+    editor.setSelection(4);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- hello");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList — multi-line selection", () => {
+  it("adds bullet markers to every selected line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar\nbaz" });
+
+    editor.setSelection(0, 11);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- foo\n- bar\n- baz");
+    editor.destroy();
+  });
+
+  it("removes bullet markers when all selected lines already have one", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- foo\n- bar\n- baz" });
+
+    editor.setSelection(0, 17);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("foo\nbar\nbaz");
+    editor.destroy();
+  });
+
+  it("adds bullets when only some lines have markers (mixed → toggle on)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- foo\nbar" });
+
+    editor.setSelection(0, 9);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+    editor.destroy();
+  });
+
+  it("normalizes reversed selection (head before anchor)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+
+    editor.setSelection(7, 0); // reversed
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+    editor.destroy();
+  });
+
+  it("does not include the next line when selection ends at its start", () => {
+    const container = document.createElement("div");
+    // selection covers "foo\n" (positions 0-4); "bar" starts at 4
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+
+    editor.setSelection(0, 4);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- foo\nbar");
+    editor.destroy();
+  });
+
+  it("replaces ordered-list markers with bullets across lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. foo\n2. bar" });
+
+    editor.setSelection(0, 13);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+    editor.destroy();
+  });
+});
+
+describe("toggleOrderedList — single line (existing behaviour)", () => {
+  it("adds numbered marker to current line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello" });
+
+    editor.setSelection(2);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. hello");
+    editor.destroy();
+  });
+
+  it("removes numbered marker when already present", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. hello" });
+
+    editor.setSelection(4);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("hello");
+    editor.destroy();
+  });
+});
+
+describe("toggleOrderedList — multi-line selection", () => {
+  it("adds sequential numbers to every selected line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar\nbaz" });
+
+    editor.setSelection(0, 11);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. foo\n2. bar\n3. baz");
+    editor.destroy();
+  });
+
+  it("removes numbered markers when all selected lines already have one", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. foo\n2. bar\n3. baz" });
+
+    editor.setSelection(0, 20); // doc length = 20
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("foo\nbar\nbaz");
+    editor.destroy();
+  });
+
+  it("adds numbers when only some lines have markers (mixed → toggle on)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. foo\nbar" });
+
+    editor.setSelection(0, 10);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. foo\n2. bar");
+    editor.destroy();
+  });
+
+  it("replaces bullet markers with sequential numbers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- foo\n- bar" });
+
+    editor.setSelection(0, 11);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. foo\n2. bar");
+    editor.destroy();
+  });
+
+  it("normalizes reversed selection (head before anchor)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+
+    editor.setSelection(7, 0); // reversed
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. foo\n2. bar");
+    editor.destroy();
+  });
+});
+
+// ── Destructive / round-trip tests ──────────────────────────────────────────
+
+describe("list toggle — round-trip stability", () => {
+  it("UL: toggle on then off restores original document", () => {
+    const container = document.createElement("div");
+    const original = "foo\nbar\nbaz";
+    const editor = createEditor({ container, initialValue: original });
+
+    editor.setSelection(0, 11);
+    toggleUnorderedList(editor); // on
+    const { anchor, head } = editor.getSelection();
+    editor.setSelection(anchor, head);
+    toggleUnorderedList(editor); // off
+
+    expect(editor.getDocument()).toBe(original);
+    editor.destroy();
+  });
+
+  it("OL: toggle on then off restores original document", () => {
+    const container = document.createElement("div");
+    const original = "foo\nbar\nbaz";
+    const editor = createEditor({ container, initialValue: original });
+
+    editor.setSelection(0, 11);
+    toggleOrderedList(editor); // on → "1. foo\n2. bar\n3. baz"
+    const { anchor, head } = editor.getSelection();
+    editor.setSelection(anchor, head);
+    toggleOrderedList(editor); // off
+
+    expect(editor.getDocument()).toBe(original);
+    editor.destroy();
+  });
+
+  it("UL→OL→UL produces consistent output at each step", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+
+    editor.setSelection(0, 7);
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+
+    const s1 = editor.getSelection();
+    editor.setSelection(s1.anchor, s1.head);
+    toggleOrderedList(editor);
+    expect(editor.getDocument()).toBe("1. foo\n2. bar");
+
+    const s2 = editor.getSelection();
+    editor.setSelection(s2.anchor, s2.head);
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+
+    editor.destroy();
+  });
+});
+
+describe("list toggle — selection at document boundary", () => {
+  it("handles selection that reaches the last character of the document", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+    const len = "foo\nbar".length; // 7
+
+    editor.setSelection(0, len);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+    editor.destroy();
+  });
+
+  it("single line at end of document toggles correctly", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+
+    editor.setSelection(4); // cursor on "bar"
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("foo\n1. bar");
+    editor.destroy();
+  });
+});
+
+describe("getSelectedText and range-aware toggles — API collaboration", () => {
+  it("getSelectedText reflects the full multi-line selection before toggle", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar\nbaz" });
+
+    editor.setSelection(0, 11);
+    expect(editor.getSelectedText()).toBe("foo\nbar\nbaz");
+
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- foo\n- bar\n- baz");
+    editor.destroy();
+  });
+
+  it("getSelectedText on collapsed cursor returns empty string even after toggle", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello" });
+
+    editor.setSelection(2);
+    expect(editor.getSelectedText()).toBe("");
+
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- hello");
+    expect(editor.getSelectedText()).toBe(""); // cursor, not selection
+    editor.destroy();
+  });
+});
+
 describe("createToolbarPlugin", () => {
   it("returns a plugin with keyboard shortcuts", () => {
     const plugin = createToolbarPlugin();
@@ -197,6 +492,117 @@ describe("createToolbarUI", () => {
     expect(document.getElementById(button?.getAttribute("aria-describedby") ?? "")).toBeNull();
 
     toolbar.destroy();
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList — atomic undo", () => {
+  // All tests register createHistoryPlugin() so CM6 history is active.
+  // Case 4 is the load-bearing regression guard: it fails on the old
+  // two-dispatch code (setDocument + setSelection) and passes only after
+  // applyLines is refactored to use replaceRange in one transaction.
+
+  it("Case 1: multi-line toggle → single undo fully restores document", () => {
+    const container = document.createElement("div");
+    const original = "foo\nbar\nbaz";
+    const editor = createEditor({ container, initialValue: original, plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(0, 11);
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- foo\n- bar\n- baz");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe(original);
+    editor.destroy();
+  });
+
+  it("Case 2: toggle → undo → redo recovers toggled state in one step", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar", plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(0, 7);
+    toggleUnorderedList(editor);
+    editor.undo();
+    expect(editor.redo()).toBe(true);
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+    editor.destroy();
+  });
+
+  it("Case 3: single-line toggle → undo restores original (regression guard)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello", plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(2);
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- hello");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("hello");
+    editor.destroy();
+  });
+
+  it("Case 4 (load-bearing): multi-line toggle → undo → second undo returns false", () => {
+    // Proves exactly one history entry was created. On the old two-dispatch
+    // code this test fails because the second undo() returns true (and
+    // leaves the document half-reverted). After the atomic replaceRange
+    // refactor, undo() exhausts history after one call.
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar", plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(0, 7);
+    toggleUnorderedList(editor);
+    editor.undo();
+
+    expect(editor.undo()).toBe(false);
+    editor.destroy();
+  });
+
+  it("Case 5: reversed multi-line selection → toggle → undo restores original", () => {
+    const container = document.createElement("div");
+    const original = "foo\nbar";
+    const editor = createEditor({ container, initialValue: original, plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(7, 0); // reversed: head before anchor
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("- foo\n- bar");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe(original);
+    editor.destroy();
+  });
+
+  it("Case 6: collapsed cursor → toggle → undo restores original", () => {
+    const container = document.createElement("div");
+    const original = "foo\nbar\nbaz";
+    const editor = createEditor({ container, initialValue: original, plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(5); // cursor inside "bar" line
+    toggleUnorderedList(editor);
+    expect(editor.getDocument()).toBe("foo\n- bar\nbaz");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe(original);
+    editor.destroy();
+  });
+
+  it("Case 7: toggle → undo → redo → undo round-trip is consistent", () => {
+    const container = document.createElement("div");
+    const original = "foo\nbar";
+    const editor = createEditor({ container, initialValue: original, plugins: [createHistoryPlugin()] });
+
+    editor.setSelection(0, 7);
+    toggleUnorderedList(editor);
+    const toggled = "- foo\n- bar";
+    expect(editor.getDocument()).toBe(toggled);
+
+    editor.undo();
+    expect(editor.getDocument()).toBe(original);
+
+    editor.redo();
+    expect(editor.getDocument()).toBe(toggled);
+
+    editor.undo();
+    expect(editor.getDocument()).toBe(original);
     editor.destroy();
   });
 });


### PR DESCRIPTION
## Summary / 摘要

Add `getSelectedText()` and `replaceRange()` to `EditorAPI`, and fix multi-line list toggle to operate on the full selection range with atomic undo.

## Motivation / 背景与动机

Roadmap: #1 (多行列表切换, P1), #5 (getSelectedText() API, P0), #8 (undo/redo 分组, P1)  
OpenSpec change: `openspec/changes/add-selection-api/`

## Changes / 变更内容

**packages/core:**
- Add `getSelectedText(): string` and `replaceRange(from, to, insert, selection?, opts?)` to `EditorAPI`

**packages/plugin-toolbar:**
- Introduce `getLinesInRange()` + refactor `applyLines()` to use `replaceRange` (single CM6 transaction)
- Fix `toggleOrderedList` / `toggleUnorderedList` to operate on full anchor/head range

**openspec/:**
- Add `changes/add-selection-api/` with `proposal.md`, `tasks.md`, spec deltas for `editor-core` and `plugin-toolbar`

## Testing / 测试

```bash
pnpm test -- packages/core packages/plugin-toolbar
# 191 passed, 0 failures
```

## Checklist / 自检清单

- [x] Title follows Conventional Commits
- [x] Public API changes update README / types — EditorAPI updated with full TSDoc
- [x] New capability → OpenSpec linked — `openspec/changes/add-selection-api/`
- [x] No secrets committed