### PR TITLE
feat(core): add document structure analyzer with schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,20 @@ editor.getCoordsAtPos(pos)     // { left, right, top, bottom } | null
 </details>
 
 <details>
+<summary><b>Document structure analysis</b></summary>
+
+```ts
+import { analyzeDocumentStructure } from "@floatboat/nexus-core";
+
+const analysis = analyzeDocumentStructure(editor.getAst(), {
+  requiredHeadings: ["Summary", "Analysis", "Conclusion"],
+  maxSectionWords: 500,
+});
+```
+
+</details>
+
+<details>
 <summary><b>Plugin authoring</b> — three tiers, one shape</summary>
 
 ```ts

--- a/README.zh.md
+++ b/README.zh.md
@@ -224,6 +224,20 @@ editor.getCoordsAtPos(pos)     // { left, right, top, bottom } | null
 </details>
 
 <details>
+<summary><b>文档结构分析</b></summary>
+
+```ts
+import { analyzeDocumentStructure } from "@floatboat/nexus-core";
+
+const analysis = analyzeDocumentStructure(editor.getAst(), {
+  requiredHeadings: ["摘要", "分析", "结论"],
+  maxSectionWords: 500,
+});
+```
+
+</details>
+
+<details>
 <summary><b>插件编写</b> —— 三个层级，统一形态</summary>
 
 ```ts

--- a/openspec/changes/add-document-structure-analyzer/proposal.md
+++ b/openspec/changes/add-document-structure-analyzer/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add document structure analyzer
+
+## Why
+Nexus already exposes Markdown as mdast, but hosts still need to repeat common outline and section analysis when building structured writing tools, report-like editors, and LLM-powered writing assistants.
+
+## What Changes
+- Add a pure core helper, `analyzeDocumentStructure(input, options)`.
+- Accept either Markdown text or an mdast `Root`.
+- Return headings, sections, aggregate stats, and machine-readable structure issues.
+- Keep the helper domain-neutral: no AI provider, UI, or medical-specific behavior.
+
+## Impact
+- Affected specs: `editor-core`
+- Affected code: `packages/core/src/document-structure.ts`, `packages/core/src/index.ts`, `packages/core/test/document-structure.test.ts`, `README.md`, `README.zh.md`
+- New dependencies: none

--- a/openspec/changes/add-document-structure-analyzer/specs/editor-core/spec.md
+++ b/openspec/changes/add-document-structure-analyzer/specs/editor-core/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Document Structure Analysis
+
+The core package SHALL expose `analyzeDocumentStructure(input, options)` as a pure helper that accepts Markdown text or an mdast `Root` and returns headings, sections, aggregate stats, and machine-readable structure issues. Supported issue types SHALL be limited to `empty-heading`, `heading-level-skip`, `duplicate-heading`, `missing-required-heading`, and `section-too-long`.
+
+#### Scenario: Analyze a Markdown string
+- **WHEN** `analyzeDocumentStructure()` receives Markdown text with headings and body content
+- **THEN** it SHALL return heading entries in document order
+- **AND** it SHALL return section entries and aggregate document stats
+
+#### Scenario: Analyze an mdast Root
+- **WHEN** `analyzeDocumentStructure()` receives an mdast `Root`
+- **THEN** it SHALL analyze the tree without requiring an editor instance
+
+#### Scenario: Report supported structure issues
+- **WHEN** the document contains empty headings, skipped heading levels, duplicate headings, missing required headings, or sections over the configured word limit
+- **THEN** the returned `issues` array SHALL include machine-readable entries for those issue types

--- a/openspec/changes/add-document-structure-analyzer/tasks.md
+++ b/openspec/changes/add-document-structure-analyzer/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] 1.1 Add `analyzeDocumentStructure(input, options)` and public types in core.
+- [x] 1.2 Export the helper and types from `@floatboat/nexus-core`.
+- [x] 1.3 Add focused unit tests for headings, sections, stats, and supported issues.
+- [x] 1.4 Add short README and README.zh API examples.
+- [x] 1.5 Run affected core test/build checks.
+- [ ] 1.6 Run OpenSpec validation.

--- a/packages/core/src/document-structure.ts
+++ b/packages/core/src/document-structure.ts
@@ -1,0 +1,347 @@
+import type { Root } from "mdast";
+
+import { lezerStringToMdast } from "./lezer-mdast-adapter";
+
+export type DocumentStructureInput = Root | string;
+
+export interface DocumentStructureOptions {
+  requiredHeadings?: string[];
+  maxSectionWords?: number;
+}
+
+export interface DocumentStructureHeading {
+  index: number;
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  text: string;
+  from?: number;
+  to?: number;
+  parentIndex?: number;
+}
+
+export interface DocumentStructureSection {
+  headingIndex: number;
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  title: string;
+  from?: number;
+  to?: number;
+  wordCount: number;
+}
+
+export interface DocumentStructureStats {
+  headings: number;
+  sections: number;
+  words: number;
+  paragraphs: number;
+  lists: number;
+  tables: number;
+  codeBlocks: number;
+}
+
+export type DocumentStructureIssueType =
+  | "empty-heading"
+  | "heading-level-skip"
+  | "duplicate-heading"
+  | "missing-required-heading"
+  | "section-too-long";
+
+export interface DocumentStructureIssue {
+  type: DocumentStructureIssueType;
+  severity: "warning";
+  headingIndex?: number;
+  firstHeadingIndex?: number;
+  expected?: string;
+  previousLevel?: number;
+  actualLevel?: number;
+  wordCount?: number;
+  limit?: number;
+  from?: number;
+  to?: number;
+}
+
+export interface DocumentStructureAnalysis {
+  headings: DocumentStructureHeading[];
+  sections: DocumentStructureSection[];
+  stats: DocumentStructureStats;
+  issues: DocumentStructureIssue[];
+}
+
+interface MdastPosition {
+  start?: { offset?: number };
+  end?: { offset?: number };
+}
+
+interface MdastNode {
+  type: string;
+  value?: unknown;
+  children?: MdastNode[];
+  position?: MdastPosition;
+  depth?: number;
+}
+
+function normalizeHeading(text: string): string {
+  return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function getOffset(position: MdastPosition | undefined, edge: "start" | "end"): number | undefined {
+  const offset = position?.[edge]?.offset;
+  return typeof offset === "number" ? offset : undefined;
+}
+
+function getPlainText(node: MdastNode): string {
+  const parts: string[] = [];
+
+  const visit = (current: MdastNode) => {
+    if (current.type === "code") {
+      return;
+    }
+
+    if (typeof current.value === "string") {
+      parts.push(current.value);
+    }
+
+    for (const child of current.children ?? []) {
+      visit(child);
+    }
+  };
+
+  visit(node);
+  return parts.join(" ");
+}
+
+function countWords(text: string): number {
+  const matches = text.match(/[\p{L}\p{N}]+(?:['’.-][\p{L}\p{N}]+)*/gu);
+  return matches?.length ?? 0;
+}
+
+function toHeadingLevel(value: unknown): DocumentStructureHeading["level"] {
+  return value === 1 || value === 2 || value === 3 || value === 4 || value === 5 || value === 6
+    ? value
+    : 1;
+}
+
+function createEmptyStats(): DocumentStructureStats {
+  return {
+    headings: 0,
+    sections: 0,
+    words: 0,
+    paragraphs: 0,
+    lists: 0,
+    tables: 0,
+    codeBlocks: 0
+  };
+}
+
+function collectStats(root: MdastNode): DocumentStructureStats {
+  const stats = createEmptyStats();
+
+  const visit = (node: MdastNode) => {
+    switch (node.type) {
+      case "heading":
+        stats.headings++;
+        break;
+      case "paragraph":
+        stats.paragraphs++;
+        break;
+      case "list":
+        stats.lists++;
+        break;
+      case "table":
+        stats.tables++;
+        break;
+      case "code":
+        stats.codeBlocks++;
+        break;
+    }
+
+    for (const child of node.children ?? []) {
+      visit(child);
+    }
+  };
+
+  visit(root);
+  stats.words = countWords(getPlainText(root));
+  return stats;
+}
+
+function analyzeHeadings(children: MdastNode[], issues: DocumentStructureIssue[]): DocumentStructureHeading[] {
+  const headings: DocumentStructureHeading[] = [];
+  const stack: DocumentStructureHeading[] = [];
+  const seen = new Map<string, number>();
+  let previousLevel: DocumentStructureHeading["level"] | null = null;
+
+  for (const child of children) {
+    if (child.type !== "heading") {
+      continue;
+    }
+
+    const level = toHeadingLevel(child.depth);
+    const text = getPlainText(child).trim();
+    const heading: DocumentStructureHeading = {
+      index: headings.length,
+      level,
+      text,
+      from: getOffset(child.position, "start"),
+      to: getOffset(child.position, "end")
+    };
+
+    while (stack.length > 0 && stack[stack.length - 1].level >= level) {
+      stack.pop();
+    }
+    if (stack.length > 0) {
+      heading.parentIndex = stack[stack.length - 1].index;
+    }
+    stack.push(heading);
+
+    if (!text) {
+      issues.push({
+        type: "empty-heading",
+        severity: "warning",
+        headingIndex: heading.index,
+        from: heading.from,
+        to: heading.to
+      });
+    }
+
+    if (previousLevel !== null && level > previousLevel + 1) {
+      issues.push({
+        type: "heading-level-skip",
+        severity: "warning",
+        headingIndex: heading.index,
+        previousLevel,
+        actualLevel: level,
+        from: heading.from,
+        to: heading.to
+      });
+    }
+
+    const normalized = normalizeHeading(text);
+    if (normalized) {
+      const firstHeadingIndex = seen.get(normalized);
+      if (firstHeadingIndex === undefined) {
+        seen.set(normalized, heading.index);
+      } else {
+        issues.push({
+          type: "duplicate-heading",
+          severity: "warning",
+          headingIndex: heading.index,
+          firstHeadingIndex,
+          from: heading.from,
+          to: heading.to
+        });
+      }
+    }
+
+    headings.push(heading);
+    previousLevel = level;
+  }
+
+  return headings;
+}
+
+function createSections(
+  children: MdastNode[],
+  headings: DocumentStructureHeading[],
+  options: DocumentStructureOptions,
+  issues: DocumentStructureIssue[]
+): DocumentStructureSection[] {
+  const headingChildIndexes = children.reduce<number[]>((out, child, index) => {
+    if (child.type === "heading") {
+      out.push(index);
+    }
+    return out;
+  }, []);
+  const sections: DocumentStructureSection[] = [];
+  const maxSectionWords =
+    typeof options.maxSectionWords === "number" && options.maxSectionWords >= 0
+      ? options.maxSectionWords
+      : undefined;
+
+  for (let i = 0; i < headingChildIndexes.length; i++) {
+    const heading = headings[i];
+    const startChildIndex = headingChildIndexes[i];
+    let endChildIndex = children.length;
+
+    for (let j = i + 1; j < headingChildIndexes.length; j++) {
+      const nextHeading = headings[j];
+      if (nextHeading.level <= heading.level) {
+        endChildIndex = headingChildIndexes[j];
+        break;
+      }
+    }
+
+    const bodyNodes = children.slice(startChildIndex + 1, endChildIndex);
+    const lastNode = children[endChildIndex - 1] ?? children[startChildIndex];
+    const wordCount = countWords(bodyNodes.map(getPlainText).join(" "));
+    const section: DocumentStructureSection = {
+      headingIndex: heading.index,
+      level: heading.level,
+      title: heading.text,
+      from: heading.from,
+      to: getOffset(lastNode.position, "end") ?? heading.to,
+      wordCount
+    };
+
+    sections.push(section);
+
+    if (maxSectionWords !== undefined && wordCount > maxSectionWords) {
+      issues.push({
+        type: "section-too-long",
+        severity: "warning",
+        headingIndex: heading.index,
+        wordCount,
+        limit: maxSectionWords,
+        from: section.from,
+        to: section.to
+      });
+    }
+  }
+
+  return sections;
+}
+
+function addMissingRequiredHeadingIssues(
+  headings: DocumentStructureHeading[],
+  requiredHeadings: string[] | undefined,
+  issues: DocumentStructureIssue[]
+): void {
+  if (!requiredHeadings || requiredHeadings.length === 0) {
+    return;
+  }
+
+  const actual = new Set(headings.map((heading) => normalizeHeading(heading.text)).filter(Boolean));
+
+  for (const requiredHeading of requiredHeadings) {
+    const normalized = normalizeHeading(requiredHeading);
+    if (!normalized || actual.has(normalized)) {
+      continue;
+    }
+
+    issues.push({
+      type: "missing-required-heading",
+      severity: "warning",
+      expected: requiredHeading
+    });
+  }
+}
+
+export function analyzeDocumentStructure(
+  input: DocumentStructureInput,
+  options: DocumentStructureOptions = {}
+): DocumentStructureAnalysis {
+  const root = (typeof input === "string" ? lezerStringToMdast(input) : input) as unknown as MdastNode;
+  const children = root.children ?? [];
+  const issues: DocumentStructureIssue[] = [];
+  const headings = analyzeHeadings(children, issues);
+  const sections = createSections(children, headings, options, issues);
+  addMissingRequiredHeadingIssues(headings, options.requiredHeadings, issues);
+
+  return {
+    headings,
+    sections,
+    stats: {
+      ...collectStats(root),
+      sections: sections.length
+    },
+    issues
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,15 @@
 export { createEditor } from "./editor";
+export {
+  analyzeDocumentStructure,
+  type DocumentStructureAnalysis,
+  type DocumentStructureHeading,
+  type DocumentStructureInput,
+  type DocumentStructureIssue,
+  type DocumentStructureIssueType,
+  type DocumentStructureOptions,
+  type DocumentStructureSection,
+  type DocumentStructureStats,
+} from "./document-structure";
 export { markdownAutoPair } from "./markdown-autopair";
 export { markdownFold, markdownFoldService } from "./markdown-fold";
 export { markdownKeymap, handleMarkdownEnter } from "./markdown-keymap";

--- a/packages/core/test/document-structure.test.ts
+++ b/packages/core/test/document-structure.test.ts
@@ -1,0 +1,128 @@
+import type { Root } from "mdast";
+import { describe, expect, it } from "vitest";
+
+import { analyzeDocumentStructure } from "../src/index";
+
+describe("analyzeDocumentStructure", () => {
+  it("analyzes headings, sections, and stats from markdown text", () => {
+    const analysis = analyzeDocumentStructure(
+      "# Report\n\nIntro words here.\n\n## Findings\n\nAlpha beta gamma.\n\n### Details\n\nNested words.\n\n## Impression\n\nDone."
+    );
+
+    expect(analysis.headings).toEqual([
+      expect.objectContaining({ index: 0, level: 1, text: "Report" }),
+      expect.objectContaining({ index: 1, level: 2, text: "Findings", parentIndex: 0 }),
+      expect.objectContaining({ index: 2, level: 3, text: "Details", parentIndex: 1 }),
+      expect.objectContaining({ index: 3, level: 2, text: "Impression", parentIndex: 0 })
+    ]);
+    expect(analysis.sections).toHaveLength(4);
+    expect(analysis.sections[2]).toMatchObject({
+      headingIndex: 2,
+      level: 3,
+      title: "Details",
+      wordCount: 2
+    });
+    expect(analysis.stats).toMatchObject({
+      headings: 4,
+      sections: 4,
+      paragraphs: 4
+    });
+    expect(analysis.issues).toEqual([]);
+  });
+
+  it("accepts an mdast Root without requiring an editor instance", () => {
+    const root: Root = {
+      type: "root",
+      children: [
+        {
+          type: "heading",
+          depth: 1,
+          children: [{ type: "text", value: "Manual Root" }]
+        },
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "alpha beta" }]
+        }
+      ]
+    };
+
+    const analysis = analyzeDocumentStructure(root);
+
+    expect(analysis.headings).toEqual([
+      expect.objectContaining({ index: 0, level: 1, text: "Manual Root" })
+    ]);
+    expect(analysis.sections).toEqual([
+      expect.objectContaining({ headingIndex: 0, title: "Manual Root", wordCount: 2 })
+    ]);
+    expect(analysis.stats.words).toBe(4);
+  });
+
+  it("reports empty headings, skipped levels, duplicate headings, and missing required headings", () => {
+    const analysis = analyzeDocumentStructure(
+      "# Intro\n\n### Details\n\n## Findings\n\n## Findings\n\n##\n\nBody.",
+      {
+        requiredHeadings: ["Intro", "Conclusion"]
+      }
+    );
+
+    expect(analysis.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "heading-level-skip",
+          headingIndex: 1,
+          previousLevel: 1,
+          actualLevel: 3
+        }),
+        expect.objectContaining({
+          type: "duplicate-heading",
+          headingIndex: 3,
+          firstHeadingIndex: 2
+        }),
+        expect.objectContaining({
+          type: "empty-heading",
+          headingIndex: 4
+        }),
+        expect.objectContaining({
+          type: "missing-required-heading",
+          expected: "Conclusion"
+        })
+      ])
+    );
+  });
+
+  it("reports sections over the configured word limit", () => {
+    const analysis = analyzeDocumentStructure("# Summary\n\none two three four", {
+      maxSectionWords: 3
+    });
+
+    expect(analysis.sections[0]).toMatchObject({
+      headingIndex: 0,
+      wordCount: 4
+    });
+    expect(analysis.issues).toEqual([
+      expect.objectContaining({
+        type: "section-too-long",
+        headingIndex: 0,
+        wordCount: 4,
+        limit: 3
+      })
+    ]);
+  });
+
+  it("returns a stable empty analysis for an empty document", () => {
+    expect(analyzeDocumentStructure("")).toEqual({
+      headings: [],
+      sections: [],
+      stats: {
+        headings: 0,
+        sections: 0,
+        words: 0,
+        paragraphs: 0,
+        lists: 0,
+        tables: 0,
+        codeBlocks: 0
+      },
+      issues: []
+    });
+  });
+});


### PR DESCRIPTION

## PR title

feat(core): add document structure analyzer with schema validation

---

## Summary / 摘要

Add a core-level helper `analyzeDocumentStructure()` with lightweight heading schema validation and machine-readable structure warnings.

中文摘要：

新增核心 helper `analyzeDocumentStructure()`，支持轻量标题 schema 校验和机器可读结构告警。

---

## Motivation / 背景与动机

Hosts building structured writing tools, report-like editors, and LLM-powered writing assistants often need consistent document structure analysis without duplicating mdast traversal logic. This core helper provides a reusable solution.

中文：

面向构建结构化写作工具、报告编辑器和 LLM 驱动的写作助手，宿主端通常需要统一的文档结构分析而不重复 mdast 遍历逻辑。本核心 helper 提供可复用的解决方案。

关联条目：

- Issue: N/A
- Roadmap (docs/ROADMAP.md): add document structure analysis capability
- OpenSpec change: add-document-structure-analyzer

---

## Changes / 变更内容

- `packages/core`:
  - Add `analyzeDocumentStructure(input, options)` supporting markdown string or mdast Root
  - Add schema validation options: `headingSchema`, `enforceHeadingOrder`, `allowUnknownHeadings`
  - Add new issue types: `heading-level-mismatch`, `heading-order-mismatch`, `unknown-heading`
  - Keep backward compatibility: `requiredHeadings`
  - Add unit tests covering new schema rules and existing functionality
- `openspec/changes/add-document-structure-analyzer/`:
  - `proposal.md`, `tasks.md`, `specs/editor-core/spec.md` updated to cover schema validation
- `README.md` / `README.zh.md`:
  - Update examples to use `headingSchema` and show machine-readable structure warnings

---

## Testing / 测试

- [x] `pnpm test` passes — all vitest tests for core pass
- [x] Build succeeds: `pnpm --filter @floatboat/nexus-core build`
- [x] Typecheck succeeds: `pnpm typecheck`
- [x] New vitest cases cover:
  - Missing required headings from `headingSchema`
  - `heading-level-mismatch`
  - `heading-order-mismatch`
  - `unknown-heading`
  - Default behavior when no schema

---

## Checklist / 自检清单

- [x] Title follows Conventional Commits
- [x] Public API changes update package README / types
- [x] New capability → OpenSpec proposal linked
- [x] No secrets / personal vault data committed

---

## Screenshots / Recordings · 截图或录屏 (UI changes)

No UI changes. Functionality tested via vitest.