### PR TITLE
feat: implement 7 Roadmap items across 6 packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Run tests
+      - name: Run unit tests
         run: pnpm test
 
       - name: Build packages
@@ -59,10 +59,46 @@ jobs:
       - name: Build Electron demo
         run: pnpm build:electron-demo
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   publish:
     name: Publish Packages
     runs-on: ubuntu-latest
-    needs: verify
+    needs: [verify, e2e]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish)
     steps:
       - name: Checkout

--- a/apps/electron-demo/test/sample-vault.test.ts
+++ b/apps/electron-demo/test/sample-vault.test.ts
@@ -8,6 +8,10 @@ const VAULT_ROOT = path.resolve(__dirname, "../sample-vault");
 const SUPPORTED = new Set([".md", ".markdown", ".txt"]);
 const SKIP_DIRS = new Set(["node_modules", ".git"]);
 
+function norm(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
 async function collect(dir: string, acc: string[]): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true });
   for (const e of entries) {
@@ -52,9 +56,9 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("every note links back to index.md (hub topology)", async () => {
     const idx = await buildIndex();
-    const hub = path.join(VAULT_ROOT, "index.md");
+    const hub = norm(path.join(VAULT_ROOT, "index.md"));
     const hits = idx.getBacklinks(hub);
-    const sources = new Set(hits.map((h) => path.relative(VAULT_ROOT, h.sourcePath)));
+    const sources = new Set(hits.map((h) => norm(path.relative(VAULT_ROOT, h.sourcePath))));
     // README is documentation, not a note that must link in; every *other*
     // markdown file should.
     const expected = [
@@ -76,25 +80,25 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("[[AI]] from Daily resolves to Topics/AI.md (globally unique basename)", async () => {
     const idx = await buildIndex();
-    const daily = path.join(VAULT_ROOT, "Daily/2026-04-20.md");
-    expect(idx.resolve("AI", daily)).toBe(path.join(VAULT_ROOT, "Topics/AI.md"));
+    const daily = norm(path.join(VAULT_ROOT, "Daily/2026-04-20.md"));
+    expect(idx.resolve("AI", daily)).toBe(norm(path.join(VAULT_ROOT, "Topics/AI.md")));
   });
 
   it("[[Meeting]] from work/Inbox.md resolves to work/Meeting.md (same-dir wins)", async () => {
     const idx = await buildIndex();
-    const inbox = path.join(VAULT_ROOT, "work/Inbox.md");
-    expect(idx.resolve("Meeting", inbox)).toBe(path.join(VAULT_ROOT, "work/Meeting.md"));
+    const inbox = norm(path.join(VAULT_ROOT, "work/Inbox.md"));
+    expect(idx.resolve("Meeting", inbox)).toBe(norm(path.join(VAULT_ROOT, "work/Meeting.md")));
   });
 
   it("[[Meeting]] from personal/Diary.md resolves to personal/Meeting.md (symmetric)", async () => {
     const idx = await buildIndex();
-    const diary = path.join(VAULT_ROOT, "personal/Diary.md");
-    expect(idx.resolve("Meeting", diary)).toBe(path.join(VAULT_ROOT, "personal/Meeting.md"));
+    const diary = norm(path.join(VAULT_ROOT, "personal/Diary.md"));
+    expect(idx.resolve("Meeting", diary)).toBe(norm(path.join(VAULT_ROOT, "personal/Meeting.md")));
   });
 
   it("[[Ghost Note]] in ghost-demo.md is unresolved (creates-on-click scenario)", async () => {
     const idx = await buildIndex();
-    const ghost = path.join(VAULT_ROOT, "ghost-demo.md");
+    const ghost = norm(path.join(VAULT_ROOT, "ghost-demo.md"));
     expect(idx.resolve("Ghost Note", ghost)).toBeNull();
     expect(idx.resolve("NonExistent", ghost)).toBeNull();
   });
@@ -103,7 +107,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
     const idx = await buildIndex();
     // NotALink should not be resolvable via any rule — it must never appear
     // as a valid target because the scanner skipped it.
-    expect(idx.resolve("NotALink", path.join(VAULT_ROOT, "ghost-demo.md"))).toBeNull();
+    expect(idx.resolve("NotALink", norm(path.join(VAULT_ROOT, "ghost-demo.md")))).toBeNull();
     // And no file's forward edges include a "NotALink" target.
     for (const source of idx.getAllFiles()) {
       const hits = idx.getBacklinks(source);
@@ -133,7 +137,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
       expect(hits).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            sourcePath: file.path,
+            sourcePath: norm(file.path),
             target: match.target,
           }),
         ])
@@ -143,42 +147,42 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("Testing.md shows linked backlinks from current sample-vault references", async () => {
     const idx = await buildIndex();
-    const testingPath = path.join(VAULT_ROOT, "Topics/Testing.md");
-    const linked = idx.getBacklinks(testingPath).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const testingPath = norm(path.join(VAULT_ROOT, "Topics/Testing.md"));
+    const linked = idx.getBacklinks(testingPath).map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(linked.length).toBeGreaterThan(0);
     expect(linked).toContain("Projects/Nexus-Editor.md");
   });
 
   it("Bob.md has an unlinked mention in Alice.md (plain text 'Bob' outside brackets)", async () => {
     const idx = await buildIndex();
-    const bob = path.join(VAULT_ROOT, "People/Bob.md");
+    const bob = norm(path.join(VAULT_ROOT, "People/Bob.md"));
     const mentions = idx.getUnlinkedMentions(bob);
-    const sources = mentions.map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const sources = mentions.map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(sources).toContain("People/Alice.md");
   });
 
   it("AI.md has an unlinked mention in Alice.md and Daily/2026-04-20.md has a linked one", async () => {
     const idx = await buildIndex();
-    const ai = path.join(VAULT_ROOT, "Topics/AI.md");
-    const unlinked = idx.getUnlinkedMentions(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    const linked = idx.getBacklinks(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    expect(unlinked).toContain("People/Alice.md"); // plain text "AI" in Alice.md
-    expect(linked).toContain("Daily/2026-04-20.md"); // [[AI]] in the daily
+    const ai = norm(path.join(VAULT_ROOT, "Topics/AI.md"));
+    const unlinked = idx.getUnlinkedMentions(ai).map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
+    const linked = idx.getBacklinks(ai).map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
+    expect(unlinked).toContain("People/Alice.md");
+    expect(linked).toContain("Daily/2026-04-20.md");
   });
 
   it("v2-shaped anchors in Ideas.md resolve to the underlying file, not ghosts", async () => {
     const idx = await buildIndex();
-    const ideas = path.join(VAULT_ROOT, "Projects/Ideas.md");
+    const ideas = norm(path.join(VAULT_ROOT, "Projects/Ideas.md"));
     expect(idx.resolve("Projects/Nexus-Editor#Context", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+      norm(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
     expect(idx.resolve("Projects/Nexus-Editor^some-block", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+      norm(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
   });
 
   it("#Context anchor in Ideas.md points into the real Context heading of Nexus-Editor.md", async () => {
-    const nexus = path.join(VAULT_ROOT, "Projects/Nexus-Editor.md");
+    const nexus = norm(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"));
     const content = await readFile(nexus, "utf-8");
     const { anchor } = parseAnchor("Projects/Nexus-Editor#Context");
     expect(anchor).not.toBeNull();

--- a/e2e-vite.config.ts
+++ b/e2e-vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import path from "node:path";
+
+export default defineConfig({
+  root: path.resolve(__dirname, "e2e"),
+  base: "./",
+  resolve: {
+    alias: {
+      "@floatboat/nexus-core": path.resolve(__dirname, "packages/core/src/index.ts"),
+      "@floatboat/nexus-preset-gfm": path.resolve(__dirname, "packages/preset-gfm/src/index.ts"),
+      "@floatboat/nexus-plugin-history": path.resolve(__dirname, "packages/plugin-history/src/index.ts"),
+      "@floatboat/nexus-plugin-toolbar": path.resolve(__dirname, "packages/plugin-toolbar/src/index.ts"),
+      "@floatboat/nexus-plugin-search": path.resolve(__dirname, "packages/plugin-search/src/index.ts"),
+    },
+  },
+  server: {
+    port: 5179,
+  },
+});

--- a/e2e/editor-e2e.spec.ts
+++ b/e2e/editor-e2e.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await page.waitForSelector(".cm-editor");
+});
+
+test("renders the CodeMirror editor", async ({ page }) => {
+  const editor = page.locator(".cm-editor");
+  await expect(editor).toBeVisible();
+});
+
+test("renders the toolbar", async ({ page }) => {
+  const toolbar = page.locator('[role="toolbar"]');
+  await expect(toolbar).toBeVisible();
+});
+
+test("renders initial document content", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await expect(content).toContainText("world");
+});
+
+test("accepts text input", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await content.click();
+  await page.keyboard.type(" appended");
+  await expect(content).toContainText("Hello **world** appended");
+});
+
+test("bold shortcut via toolbar click", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await content.click();
+  const boldBtn = page.locator('[data-toolbar-action="bold"]');
+  await boldBtn.click();
+  await expect(content).toContainText("**");
+});
+
+test("Ctrl+F opens the search panel", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await content.click();
+  await content.press("Control+f");
+  const searchPanel = page.locator('[data-test-id="markdown-search-bar"]');
+  await expect(searchPanel).toBeVisible({ timeout: 3000 });
+});
+
+test("search panel input is visible after opening", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await content.click();
+  await content.press("Control+f");
+  const input = page.locator('[data-test-id="markdown-search-input"]');
+  await expect(input).toBeVisible({ timeout: 3000 });
+});
+
+test("undo reverts text change via Ctrl+Z", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await content.click();
+  await content.press("End");
+  await page.keyboard.type("extra");
+  await content.press("Control+z");
+  await expect(content).not.toContainText("extra");
+});
+
+test("toolbar ordered and unordered list buttons exist", async ({ page }) => {
+  const olBtn = page.locator('[data-toolbar-action="ordered-list"]');
+  const ulBtn = page.locator('[data-toolbar-action="unordered-list"]');
+  await expect(olBtn).toBeVisible();
+  await expect(ulBtn).toBeVisible();
+});
+
+test("editor accepts keyboard shortcuts and toolbar buttons", async ({ page }) => {
+  const content = page.locator(".cm-content");
+  await content.click();
+  await content.press("Control+End");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("new line");
+  await expect(content).toContainText("new line");
+});

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nexus Editor E2E Test</title>
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; }
+  </style>
+</head>
+<body>
+  <div id="editor-mount"></div>
+  <script type="module" src="./test-app.ts"></script>
+</body>
+</html>

--- a/e2e/test-app.ts
+++ b/e2e/test-app.ts
@@ -1,0 +1,24 @@
+import { createEditor } from "@floatboat/nexus-core";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
+import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
+import { createToolbarPlugin, createToolbarUI } from "@floatboat/nexus-plugin-toolbar";
+import { createSearchPlugin } from "@floatboat/nexus-plugin-search";
+
+const container = document.getElementById("editor-mount")!;
+
+const editor = createEditor({
+  container,
+  initialValue: "Hello **world**",
+  plugins: [
+    createGfmPreset(),
+    createHistoryPlugin(),
+    createToolbarPlugin(),
+    createSearchPlugin(),
+  ],
+  livePreview: { enabled: true },
+});
+
+const toolbar = createToolbarUI(editor);
+container.insertBefore(toolbar.element, container.firstChild);
+
+(window as any).__nexusEditor = editor;

--- a/openspec/changes/add-missing-features/tasks.md
+++ b/openspec/changes/add-missing-features/tasks.md
@@ -14,7 +14,7 @@
 - [x] 2.1 Markdown auto-continuation
 - [x] 2.2 Fold/unfold for headings
 - [x] 2.3 Fold/unfold for code blocks
-- [ ] 2.4 List item drag reorder
+- [x] 2.4 List item drag reorder
 - [x] 2.5 Link hover preview
 
 ## Phase 3: P2 — Ecosystem
@@ -28,6 +28,6 @@
 ## Phase 4: P3 — Quality
 
 - [x] 4.1 Accessibility (a11y) — ARIA attributes on headings, code blocks, tables
-- [ ] 4.2 Performance benchmarks
-- [ ] 4.3 API documentation
-- [ ] 4.4 E2E tests
+- [x] 4.2 Performance benchmarks
+- [x] 4.3 API documentation
+- [x] 4.4 E2E tests

--- a/openspec/changes/add-multi-cursor/design.md
+++ b/openspec/changes/add-multi-cursor/design.md
@@ -1,0 +1,73 @@
+## Context
+
+CM6's `EditorState.allowMultipleSelections` facet controls whether users can create additional selection ranges via Ctrl+click, Ctrl+Alt+↑/↓, or `selectNextOccurrence`. Nexus Editor currently inherits the default (`false`). Enabling it requires auditing every code path that reads `view.state.selection.main` and deciding whether it should iterate all ranges instead.
+
+The main risk areas are:
+1. **Live-preview decorations**: Widgets (images, mermaid diagrams, tables) are bound to a single document range. If the user creates a secondary cursor inside a widget's rendered region, decoration logic must not corrupt the widget DOM.
+2. **Table editing**: The table widget uses `tableEditingCount` to prevent CM6 from recreating widget DOM during drag/click operations. A secondary cursor inside an editing table cell must be deferred.
+3. **Event contracts**: `selectionChange` currently fires with `{ anchor, head }` representing the primary selection. Multi-cursor consumers need all ranges.
+4. **Formatting commands**: `toggleBold`, `toggleOrderedList`, etc. apply to the word/line at the primary cursor. With multiple ranges, each range must be processed independently, with offset tracking to account for concurrent document mutations.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Enable `allowMultipleSelections` by default.
+  - `getSelection()` returns primary range (backwards-compatible).
+  - `getSelections(): { anchor: number; head: number }[]` returns all ranges.
+  - `selectionChange` event includes `ranges` array.
+  - Formatting commands handle multiple ranges correctly.
+  - Live-preview and table editing degrade gracefully under multi-cursor.
+- Non-Goals:
+  - Multi-cursor inside live-preview widgets (cursors remain in source text only).
+  - Vim visual-block integration beyond what CM6 already provides.
+  - AST-aware "select next occurrence" (v2).
+
+## Decisions
+
+### Decision 1: Enable `allowMultipleSelections` via EditorState facet, not config option
+
+Add `EditorState.allowMultipleSelections.of(true)` to the base extensions array in `editor.ts`. No opt-out config — multi-cursor is a default editor capability. Reasoning: CM6 already handles the UX (keybindings, rendering); the work is in making Nexus code paths robust to it.
+
+### Decision 2: `getSelection()` stays single, add `getSelections()` for all ranges
+
+Backwards compatibility: existing callers (toolbar commands, electron-demo backlink navigation, slash menu) expect a single `{ anchor, head }`. Those remain correct — toolbar commands are updated to call `getSelections()` internally, but external consumers see no API break.
+
+### Decision 3: Multi-range formatting: process last-to-first, track offset per range
+
+When `toggleBold` is called with 3 cursor ranges `[{0,5}, {10,15}, {20,25}]`:
+1. Sort ranges by `from` descending.
+2. For each range, apply the wrap/unwrap logic on the current document state.
+3. After all ranges are processed, set the document and restore all cursor positions with accumulated offsets.
+
+This avoids the offset-drift problem where modifying range 1 shifts the positions of ranges 2 and 3.
+
+### Decision 4: Skip live-preview widget toggling when `ranges > 1`
+
+The decoration builder (`buildDecorations`) already checks `cursorPos` against widget ranges. When `state.selection.ranges.length > 1`, skip the "show source on cursor-in-widget" logic — widgets stay in preview mode. The user can still edit source text directly.
+
+### Decision 5: Suppress secondary selections during table editing
+
+In the `EditorView.updateListener`, if `isTableEditing()` is true and the transaction creates a selection with `ranges.length > 1`, filter it to keep only the primary range. Table editing relies on single-cursor invariants (per CLAUDE.md rules 8-12).
+
+## Risks / Trade-offs
+
+- **Risk**: Multi-cursor + table column drag creates an unrecoverable state.
+  - **Mitigation**: Decision 5 — suppress any multi-cursor transaction while `tableEditingCount > 0`.
+- **Risk**: Formatting commands with many ranges produce a large number of document mutations in one frame.
+  - **Mitigation**: CM6 batches transactions; our loop applies one final `setDocument` call with the accumulated result. No per-range dispatch.
+
+## Migration Plan
+
+1. Enable the facet in core.
+2. Add `getSelections()` and update `selectionChange`.
+3. Update formatting commands for multi-range.
+4. Add table/live-preview guards.
+5. Write tests.
+6. Smoke-test in electron-demo.
+
+Rollback: remove the `allowMultipleSelections` facet line. All other changes are additive and harm no one when multi-cursor is off.
+
+## Open Questions
+
+- Should `setSelection` support setting arbitrary ranges beyond the primary? (Proposal: yes, add optional `rangeIndex` parameter for power users; `undefined` = replace all with a single range.)
+- Should `plugin-vim`'s visual-block mode be tested as part of this change? (Proposal: out of scope for now; vim plugin is thin and visual-block already works at the CM6 level.)

--- a/openspec/changes/add-multi-cursor/proposal.md
+++ b/openspec/changes/add-multi-cursor/proposal.md
@@ -1,0 +1,42 @@
+# Change: Add Multi-Cursor / Multi-Selection Support
+
+## Why
+
+CM6 supports multi-cursor editing natively via `allowMultipleSelections`, but Nexus Editor disables it (the facet defaults to `false` when omitted). The roadmap lists `[#6 Multi-cursor / multi-selection | core | P1 | planned]`. Enabling multi-cursor unlocks simultaneous editing of multiple locations — a power-user feature expected in modern editors (VS Code, Obsidian, etc.). However, enabling it naively risks breaking live-preview decorations, table widget state management, and selection-change event contracts, all of which currently assume a single `selection.main`.
+
+## What Changes
+
+- **Core (`@floatboat/nexus-core`)**:
+  - Enable `allowMultipleSelections` in the editor state configuration.
+  - Update `getSelection()` to return the **primary** selection (`.main`) — existing callers are unaffected.
+  - Add `getSelections()` returning all ranges for multi-cursor-aware consumers.
+  - Extend `setSelection(anchor, head)` to accept an optional third `rangeIndex` for multi-cursor positioning.
+  - Update `selectionChange` event payload to include `ranges: { anchor: number; head: number }[]` alongside the primary `anchor`/`head` — additive, not breaking.
+  - Wire `EditorView.updateListener` selection-set branch to emit `selectionChange` whenever **any** selection range changes (currently only fires when `.main` changes).
+  - Guard live-preview decoration builder against multi-selection states: when more than one range is active, skip inline widget toggling (widgets are bound to a single position).
+  - Guard table editing state: if `tableEditingCount > 0` and CM6 creates a secondary selection (e.g. Ctrl+click inside a table cell), either suppress the extra selection or defer it until editing ends. Document this interaction in the table widget rules section of `CLAUDE.md`.
+- **Plugin Toolbar (`@floatboat/nexus-plugin-toolbar`)**:
+  - Formatting commands (`toggleBold`, `toggleItalic`, `toggleHeading`, `toggleOrderedList`, etc.) operate on **every** selection range, not just the primary one. Each range's enclosing word/line is toggled independently, and the resulting document is produced by applying changes from last-to-first range (avoiding offset drift).
+- **Docs**: `docs/ROADMAP.md` row #6 transitions to `in-progress` and links this change id.
+
+No breaking changes: the `getSelection()` return type is unchanged; `selectionChange` gains an additive field; formatting commands produce correct results for single-selection callers (range count = 1).
+
+## Impact
+
+- Affected specs: `editor-core` (MODIFIED — selection API, multi-cursor contract)
+- Affected code:
+  - `packages/core/src/editor.ts` (enable facet, update listener, selection API methods)
+  - `packages/core/src/types.ts` (EditorEventMap.selectionChange, EditorAPI additions)
+  - `packages/core/src/live-preview.ts` (guard decoration builder)
+  - `packages/core/src/live-preview-table.ts` (guard table editing)
+  - `packages/plugin-toolbar/src/formatting.ts` (multi-range formatting)
+  - `packages/core/test/editor-selection.test.ts` (NEW — multi-cursor unit tests)
+  - `packages/core/test/events.test.ts` (extend selectionChange suite)
+  - `packages/plugin-toolbar/test/plugin-toolbar.test.ts` (multi-range formatting tests)
+  - `CLAUDE.md` (new table widget rule for multi-cursor)
+  - `docs/ROADMAP.md` (status update)
+- New dev dependencies: none.
+- Out of scope:
+  - Cross-widget cursor positions (placing a cursor inside a rendered table cell vs its markdown source).
+  - Multi-cursor in `plugin-vim` (visual-block mode already works; full Vim multi-cursor commands are a v2 concern).
+  - AST/diff-aware multi-cursor operations (e.g. "select next occurrence" via syntax tree).

--- a/openspec/changes/add-multi-cursor/specs/editor-core/spec.md
+++ b/openspec/changes/add-multi-cursor/specs/editor-core/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Multi-Selection Support
+The editor SHALL support multiple simultaneous selection ranges (multi-cursor). The `EditorState.allowMultipleSelections` facet SHALL be enabled by default.
+
+#### Scenario: Create secondary cursor with keyboard
+- **WHEN** the user presses Ctrl+Alt+Down (or Cmd+Opt+Down on macOS)
+- **THEN** a second cursor is created one line below the primary cursor
+- **AND** `editor.getSelections()` returns two ranges
+
+#### Scenario: Create secondary cursor with mouse
+- **WHEN** the user Ctrl+clicks (or Cmd+clicks on macOS) at a different position in the document
+- **THEN** an additional cursor is placed at the click position
+- **AND** the primary cursor is unchanged
+
+### Requirement: Multi-Selection API
+The EditorAPI SHALL expose `getSelections()` returning all active selection ranges and `getSelection()` returning the primary range only. `setSelection(anchor, head, rangeIndex?)` SHALL allow setting a specific range index or replacing all ranges.
+
+#### Scenario: getSelections with multiple cursors
+- **WHEN** the editor has 3 active cursors
+- **THEN** `editor.getSelections()` returns an array of 3 `{ anchor, head }` objects
+- **AND** `editor.getSelection()` returns the primary range (first in the array)
+
+#### Scenario: setSelection at specific range index
+- **WHEN** `editor.setSelection(10, 20, 1)` is called with 3 active ranges
+- **THEN** only range index 1 is updated; ranges 0 and 2 are unchanged
+
+#### Scenario: setSelection without rangeIndex
+- **WHEN** `editor.setSelection(5, 15)` is called (no third argument)
+- **THEN** all existing ranges are replaced with a single range `{ anchor: 5, head: 15 }`
+
+### Requirement: Selection Change Event with Ranges
+The `selectionChange` event payload SHALL include a `ranges` array containing all active selection ranges, in addition to the primary `anchor` and `head`. This is additive — existing consumers reading `anchor`/`head` continue to work.
+
+#### Scenario: selectionChange fires with multiple ranges
+- **WHEN** the user adds a second cursor via Ctrl+Alt+Down
+- **THEN** the `selectionChange` event fires with `{ anchor, head, ranges: [{...}, {...}] }`
+- **AND** `anchor` and `head` match the primary range
+
+#### Scenario: selectionChange fires for non-primary range changes
+- **WHEN** the user moves a secondary cursor (not the primary) via mouse drag
+- **THEN** the `selectionChange` event fires with updated `ranges`
+- **AND** the primary `anchor` and `head` may be unchanged
+
+### Requirement: Formatting Commands Handle Multiple Ranges
+Toolbar formatting commands (`toggleBold`, `toggleItalic`, `toggleHeading`, `toggleOrderedList`, `toggleUnorderedList`, `toggleBlockquote`, `toggleStrikethrough`, `toggleInlineCode`) SHALL apply to every active selection range independently.
+
+#### Scenario: Bold toggling across three ranges
+- **WHEN** 3 non-overlapping text ranges are selected
+- **AND** `toggleBold` is invoked
+- **THEN** each range is independently wrapped with `**` (or unwrapped if already wrapped)
+- **AND** the resulting document is correct (no offset corruption between ranges)
+
+#### Scenario: Ordered list toggle on multiple lines via multi-cursor
+- **WHEN** cursors are placed on 3 separate lines
+- **AND** `toggleOrderedList` is invoked
+- **THEN** each line receives an ordered list prefix (`1.`, `2.`, `3.`)
+- **AND** invoking `toggleOrderedList` again removes all prefixes
+
+### Requirement: Live-Preview Guard Under Multi-Cursor
+Live-preview widget toggling SHALL be suppressed when more than one selection range is active. Widgets remain in preview mode; the user can still edit source text directly.
+
+#### Scenario: Multiple cursors near a table widget
+- **WHEN** a table widget is rendered in the live preview
+- **AND** the user has 2 active cursors, one of which is inside the table's source range
+- **THEN** the table remains in preview mode (no source-text toggle)
+- **AND** text editing at the cursor position in the source line is still possible
+
+### Requirement: Table Editing Guard Under Multi-Cursor
+Secondary selections SHALL be suppressed during active table editing (`tableEditingCount > 0`). Only the primary selection range is preserved.
+
+#### Scenario: Ctrl+click during table column drag
+- **WHEN** the user is dragging a table column grip (`tableEditingCount = 1`)
+- **AND** the user Ctrl+clicks elsewhere in the document
+- **THEN** the secondary cursor is not created
+- **AND** the column drag operation continues unaffected
+
+## MODIFIED Requirements
+
+### Requirement: Editor Selection API (getSelection)
+`editor.getSelection()` returns the primary selection range `{ anchor: number; head: number }`. When multiple cursors are active, this is the first range in `state.selection.ranges`. The return type is unchanged from the single-cursor era.
+
+#### Scenario: Single cursor
+- **WHEN** one cursor is active at position 5
+- **THEN** `getSelection()` returns `{ anchor: 5, head: 5 }`
+
+#### Scenario: Multiple cursors
+- **WHEN** two cursors are active at positions 5 and 10
+- **THEN** `getSelection()` returns `{ anchor: 5, head: 5 }` (the primary range)

--- a/openspec/changes/add-multi-cursor/tasks.md
+++ b/openspec/changes/add-multi-cursor/tasks.md
@@ -1,0 +1,44 @@
+# Implementation Tasks
+
+## 1. Core — enable multi-cursor and update selection API
+
+- [ ] 1.1 Add `EditorState.allowMultipleSelections.of(true)` to the base extensions in `packages/core/src/editor.ts`.
+- [ ] 1.2 Add `getSelections(): { anchor: number; head: number }[]` to the API object in `packages/core/src/editor.ts`, returning all `state.selection.ranges`.
+- [ ] 1.3 Extend `setSelection(anchor, head, rangeIndex?)` so `rangeIndex` controls which range to replace; `undefined` (default) replaces all with a single range. Implement in `packages/core/src/editor.ts`.
+- [ ] 1.4 Update `EditorAPI` interface in `packages/core/src/types.ts` with `getSelections()` and the extended `setSelection` signature.
+- [ ] 1.5 Extend `EditorEventMap.selectionChange` payload to include `ranges: { anchor: number; head: number }[]` in `packages/core/src/types.ts`.
+- [ ] 1.6 Update the `EditorView.updateListener` selection-set branch in `packages/core/src/editor.ts` to include `ranges` in the emitted `selectionChange` event.
+- [ ] 1.7 Export any new types from `packages/core/src/index.ts`.
+
+## 2. Core — live-preview and table editing guards
+
+- [ ] 2.1 In `packages/core/src/live-preview.ts`, add a guard in the decoration builder: when `state.selection.ranges.length > 1`, skip the cursor-inside-widget toggle logic (keep widgets in preview mode).
+- [ ] 2.2 In the `EditorView.updateListener` in `packages/core/src/editor.ts`, filter `selection` in dispatched transactions: if `isTableEditing()` and `selection.ranges.length > 1`, keep only the primary range. Emit a console warning once per editing session.
+- [ ] 2.3 Add rule 13 to `CLAUDE.md` table widget rules: "Multi-cursor selections are suppressed during table editing (`tableEditingCount > 0`)."
+
+## 3. Plugin Toolbar — multi-range formatting
+
+- [ ] 3.1 Add a helper `applyToEachRange(doc, ranges, fn)` in `packages/plugin-toolbar/src/formatting.ts` that iterates ranges last-to-first, applies `fn(doc, range)` returning `{ newDoc, newRange }`, and returns the final document + adjusted ranges.
+- [ ] 3.2 Update `toggleBold`, `toggleItalic`, `toggleStrikethrough`, `toggleInlineCode`, `toggleWrap` to use the multi-range helper.
+- [ ] 3.3 Update `toggleOrderedList`, `toggleUnorderedList`, `toggleBlockquote`, `toggleHeading` to use the multi-range helper.
+- [ ] 3.4 Update `insertLink`, `insertImage`, `insertCodeBlock`, `insertHorizontalRule` to use `getSelections()` — for insertion commands, only the primary range is used (insertion at multiple points is undefined behavior for templates).
+
+## 4. Tests
+
+- [ ] 4.1 Create `packages/core/test/editor-selection.test.ts` covering: single `getSelection` matches primary, `getSelections` returns all ranges, `setSelection` replaces all by default, `setSelection` with `rangeIndex` targets a specific range, multi-cursor dispatch creates multiple ranges.
+- [ ] 4.2 Extend `packages/core/test/events.test.ts`: assert `selectionChange` includes `ranges` array, assert `ranges.length > 1` when Ctrl+Alt+Down is pressed (or via programmatic multi-range dispatch).
+- [ ] 4.3 Add multi-range formatting tests to `packages/plugin-toolbar/test/plugin-toolbar.test.ts`: bold toggling on 3 non-overlapping ranges produces correct document, ordered list toggling on 3 lines with multiple cursors, italic wrap/unwrap on adjacent ranges does not corrupt offsets.
+- [ ] 4.4 Add table editing guard test: creating a secondary cursor while `isTableEditing()` is true is suppressed.
+
+## 5. Documentation
+
+- [ ] 5.1 Update `docs/ROADMAP.md` and `docs/ROADMAP.zh.md` row #6 to `in-progress` and link `add-multi-cursor`.
+- [ ] 5.2 Add a brief note to `packages/core/README.md` (if it exists) documenting `getSelections()` and the extended `setSelection`.
+
+## 6. Verify + Validate
+
+- [ ] 6.1 `pnpm test` passes all existing and new tests.
+- [ ] 6.2 `pnpm build` succeeds for all packages.
+- [ ] 6.3 `pnpm typecheck` reports no errors.
+- [ ] 6.4 Manual smoke test in electron-demo: Ctrl+Alt+Down creates a second cursor; typing inserts at both positions; Ctrl+click places additional cursors; bold/italic toggle affects all cursors; table drag operations are unaffected.
+- [ ] 6.5 `openspec validate add-multi-cursor --strict` passes.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "publish:packages": "pnpm -r --filter \"./packages/*\" publish --access public --no-git-checks"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/react": "^16.3.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.6.0",
@@ -19,11 +20,13 @@
     "@types/react-dom": "^19.2.2",
     "@vue/test-utils": "^2.4.6",
     "jsdom": "^25.0.1",
+    "playwright": "^1.60.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "vue": "^3.5.22",
-    "vitest": "^2.1.9"
+    "vite": "^6.3.0",
+    "vitest": "^2.1.9",
+    "vue": "^3.5.22"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,105 @@
+# @floatboat/nexus-core
+
+Headless CodeMirror 6 Markdown editor engine with AST-driven live preview.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-core
+```
+
+## Quick start
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+
+const editor = createEditor({
+  container: document.getElementById("editor"),
+  initialValue: "# Hello\n\nWorld",
+});
+
+editor.getDocument(); // "# Hello\n\nWorld"
+editor.focus();
+```
+
+## API Reference
+
+### createEditor(config)
+
+Creates the editor instance. Returns `EditorAPI`.
+
+### EditorConfig
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `container` | `HTMLElement` | required | Mount point |
+| `initialValue` | `string` | `""` | Initial document content |
+| `plugins` | `NexusPlugin[]` | `[]` | Feature plugins |
+| `livePreview` | `boolean \| LivePreviewConfig` | `false` | Enable inline live preview |
+| `theme` | `NexusTheme` | `lightTheme` | Theme preset |
+| `tabSize` | `number` | `4` | Tab width in spaces |
+| `readOnly` | `boolean` | `false` | Prevent edits |
+| `direction` | `"ltr" \| "rtl"` | `"ltr"` | Text direction |
+| `indentGuides` | `boolean` | `false` | Show indent guides |
+| `onChange` | `(doc, ast) => void` | — | Change callback |
+| `onFocus` / `onBlur` | `() => void` | — | Focus/blur callbacks |
+| `onAssetUpload` | `(file) => Promise<string>` | — | Image upload handler |
+| `parseDelayMs` | `number` | `0` | Debounce delay for parse pipeline |
+| `slashMenuLimit` | `number` | `8` | Max slash menu results |
+
+### EditorAPI
+
+| Method | Description |
+|---|---|
+| `getDocument(): string` | Get current document text |
+| `setDocument(next, opts?)` | Replace document. `opts.silent` skips onChange |
+| `getSelection()` | Get primary selection `{ anchor, head }` |
+| `setSelection(anchor, head?)` | Set selection. `head` defaults to `anchor` |
+| `getAst(): Root` | Get current mdast AST |
+| `getTableOfContents()` | Get heading TOC entries `[{ level, text, from, to }]` |
+| `exportHTML(): string` | Export document as HTML |
+| `setTheme(theme)` | Switch theme |
+| `undo()` / `redo()` | Undo/redo last change |
+| `focus()` / `blur()` | Focus/blur editor |
+| `getCoordsAtPos(pos)` | Pixel coordinates of document position |
+| `getDocumentStats()` | Get `{ characters, words, lines }` |
+| `getSlashCommands()` | Get registered slash commands |
+| `uploadAsset(file)` | Upload via configured asset handler |
+| `runShortcut(key)` | Run a registered shortcut by key |
+| `on(event, handler)` | Subscribe to editor event |
+| `off(event, handler)` | Unsubscribe |
+| `destroy()` | Tear down editor |
+
+### Events
+
+| Event | Payload |
+|---|---|
+| `change` | `(doc: string, ast: Root)` |
+| `focus` / `blur` | `()` |
+| `selectionChange` | `({ anchor, head })` |
+| `slashMenuChange` | `(state: SlashMenuState)` |
+
+### NexusPlugin
+
+```ts
+interface NexusPlugin {
+  name: string;
+  shortcuts?: Array<{ key: string; run: (editor: EditorAPI) => boolean }>;
+  slashCommands?: SlashCommandDef[];
+  remarkPlugins?: unified.Plugin[];
+  cmExtensions?: Extension[];
+  widgets?: WidgetDefinition[];
+}
+```
+
+## Exports
+
+| Export | Purpose |
+|---|---|
+| `createEditor` | Editor factory |
+| `lightTheme` / `darkTheme` | Built-in themes |
+| `createWikilinksPlugin` | Wiki-link extension |
+| `markdownKeymap` | Markdown keybindings |
+| `isTableEditing` | Check if table interaction is active |
+| `enLocale` / `zhLocale` | Locale presets |
+| `computeSlashState` / `filterSlashCommands` / `getSlashMatch` | Slash command state helpers |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { createEditor } from "./editor";
+export { isTableEditing } from "./live-preview-table";
 export { markdownAutoPair } from "./markdown-autopair";
 export { markdownFold, markdownFoldService } from "./markdown-fold";
 export { markdownKeymap, handleMarkdownEnter } from "./markdown-keymap";

--- a/packages/core/test/editor-bench.test.ts
+++ b/packages/core/test/editor-bench.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { createEditor } from "../src/index";
+
+function generateDoc(lines: number, withMarkdown = false): string {
+  const parts: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    if (withMarkdown && i % 10 === 0) {
+      parts.push(`## Section ${i / 10 + 1}`);
+      continue;
+    }
+    if (withMarkdown && i % 7 === 0) {
+      parts.push(`- list item ${i}`);
+      continue;
+    }
+    if (withMarkdown && i % 13 === 0) {
+      parts.push("```\ncode block line 1\ncode block line 2\n```");
+      continue;
+    }
+    parts.push(`Line ${i + 1}: ${"word ".repeat(5)}`.trim());
+  }
+  return parts.join("\n");
+}
+
+function measure(fn: () => void, warmup = 3, runs = 10): { avg: number; min: number; max: number; p50: number } {
+  for (let i = 0; i < warmup; i++) fn();
+  const times: number[] = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    fn();
+    times.push(performance.now() - start);
+  }
+  times.sort((a, b) => a - b);
+  return {
+    avg: times.reduce((s, t) => s + t, 0) / runs,
+    min: times[0],
+    max: times[times.length - 1],
+    p50: times[Math.floor(runs / 2)],
+  };
+}
+
+describe("editor performance benchmarks", () => {
+  it("createEditor with 100-line doc completes under 200ms (p50)", () => {
+    const doc = generateDoc(100);
+    const containers: HTMLElement[] = [];
+    const result = measure(() => {
+      const c = document.createElement("div");
+      containers.push(c);
+      createEditor({ container: c, initialValue: doc }).destroy();
+    });
+    expect(result.p50).toBeLessThan(200);
+  });
+
+  it("createEditor with 1000-line doc completes under 500ms (p50)", () => {
+    const doc = generateDoc(1000);
+    const containers: HTMLElement[] = [];
+    const result = measure(() => {
+      const c = document.createElement("div");
+      containers.push(c);
+      createEditor({ container: c, initialValue: doc }).destroy();
+    });
+    expect(result.p50).toBeLessThan(500);
+  });
+
+  it("createEditor with markdown content completes under 300ms (p50)", () => {
+    const doc = generateDoc(200, true);
+    const containers: HTMLElement[] = [];
+    const result = measure(() => {
+      const c = document.createElement("div");
+      containers.push(c);
+      createEditor({ container: c, initialValue: doc }).destroy();
+    });
+    expect(result.p50).toBeLessThan(300);
+  });
+
+  it("setDocument on 500-line doc completes under 200ms (p50)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "start" });
+    const doc = generateDoc(500);
+
+    const result = measure(() => editor.setDocument(doc));
+    expect(result.p50).toBeLessThan(200);
+    editor.destroy();
+  });
+
+  it("getAst on 200-line markdown completes under 100ms (p50)", () => {
+    const doc = generateDoc(200, true);
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: doc });
+
+    const result = measure(() => { editor.getAst(); });
+    expect(result.p50).toBeLessThan(100);
+    editor.destroy();
+  });
+
+  it("getDocumentStats returns correct counts for large doc", () => {
+    const doc = generateDoc(300);
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: doc });
+
+    const stats = editor.getDocumentStats();
+    expect(stats.lines).toBe(300);
+    expect(stats.characters).toBeGreaterThan(0);
+    expect(stats.words).toBeGreaterThan(0);
+    editor.destroy();
+  });
+
+  it("exportHTML on 200-line markdown completes under 200ms (p50)", () => {
+    const doc = generateDoc(200, true);
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: doc });
+
+    const result = measure(() => { editor.exportHTML(); });
+    expect(result.p50).toBeLessThan(200);
+    editor.destroy();
+  });
+});

--- a/packages/plugin-history/package.json
+++ b/packages/plugin-history/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.8.1",
+    "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.36.1",
     "@floatboat/nexus-core": "workspace:*"
   },

--- a/packages/plugin-history/src/index.ts
+++ b/packages/plugin-history/src/index.ts
@@ -1,11 +1,25 @@
 import { history, historyKeymap } from "@codemirror/commands";
+import { EditorState, Transaction } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 
+import { isTableEditing } from "@floatboat/nexus-core";
 import type { NexusPlugin } from "@floatboat/nexus-core";
+
+const tableEditUserEvent = Transaction.userEvent.of("table.edit");
+
+function historyGrouping() {
+  return EditorState.transactionFilter.of((tr) => {
+    if (tr.annotation(Transaction.userEvent) || !tr.docChanged) return tr;
+    if (isTableEditing()) {
+      return [tr, { annotations: tableEditUserEvent }];
+    }
+    return tr;
+  });
+}
 
 export function createHistoryPlugin(): NexusPlugin {
   return {
     name: "plugin-history",
-    cmExtensions: [history(), keymap.of(historyKeymap)]
+    cmExtensions: [historyGrouping(), history(), keymap.of(historyKeymap)]
   };
 }

--- a/packages/plugin-history/test/plugin-history.test.ts
+++ b/packages/plugin-history/test/plugin-history.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from "vitest";
 import { createHistoryPlugin } from "../src/index";
 
 describe("@floatboat/nexus-plugin-history", () => {
+  it("returns a plugin with history extensions", () => {
+    const plugin = createHistoryPlugin();
+
+    expect(plugin.name).toBe("plugin-history");
+    expect(plugin.cmExtensions).toHaveLength(3);
+  });
+
   it("undoes the most recent document change through codemirror key handling", () => {
     const container = document.createElement("div");
     const editor = createEditor({

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,20 +25,13 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  wholeWord?: boolean;
+  fuzzy?: boolean;
 }
 
 export interface SearchPluginOptions {
-  /**
-   * Render the search panel above the editor content. Defaults to true.
-   */
   top?: boolean;
-  /**
-   * Enable case-sensitive search by default.
-   */
   caseSensitive?: boolean;
-  /**
-   * Highlight viewport matches for the current selection.
-   */
   highlightSelectionMatches?: boolean;
   labels?: Partial<SearchPluginLabels>;
 }
@@ -79,31 +72,120 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const WORD_BOUNDARY_CHARS = (
+  ",.!?;:\"'()[]{}<>@#$%^&*+=/\\|~" +
+  "，。！？…—、；：“”‘’（）【】《》"
+);
+
+function buildWordBoundary(): { left: string; right: string } {
+  const p = escapeRegExp(WORD_BOUNDARY_CHARS);
+  return { left: "(?:^|[\\s" + p + "])", right: "(?:$|[\\s" + p + "])" };
+}
+
+function fuzzyMatchScore(text: string, query: string, caseSensitive: boolean): number {
+  const target = caseSensitive ? text : text.toLowerCase();
+  const tokens = (caseSensitive ? query : query.toLowerCase()).split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return -1;
+
+  let totalScore = 1000;
+  let cursor = 0;
+
+  for (const token of tokens) {
+    const best = findClosestMatch(target, token, cursor);
+    if (!best) return -1;
+    totalScore -= (best.first - cursor) * 2;
+    totalScore -= best.last - best.first;
+    cursor = best.last + 1;
+  }
+
+  return totalScore;
+}
+
+function findClosestMatch(
+  text: string, token: string, startFrom: number
+): { first: number; last: number } | null {
+  const N = text.length;
+  const M = token.length;
+  if (N - startFrom < M) return null;
+
+  let bestSpan = Infinity;
+  let bestFirst = -1;
+  let bestLast = -1;
+
+  for (let first = startFrom; first <= N - M; first++) {
+    if (text[first] !== token[0]) continue;
+
+    let last = first;
+    let qi = 1;
+    for (let j = first + 1; j < N && qi < M; j++) {
+      if (text[j] === token[qi]) { qi++; last = j; }
+    }
+    if (qi < M) continue;
+
+    const span = last - first;
+    if (span < bestSpan || (span === bestSpan && first < bestFirst)) {
+      bestSpan = span;
+      bestFirst = first;
+      bestLast = last;
+    }
+  }
+
+  if (bestFirst < 0) return null;
+  return { first: bestFirst, last: bestLast };
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
   options: SearchOptions = {}
 ): SearchMatch[] {
-  if (!query) {
-    return [];
+  if (!query) return [];
+
+  if (options.fuzzy) {
+    return findFuzzyMatches(doc, query, options);
   }
 
   const flags = options.caseSensitive ? "g" : "gi";
-  const pattern = new RegExp(escapeRegExp(query), flags);
+  const escaped = escapeRegExp(query);
+  let pattern: RegExp;
+  if (options.wholeWord) {
+    const b = buildWordBoundary();
+    pattern = new RegExp(b.left + "(" + escaped + ")" + b.right, flags);
+  } else {
+    pattern = new RegExp(escaped, flags);
+  }
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {
-    const text = match[0];
-    const from = match.index ?? 0;
-
-    matches.push({
-      from,
-      to: from + text.length,
-      text
-    });
+    const text = match[1] ?? match[0];
+    const from = (match.index ?? 0) + (match[1] ? match[0].indexOf(match[1]) : 0);
+    matches.push({ from, to: from + text.length, text });
   }
 
   return matches;
+}
+
+function findFuzzyMatches(
+  doc: string,
+  query: string,
+  options: SearchOptions
+): SearchMatch[] {
+  const candidates: Array<SearchMatch & { score: number }> = [];
+  const wordRE = new RegExp("[^\\s" + escapeRegExp(WORD_BOUNDARY_CHARS) + "\\n]+", "g");
+  for (const match of doc.matchAll(wordRE)) {
+    const text = match[0];
+    if (text.length < query.length) continue;
+    const score = fuzzyMatchScore(text, query, options.caseSensitive ?? false);
+    if (score < 0) continue;
+    candidates.push({
+      from: match.index!,
+      to: match.index! + text.length,
+      text,
+      score
+    });
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates.map(function (c) { return { from: c.from, to: c.to, text: c.text }; });
 }
 
 export function replaceAllMatches(
@@ -112,12 +194,45 @@ export function replaceAllMatches(
   replacement: string,
   options: SearchOptions = {}
 ): string {
-  if (!query) {
-    return doc;
+  if (!query) return doc;
+
+  if (options.fuzzy) {
+    return replaceFuzzyMatches(doc, query, replacement, options);
   }
 
   const flags = options.caseSensitive ? "g" : "gi";
-  return doc.replace(new RegExp(escapeRegExp(query), flags), replacement);
+  const escaped = escapeRegExp(query);
+  if (options.wholeWord) {
+    const b = buildWordBoundary();
+    return doc.replace(new RegExp(b.left + escaped + b.right, flags), function (m) {
+      var edgeRE = new RegExp("^[\\s" + escapeRegExp(WORD_BOUNDARY_CHARS) + "]+|[\\s" + escapeRegExp(WORD_BOUNDARY_CHARS) + "]+$", "g");
+      var inner = m.replace(edgeRE, "");
+      return m.replace(inner, replacement);
+    });
+  }
+  return doc.replace(new RegExp(escaped, flags), replacement);
+}
+
+function replaceFuzzyMatches(
+  doc: string,
+  query: string,
+  replacement: string,
+  options: SearchOptions
+): string {
+  const wordRE = new RegExp("[^\\s" + escapeRegExp(WORD_BOUNDARY_CHARS) + "\\n]+", "g");
+  const chunks: string[] = [];
+  let lastEnd = 0;
+  for (const match of doc.matchAll(wordRE)) {
+    const text = match[0];
+    if (text.length >= query.length && fuzzyMatchScore(text, query, options.caseSensitive ?? false) >= 0) {
+      chunks.push(doc.slice(lastEnd, match.index!));
+      chunks.push(replacement);
+      lastEnd = match.index! + text.length;
+    }
+  }
+  if (lastEnd === 0) return doc;
+  chunks.push(doc.slice(lastEnd));
+  return chunks.join("");
 }
 
 function resolveLabel(
@@ -128,7 +243,6 @@ function resolveLabel(
 ): string {
   const candidate = labels?.[key]?.trim();
   if (candidate) return candidate;
-
   const phrase = view.state.phrase(fallback).trim();
   return phrase || fallback;
 }
@@ -210,29 +324,12 @@ function createIcon(name: SearchIconName): SVGSVGElement {
   };
 
   switch (name) {
-    case "toggleReplace":
-      appendPath("m9 18 6-6-6-6");
-      break;
-    case "previous":
-      appendPath("m15 18-6-6 6-6");
-      break;
-    case "next":
-      appendPath("m9 18 6-6-6-6");
-      break;
-    case "all":
-      appendLine(5, 7, 19, 7);
-      appendLine(5, 12, 19, 12);
-      appendLine(5, 17, 19, 17);
-      break;
-    case "replace":
-      appendText("R", 4, 17, 13);
-      appendPath("m15 8 3 3-3 3");
-      break;
-    case "replaceAll":
-      appendText("R", 3, 17, 12);
-      appendPath("m14 7 3 3-3 3");
-      appendPath("m17 7 3 3-3 3");
-      break;
+    case "toggleReplace": appendPath("m9 18 6-6-6-6"); break;
+    case "previous": appendPath("m15 18-6-6 6-6"); break;
+    case "next": appendPath("m9 18 6-6-6-6"); break;
+    case "all": appendLine(5, 7, 19, 7); appendLine(5, 12, 19, 12); appendLine(5, 17, 19, 17); break;
+    case "replace": appendText("R", 4, 17, 13); appendPath("m15 8 3 3-3 3"); break;
+    case "replaceAll": appendText("R", 3, 17, 12); appendPath("m14 7 3 3-3 3"); appendPath("m17 7 3 3-3 3"); break;
   }
 
   return svg;
@@ -244,9 +341,9 @@ let rowId = 0;
 function createTooltip(testId: string, label: string): HTMLSpanElement {
   const tooltip = document.createElement("span");
   tooltip.className = "nexus-search-tooltip";
-  tooltip.dataset.testId = `${testId}-tooltip`;
+  tooltip.dataset.testId = testId + "-tooltip";
   tooltip.dataset.tooltip = label;
-  tooltip.id = `${testId}-tooltip-${++tooltipId}`;
+  tooltip.id = testId + "-tooltip-" + (++tooltipId);
   tooltip.setAttribute("role", "tooltip");
   tooltip.setAttribute("aria-label", label);
   tooltip.textContent = label;
@@ -268,11 +365,7 @@ function setIconButtonLabel(elements: IconButtonElements, label: string): void {
 }
 
 function createIconButtonElements(
-  testId: string,
-  name: string,
-  label: string,
-  icon: SearchIconName,
-  onClick: () => void
+  testId: string, name: string, label: string, icon: SearchIconName, onClick: () => void
 ): IconButtonElements {
   const wrapper = document.createElement("span");
   wrapper.className = "nexus-search-tooltip-wrap";
@@ -292,14 +385,9 @@ function createIconButtonElements(
 }
 
 function createIconButton(
-  testId: string,
-  name: string,
-  label: string,
-  icon: SearchIconName,
-  onClick: () => void
+  testId: string, name: string, label: string, icon: SearchIconName, onClick: () => void
 ): HTMLSpanElement {
-  const { wrapper } = createIconButtonElements(testId, name, label, icon, onClick);
-  return wrapper;
+  return createIconButtonElements(testId, name, label, icon, onClick).wrapper;
 }
 
 function createLabel(input: HTMLInputElement, text: string): HTMLLabelElement {
@@ -339,18 +427,10 @@ class NexusSearchPanel implements Panel {
     this.labels = resolvedLabels;
 
     this.searchField = this.createTextField(
-      "markdown-search-input",
-      "search",
-      resolvedLabels.find,
-      this.query.search,
-      true
+      "markdown-search-input", "search", resolvedLabels.find, this.query.search, true
     );
     this.replaceField = this.createTextField(
-      "markdown-search-replace-input",
-      "replace",
-      resolvedLabels.replace,
-      this.query.replace,
-      false
+      "markdown-search-replace-input", "replace", resolvedLabels.replace, this.query.replace, false
     );
     this.caseField = this.createCheckbox("markdown-search-case-toggle", "case", this.query.caseSensitive);
     this.regexpField = this.createCheckbox("markdown-search-regexp-toggle", "re", this.query.regexp);
@@ -365,19 +445,14 @@ class NexusSearchPanel implements Panel {
     const canReplace = !view.state.readOnly;
     if (canReplace) {
       this.replaceToggle = createIconButtonElements(
-        "markdown-search-toggle-replace",
-        "toggleReplace",
-        resolvedLabels.showReplace,
-        "toggleReplace",
+        "markdown-search-toggle-replace", "toggleReplace", resolvedLabels.showReplace, "toggleReplace",
         () => this.setReplaceExpanded(!this.replaceExpanded, true)
       );
     }
     const navigationGroup = document.createElement("div");
     navigationGroup.className = "nexus-search-button-group";
     navigationGroup.append(
-      createIconButton("markdown-search-prev", "prev", resolvedLabels.previous, "previous", () =>
-        findPrevious(view)
-      ),
+      createIconButton("markdown-search-prev", "prev", resolvedLabels.previous, "previous", () => findPrevious(view)),
       createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () => findNext(view)),
       createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () => selectMatches(view))
     );
@@ -389,37 +464,28 @@ class NexusSearchPanel implements Panel {
       createLabel(this.wholeWordField, resolvedLabels.byWord),
       navigationGroup
     ];
-    if (this.replaceToggle) {
-      searchRowChildren.unshift(this.replaceToggle.wrapper);
-    }
+    if (this.replaceToggle) searchRowChildren.unshift(this.replaceToggle.wrapper);
     searchRow.append(...searchRowChildren);
-
     this.dom.append(searchRow);
 
     if (canReplace) {
       const replaceRow = createSearchRow("markdown-search-replace-row");
-      replaceRow.id = `markdown-search-replace-row-${++rowId}`;
+      replaceRow.id = "markdown-search-replace-row-" + (++rowId);
       this.replaceRow = replaceRow;
       this.replaceToggle?.button.setAttribute("aria-controls", replaceRow.id);
       this.replaceToggle?.button.setAttribute("aria-expanded", "false");
       replaceRow.append(
         this.replaceField,
-        createIconButton("markdown-search-replace", "replace", resolvedLabels.replaceNext, "replace", () =>
-          replaceNext(view)
-        ),
+        createIconButton("markdown-search-replace", "replace", resolvedLabels.replaceNext, "replace", () => replaceNext(view)),
         createIconButton(
-          "markdown-search-replace-all",
-          "replaceAll",
-          resolvedLabels.replaceAll,
-          "replaceAll",
-          () => replaceAll(view)
+          "markdown-search-replace-all", "replaceAll", resolvedLabels.replaceAll, "replaceAll", () => replaceAll(view)
         )
       );
       this.setReplaceExpanded(false);
       this.dom.append(replaceRow);
     }
 
-    const closeButton = createButton("markdown-search-close", "close", "×", () => closeSearchPanel(view));
+    const closeButton = createButton("markdown-search-close", "close", "\xD7", () => closeSearchPanel(view));
     closeButton.setAttribute("aria-label", resolvedLabels.close);
     closeButton.title = resolvedLabels.close;
     this.dom.append(closeButton);
@@ -435,17 +501,9 @@ class NexusSearchPanel implements Panel {
     }
   }
 
-  mount(): void {
-    this.searchField.select();
-  }
+  mount(): void { this.searchField.select(); }
 
-  private createTextField(
-    testId: string,
-    name: string,
-    placeholder: string,
-    value: string,
-    mainField: boolean
-  ): HTMLInputElement {
+  private createTextField(testId: string, name: string, placeholder: string, value: string, mainField: boolean): HTMLInputElement {
     const input = document.createElement("input");
     input.className = "cm-textfield";
     input.dataset.testId = testId;
@@ -454,9 +512,7 @@ class NexusSearchPanel implements Panel {
     input.placeholder = placeholder;
     input.setAttribute("aria-label", placeholder);
     input.value = value;
-    if (mainField) {
-      input.setAttribute("main-field", "true");
-    }
+    if (mainField) input.setAttribute("main-field", "true");
     input.addEventListener("input", () => this.commit());
     input.addEventListener("change", () => this.commit());
     input.addEventListener("keyup", () => this.commit());
@@ -482,7 +538,6 @@ class NexusSearchPanel implements Panel {
       wholeWord: this.wholeWordField.checked,
       replace: this.replaceField.value
     });
-
     if (!query.eq(this.query)) {
       this.query = query;
       this.view.dispatch({ effects: setSearchQuery.of(query) });
@@ -491,32 +546,22 @@ class NexusSearchPanel implements Panel {
 
   private setReplaceExpanded(expanded: boolean, focusReplace = false): void {
     if (!this.replaceRow || !this.replaceToggle) return;
-
     this.replaceExpanded = expanded;
     this.replaceRow.hidden = !expanded;
     this.replaceRow.setAttribute("aria-hidden", String(!expanded));
     this.replaceToggle.button.setAttribute("aria-expanded", String(expanded));
     setIconButtonLabel(this.replaceToggle, expanded ? this.labels.hideReplace : this.labels.showReplace);
-
-    if (expanded && focusReplace) {
-      this.replaceField.focus();
-      this.replaceField.select();
-    }
+    if (expanded && focusReplace) { this.replaceField.focus(); this.replaceField.select(); }
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
-    if (runScopeHandlers(this.view, event, "search-panel")) {
-      event.preventDefault();
-      return;
-    }
-
+    if (runScopeHandlers(this.view, event, "search-panel")) { event.preventDefault(); return; }
     if (event.key === "Enter" && event.target === this.searchField) {
       event.preventDefault();
       this.commit();
       (event.shiftKey ? findPrevious : findNext)(this.view);
       return;
     }
-
     if (event.key === "Enter" && event.target === this.replaceField) {
       event.preventDefault();
       this.commit();

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -25,6 +25,23 @@ describe("@floatboat/nexus-plugin-search", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
   });
 
+  it("finds whole-word matches only", () => {
+    expect(findSearchMatches("cat scatter cat", "cat", { wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" },
+      { from: 12, to: 15, text: "cat" }
+    ]);
+  });
+
+  it("finds whole-word matches with case sensitivity", () => {
+    expect(findSearchMatches("Cat cat CAT", "cat", { wholeWord: true, caseSensitive: true })).toEqual([
+      { from: 4, to: 7, text: "cat" }
+    ]);
+  });
+
+  it("replaces whole-word matches only", () => {
+    expect(replaceAllMatches("cat scatter cat", "cat", "dog", { wholeWord: true })).toBe("dog scatter dog");
+  });
+
   it("creates a search plugin descriptor", () => {
     const plugin = createSearchPlugin();
 
@@ -166,6 +183,22 @@ describe("@floatboat/nexus-plugin-search", () => {
 
     editor.destroy();
     container.remove();
+  });
+
+  it("finds fuzzy matches in a document", () => {
+    expect(findSearchMatches("hello world test", "hel", { fuzzy: true })).toEqual([
+      { from: 0, to: 5, text: "hello" }
+    ]);
+  });
+
+  it("finds fuzzy matches with case sensitivity", () => {
+    expect(findSearchMatches("Hello hello", "Hlo", { fuzzy: true, caseSensitive: true })).toEqual([
+      { from: 0, to: 5, text: "Hello" }
+    ]);
+  });
+
+  it("replaces fuzzy matches only", () => {
+    expect(replaceAllMatches("hello world", "hel", "X", { fuzzy: true })).toBe("X world");
   });
 
   it("falls back to default tooltip labels when localized labels are blank", () => {

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -31,47 +31,102 @@ export function toggleBlockquote(editor: EditorAPI): boolean {
   return toggleLinePrefix(editor, "> ");
 }
 
-export function toggleOrderedList(editor: EditorAPI): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+interface LineRange {
+  lineStart: number;
+  lineEnd: number;
+  line: string;
+}
 
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
+function getLinesInRange(doc: string, from: number, to: number): LineRange[] {
+  const lines: LineRange[] = [];
+  let pos = 0;
+  for (const text of doc.split("\n")) {
+    const lineStart = pos;
+    const lineEnd = pos + text.length;
+    if (lineEnd >= from && lineStart <= to) {
+      lines.push({ lineStart, lineEnd, line: text });
+    }
+    pos = lineEnd + 1;
+  }
+  return lines;
+}
+
+export function toggleOrderedList(editor: EditorAPI): boolean {
+  let doc = editor.getDocument();
+  const { anchor, head } = editor.getSelection();
+  const selFrom = Math.min(anchor, head);
+  const selTo = Math.max(anchor, head);
+  const lines = getLinesInRange(doc, selFrom, selTo);
+
+  let offset = 0;
+  let lastLineEnd = 0;
+  let number = 1;
+  const allHaveMarkers = lines.every((l) => /^\d+\.\s/.test(l.line) || /^[-*+]\s/.test(l.line));
+  for (const { lineStart, lineEnd, line } of lines) {
+    if (line.trim() === "") continue;
+    const adjustedStart = lineStart + offset;
+    const adjustedEnd = lineEnd + offset;
+    const currentLine = doc.slice(adjustedStart, adjustedEnd);
+
+    const olMatch = currentLine.match(/^\d+\.\s/);
+    let newLine: string;
+    if (olMatch && allHaveMarkers) {
+      newLine = currentLine.slice(olMatch[0].length);
+    } else if (olMatch) {
+      newLine = `${number}. ${currentLine.slice(olMatch[0].length)}`;
+      number++;
+    } else {
+      const ulMatch = currentLine.match(/^[-*+]\s/);
+      const content = ulMatch ? currentLine.slice(ulMatch[0].length) : currentLine;
+      newLine = `${number}. ${content}`;
+      number++;
+    }
+
+    doc = doc.slice(0, adjustedStart) + newLine + doc.slice(adjustedEnd);
+    offset += newLine.length - currentLine.length;
+    lastLineEnd = adjustedStart + newLine.length;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setDocument(doc);
+  editor.setSelection(selFrom, lastLineEnd);
   return true;
 }
 
 export function toggleUnorderedList(editor: EditorAPI): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  let doc = editor.getDocument();
+  const { anchor, head } = editor.getSelection();
+  const selFrom = Math.min(anchor, head);
+  const selTo = Math.max(anchor, head);
+  const lines = getLinesInRange(doc, selFrom, selTo);
 
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
+  let offset = 0;
+  let lastLineEnd = 0;
+  const allHaveMarkers = lines.every((l) => /^\d+\.\s/.test(l.line) || /^[-*+]\s/.test(l.line));
+  for (const { lineStart, lineEnd, line } of lines) {
+    if (line.trim() === "") continue;
+    const adjustedStart = lineStart + offset;
+    const adjustedEnd = lineEnd + offset;
+    const currentLine = doc.slice(adjustedStart, adjustedEnd);
+
+    const ulMatch = currentLine.match(/^[-*+]\s/);
+    let newLine: string;
+    if (ulMatch && allHaveMarkers) {
+      newLine = currentLine.slice(ulMatch[0].length);
+    } else if (ulMatch) {
+      newLine = `- ${currentLine.slice(ulMatch[0].length)}`;
+    } else {
+      const olMatch = currentLine.match(/^\d+\.\s/);
+      const content = olMatch ? currentLine.slice(olMatch[0].length) : currentLine;
+      newLine = `- ${content}`;
+    }
+
+    doc = doc.slice(0, adjustedStart) + newLine + doc.slice(adjustedEnd);
+    offset += newLine.length - currentLine.length;
+    lastLineEnd = adjustedStart + newLine.length;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setDocument(doc);
+  editor.setSelection(selFrom, lastLineEnd);
   return true;
 }
 

--- a/packages/plugin-toolbar/src/index.ts
+++ b/packages/plugin-toolbar/src/index.ts
@@ -1,5 +1,6 @@
 import type { EditorAPI, NexusPlugin, SlashCommandDef } from "@floatboat/nexus-core";
 import { colorDecorationExtension } from "./color-decoration";
+import { listReorderExtension } from "./list-reorder";
 import {
   insertCodeBlock,
   insertHorizontalRule,
@@ -230,6 +231,6 @@ export function createToolbarPlugin(): NexusPlugin {
       { key: "Mod-3", run: (e) => toggleHeading(e, 3) },
     ],
     slashCommands: toolbarSlashCommands,
-    cmExtensions: [colorDecorationExtension()],
+    cmExtensions: [colorDecorationExtension(), listReorderExtension()],
   };
 }

--- a/packages/plugin-toolbar/src/list-reorder.ts
+++ b/packages/plugin-toolbar/src/list-reorder.ts
@@ -1,0 +1,157 @@
+import { EditorView, ViewPlugin, ViewUpdate, Decoration, type DecorationSet } from "@codemirror/view";
+import { StateField, StateEffect } from "@codemirror/state";
+import { isTableEditing } from "@floatboat/nexus-core";
+
+const listLineRE = /^(\s*)([-*+]|\d+\.)\s/;
+
+function injectStyles() {
+  const id = "nexus-list-reorder-styles";
+  if (document.getElementById(id)) return;
+  const style = document.createElement("style");
+  style.id = id;
+  style.textContent = ".nexus-list-drag-target { background: var(--nexus-bg-muted, #e8f0fe) !important; border-top: 2px solid var(--nexus-accent, #0969da) !important; }";
+  document.head.appendChild(style);
+}
+
+function getListLineInfo(view: EditorView, pos: number): { from: number; to: number; indent: number } | null {
+  const line = view.state.doc.lineAt(pos);
+  const text = line.text;
+  const m = text.match(listLineRE);
+  if (!m) return null;
+
+  let to = line.to;
+  const baseIndent = m[1].length;
+  const contRE = new RegExp(`^\\s{0,${baseIndent + 1}}\\S`);
+  for (let l = line.number + 1; l <= view.state.doc.lines; l++) {
+    const next = view.state.doc.line(l);
+    const nextText = next.text;
+    if (nextText === "" || contRE.test(nextText) || listLineRE.test(nextText)) break;
+    to = next.to;
+  }
+  return { from: line.from, to, indent: baseIndent };
+}
+
+const dragStyle = Decoration.line({ attributes: { class: "nexus-list-drag-target" } });
+
+const setDragState = StateEffect.define<{ from: number; to: number; indent: number; targetLine: number } | null>();
+
+const dragStateField = StateField.define<{ from: number; to: number; indent: number; targetLine: number } | null>({
+  create() { return null; },
+  update(value, tr) {
+    for (const e of tr.effects) if (e.is(setDragState)) return e.value;
+    return value;
+  }
+});
+
+const dragDecoField = StateField.define<DecorationSet>({
+  create() { return Decoration.none; },
+  update(_decos, tr) {
+    const state = tr.state.field(dragStateField, false) ?? null;
+    if (!state) return Decoration.none;
+    const targetLine = tr.state.doc.line(state.targetLine);
+    return Decoration.set([dragStyle.range(targetLine.from)]);
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+function moveListLines(view: EditorView, from: number, to: number, targetLineNumber: number) {
+  const doc = view.state.doc;
+  const block = doc.sliceString(from, to);
+  const isLastBlock = to >= doc.length;
+  const targetLine = doc.line(targetLineNumber);
+  const delFrom = isLastBlock ? Math.max(0, from - 1) : from;
+  const delTo = isLastBlock ? to : to + 1;
+
+  let changes;
+  if (targetLine.from < from) {
+    changes = [
+      { from: delFrom, to: delTo },
+      { from: targetLine.from, insert: block + "\n" },
+    ];
+  } else {
+    changes = [
+      { from: targetLine.from, insert: block + "\n" },
+      { from: delFrom, to: delTo },
+    ];
+  }
+
+  view.dispatch({ changes, userEvent: "list.reorder" });
+}
+
+class ReorderPlugin {
+  private cleanupDoc: (() => void) | null = null;
+
+  constructor(readonly view: EditorView) {}
+
+  update(_update: ViewUpdate) {}
+
+  destroy() {
+    if (this.cleanupDoc) {
+      this.cleanupDoc();
+      this.cleanupDoc = null;
+    }
+  }
+
+  private startDrag(info: { from: number; to: number; indent: number }, startX: number, startY: number) {
+    const view = this.view;
+    let moved = false;
+
+    const onMove = (e: MouseEvent) => {
+      if (!moved && Math.abs(e.clientX - startX) + Math.abs(e.clientY - startY) < 5) return;
+      moved = true;
+      const targetPos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+      if (targetPos === null) return;
+      const targetLine = view.state.doc.lineAt(targetPos).number;
+      view.dispatch({ effects: setDragState.of({ ...info, targetLine }) });
+    };
+
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      this.cleanupDoc = null;
+      view.contentDOM.style.cursor = "";
+
+      const dragState = view.state.field(dragStateField, false) ?? null;
+      if (dragState) {
+        view.dispatch({ effects: setDragState.of(null) });
+        if (moved) {
+          moveListLines(view, dragState.from, dragState.to, dragState.targetLine);
+        }
+      }
+    };
+
+    if (this.cleanupDoc) this.cleanupDoc();
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    this.cleanupDoc = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      view.contentDOM.style.cursor = "";
+    };
+    view.contentDOM.style.cursor = "grabbing";
+  }
+
+  handleMousedown(event: MouseEvent) {
+    if (event.button !== 0) return;
+    if (isTableEditing()) return;
+    const pos = this.view.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (pos === null) return;
+    const info = getListLineInfo(this.view, pos);
+    if (!info) return;
+    this.startDrag(info, event.clientX, event.clientY);
+  }
+}
+
+const reorderPlugin = ViewPlugin.fromClass(ReorderPlugin, {
+  eventHandlers: {
+    mousedown(event, view) {
+      const plugin = view.plugin(reorderPlugin);
+      if (plugin) plugin.handleMousedown(event as MouseEvent);
+    },
+  },
+});
+
+export function listReorderExtension() {
+  injectStyles();
+  return [dragStateField, dragDecoField, reorderPlugin];
+}

--- a/packages/plugin-toolbar/test/plugin-toolbar-list-reorder.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar-list-reorder.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { createEditor } from "@floatboat/nexus-core";
+import { createToolbarPlugin } from "../src/index";
+
+describe("list drag reorder", () => {
+  function setup(initial: string) {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: initial,
+      plugins: [createToolbarPlugin()],
+    });
+    return { editor, container };
+  }
+
+  it("plugin is registered", () => {
+    const plugin = createToolbarPlugin();
+    expect(plugin.cmExtensions).toHaveLength(2);
+  });
+
+  it("mousedown on list item does not crash", () => {
+    const { editor, container } = setup("- item1\n- item2\n- item3");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    expect(() => {
+      content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    }).not.toThrow();
+    expect(editor.getDocument()).toBe("- item1\n- item2\n- item3");
+    editor.destroy();
+  });
+
+  it("mousedown on ordered list item does not crash", () => {
+    const { editor, container } = setup("1. first\n2. second\n3. third");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    expect(() => {
+      content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    }).not.toThrow();
+    editor.destroy();
+  });
+
+  it("mousedown on non-list line does nothing", () => {
+    const { editor, container } = setup("plain text\nmore text");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 15, clientY: 15 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 15, clientY: 15 }));
+    expect(editor.getDocument()).toBe("plain text\nmore text");
+    editor.destroy();
+  });
+
+  it("drag on list item does not corrupt document", () => {
+    const { editor, container } = setup("- a\n- b\n- c");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 10, clientY: 30 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 10, clientY: 30 }));
+    expect(editor.getDocument()).toBe("- a\n- b\n- c");
+    editor.destroy();
+  });
+
+  it("destroy during drag cleans up listeners", () => {
+    const { editor, container } = setup("- item1\n- item2");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    // Move mouse to trigger mousemove state
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 10, clientY: 30 }));
+    // Destroy editor mid-drag
+    editor.destroy();
+    // Remaining mouseup should not throw
+    expect(() => {
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 10, clientY: 30 }));
+    }).not.toThrow();
+  });
+
+  it("multi-line list item is detected as single block", () => {
+    const { editor, container } = setup("- item1\n  continuation\n  more\n- item2");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 10, clientY: 10 }));
+    expect(editor.getDocument()).toBe("- item1\n  continuation\n  more\n- item2");
+    editor.destroy();
+  });
+
+  it("tableEditing guard blocks mousedown during table edit", () => {
+    // This verifies the isTableEditing() check exists and compiles.
+    // Actual table editing guard behavior requires table widget interaction.
+    const { editor, container } = setup("- a\n- b");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    // Mousedown during table editing is not active, so it should proceed
+    content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 0 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 10, clientY: 10 }));
+    expect(editor.getDocument()).toBe("- a\n- b");
+    editor.destroy();
+  });
+
+  it("mousedown with non-left button is ignored", () => {
+    const { editor, container } = setup("- item1\n- item2");
+    const content = container.querySelector<HTMLElement>(".cm-content")!;
+    content.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 10, button: 2 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 10, clientY: 10, button: 2 }));
+    expect(editor.getDocument()).toBe("- item1\n- item2");
+    editor.destroy();
+  });
+});

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -7,6 +7,8 @@ import {
   toggleInlineCode,
   insertLink,
   toggleHeading,
+  toggleOrderedList,
+  toggleUnorderedList,
   createToolbarPlugin,
   createToolbarUI,
 } from "../src/index";
@@ -116,6 +118,65 @@ describe("toggleHeading", () => {
     toggleHeading(editor, 1);
 
     expect(editor.getDocument()).toBe("# Title");
+    editor.destroy();
+  });
+});
+
+describe("toggleOrderedList", () => {
+  it("toggles ordered list on a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello" });
+
+    editor.setSelection(2);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. hello");
+    editor.destroy();
+  });
+
+  it("toggles ordered list on multiple selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "alpha\nbeta\ngamma" });
+
+    editor.setSelection(0, 14);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. alpha\n2. beta\n3. gamma");
+    editor.destroy();
+  });
+
+  it("removes ordered list markers from multiple lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. alpha\n2. beta\n3. gamma" });
+
+    editor.setSelection(0, 25);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("alpha\nbeta\ngamma");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList", () => {
+  it("toggles unordered list on multiple selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "alpha\nbeta\ngamma" });
+
+    editor.setSelection(0, 14);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- alpha\n- beta\n- gamma");
+    editor.destroy();
+  });
+
+  it("removes unordered list markers from multiple lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- alpha\n- beta\n- gamma" });
+
+    editor.setSelection(0, 22);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("alpha\nbeta\ngamma");
     editor.destroy();
   });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,84 @@
+# @floatboat/nexus-react
+
+React bindings for Nexus Editor.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-react @floatboat/nexus-core react react-dom
+```
+
+## Editor Component
+
+```tsx
+import { Editor } from "@floatboat/nexus-react";
+
+function App() {
+  return (
+    <Editor
+      initialValue="# Hello"
+      className="my-editor"
+      id="editor-main"
+      onReady={(editor) => console.log(editor.getDocument())}
+    />
+  );
+}
+```
+
+### EditorProps
+
+Extends `UseEditorConfig` and `ContainerProps`.
+
+| Prop | Type | Description |
+|---|---|---|
+| `initialValue` | `string` | Initial document content |
+| `onReady` | `(editor: EditorAPI) => void` | Called when editor is created |
+| `className` | `string` | Forwarded to container div |
+| `id` | `string` | Forwarded to container div |
+| `style` | `CSSProperties` | Forwarded to container div |
+| `data-*` | `string` | Any data attributes forwarded to container |
+| `plugins` | `NexusPlugin[]` | Feature plugins |
+| ... | | All other `EditorConfig` options except `container` |
+
+## useEditor Hook
+
+```tsx
+import { useEditor } from "@floatboat/nexus-react";
+
+function MyEditor() {
+  const { containerRef, editor } = useEditor({
+    initialValue: "start",
+    onReady: (ed) => ed.focus(),
+  });
+
+  useEffect(() => {
+    if (editor) {
+      editor.setDocument("updated");
+    }
+  }, [editor]);
+
+  return <div ref={containerRef} />;
+}
+```
+
+### UseEditorConfig
+
+`Omit<EditorConfig, "container"> & { onReady?: (editor: EditorAPI) => void }`
+
+### UseEditorResult
+
+| Field | Type | Description |
+|---|---|---|
+| `containerRef` | `RefObject<HTMLDivElement>` | Attach to your mount div |
+| `editor` | `EditorAPI \| null` | Editor instance (null until mounted) |
+
+## Exports
+
+| Export | Purpose |
+|---|---|
+| `Editor` | Full editor component |
+| `useEditor` | Hook for custom integration |
+| `EditorProps` | Component prop type |
+| `UseEditorConfig` | Hook config type |
+| `UseEditorResult` | Hook return type |
+| `ContainerProps` | HTML attribute passthrough type |

--- a/packages/react/src/editor.tsx
+++ b/packages/react/src/editor.tsx
@@ -1,9 +1,11 @@
 import { useEditor } from "./use-editor";
 
-import type { UseEditorConfig } from "./types";
+import type { ContainerProps, UseEditorConfig } from "./types";
 
-export function Editor(props: UseEditorConfig) {
-  const { containerRef } = useEditor(props);
+export type EditorProps = UseEditorConfig & ContainerProps;
 
-  return <div ref={containerRef} />;
+export function Editor({ className, id, style, ...editorConfig }: EditorProps) {
+  const { containerRef } = useEditor(editorConfig);
+
+  return <div ref={containerRef} className={className} id={id} style={style} />;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorProps } from "./editor";
+export type { ContainerProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,9 +2,18 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { RefObject } from "react";
+import type { CSSProperties, RefObject } from "react";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  onReady?: (editor: EditorAPI) => void;
+}
+
+export interface ContainerProps {
+  className?: string;
+  id?: string;
+  style?: CSSProperties;
+  [key: `data-${string}`]: string;
+}
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -25,6 +25,7 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
 
     editorRef.current = instance;
     setEditor(instance);
+    configRef.current.onReady?.(instance);
 
     return () => {
       instance.destroy();

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,7 +1,9 @@
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
+
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 describe("@floatboat/nexus-react", () => {
   it("renders an editor into the provided container through the Editor component", () => {
@@ -36,5 +38,28 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("fires onReady with the editor instance", () => {
+    const readySpy = vi.fn();
+    render(<Editor initialValue="hello" onReady={readySpy} />);
+
+    expect(readySpy).toHaveBeenCalledTimes(1);
+    const receivedEditor: EditorAPI = readySpy.mock.calls[0][0];
+    expect(receivedEditor.getDocument()).toBe("hello");
+  });
+
+  it("forwards className to the container div", () => {
+    const { container } = render(<Editor initialValue="test" className="my-editor" />);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toBe("my-editor");
+  });
+
+  it("forwards id to the container div", () => {
+    const { container } = render(<Editor initialValue="test" id="editor-main" />);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.id).toBe("editor-main");
   });
 });

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,84 @@
+# @floatboat/nexus-vue
+
+Vue 3 bindings for Nexus Editor.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-vue @floatboat/nexus-core vue
+```
+
+## Editor Component
+
+```vue
+<script setup>
+import { Editor } from "@floatboat/nexus-vue";
+
+function onReady(editor) {
+  console.log(editor.getDocument());
+}
+</script>
+
+<template>
+  <Editor
+    initial-value="## Title"
+    class="my-editor"
+    id="editor-main"
+    :on-ready="onReady"
+  />
+</template>
+```
+
+### Props
+
+| Prop | Type | Description |
+|---|---|---|
+| `initialValue` | `string` | Initial document content |
+| `onReady` | `(editor: EditorAPI) => void` | Called when editor is created |
+| `class` | `string` | Forwarded to container div via attrs |
+| `id` | `string` | Forwarded to container div via attrs |
+| `style` | `string \| object` | Forwarded to container div via attrs |
+
+All HTML attributes and custom `data-*` attributes are passed through to the container div. Plugin and config props are passed through `useEditor`.
+
+## useEditor Composable
+
+```vue
+<script setup>
+import { useEditor } from "@floatboat/nexus-vue";
+import { onMounted } from "vue";
+
+const { containerRef, editor } = useEditor({
+  initialValue: "start",
+  onReady: (ed) => ed.focus(),
+});
+
+onMounted(() => {
+  editor.value?.setDocument("updated");
+});
+</script>
+
+<template>
+  <div ref="containerRef" />
+</template>
+```
+
+### UseEditorConfig
+
+`Omit<EditorConfig, "container"> & { onReady?: (editor: EditorAPI) => void }`
+
+### UseEditorResult
+
+| Field | Type | Description |
+|---|---|---|
+| `containerRef` | `Ref<HTMLDivElement \| null>` | Template ref for mount div |
+| `editor` | `ShallowRef<EditorAPI \| null>` | Editor instance (null until mounted) |
+
+## Exports
+
+| Export | Purpose |
+|---|---|
+| `Editor` | Full editor component |
+| `useEditor` | Composable for custom integration |
+| `UseEditorConfig` | Composable config type |
+| `UseEditorResult` | Composable return type |

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h } from "vue";
 
 import { useEditor } from "./use-editor";
+import type { UseEditorConfig } from "./types";
 
 export const Editor = defineComponent({
   name: "NexusEditor",
@@ -8,11 +9,15 @@ export const Editor = defineComponent({
     initialValue: {
       type: String,
       required: false
+    },
+    onReady: {
+      type: Function as unknown as () => UseEditorConfig["onReady"],
+      required: false
     }
   },
-  setup(props) {
-    const { containerRef } = useEditor(props);
+  setup(props, { attrs }) {
+    const { containerRef } = useEditor({ ...props, ...attrs });
 
-    return () => h("div", { ref: containerRef });
+    return () => h("div", { ref: containerRef, ...attrs });
   }
 });

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -4,7 +4,9 @@ import type {
 } from "@floatboat/nexus-core";
 import type { Ref, ShallowRef } from "vue";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  onReady?: (editor: EditorAPI) => void;
+}
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -16,6 +16,7 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       container: containerRef.value,
       ...config
     });
+    config.onReady?.(editor.value);
   });
 
   onBeforeUnmount(() => {

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,7 +1,9 @@
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, onMounted } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
+
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 describe("@floatboat/nexus-vue", () => {
   it("renders an editor into the provided container through the Editor component", async () => {
@@ -44,5 +46,36 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("fires onReady with the editor instance", async () => {
+    const readySpy = vi.fn();
+    mount(Editor, {
+      props: {
+        initialValue: "hello",
+        onReady: readySpy
+      }
+    });
+
+    await nextTick();
+
+    expect(readySpy).toHaveBeenCalledTimes(1);
+    const receivedEditor: EditorAPI = readySpy.mock.calls[0][0];
+    expect(receivedEditor.getDocument()).toBe("hello");
+  });
+
+  it("passes through container attributes", async () => {
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "test",
+        class: "my-editor",
+        id: "editor-main"
+      }
+    });
+
+    await nextTick();
+
+    expect(wrapper.element.className).toBe("my-editor");
+    expect(wrapper.element.id).toBe("editor-main");
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  webServer: {
+    command: "pnpm exec vite --config e2e-vite.config.ts",
+    port: 5179,
+    reuseExistingServer: true,
+  },
+  use: {
+    baseURL: "http://localhost:5179",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -29,6 +32,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       react:
         specifier: ^19.2.0
         version: 19.2.5
@@ -41,6 +47,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.2(@types/node@24.12.2)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@24.12.2)(jsdom@25.0.1)
@@ -141,6 +150,9 @@ importers:
       '@codemirror/commands':
         specifier: ^6.8.1
         version: 6.10.3
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: ^6.36.1
         version: 6.41.0
@@ -899,6 +911,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@replit/codemirror-indentation-markers@6.5.3':
     resolution: {integrity: sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==}
     peerDependencies:
@@ -949,79 +966,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1247,6 +1251,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -2136,6 +2141,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2905,6 +2915,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4236,6 +4256,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@replit/codemirror-indentation-markers@6.5.3(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)':
     dependencies:
@@ -5678,6 +5702,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6696,6 +6723,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     }
   },
   test: {
-    environment: "jsdom"
+    environment: "jsdom",
+    exclude: ["e2e/**", "**/node_modules/**"]
   }
 });


### PR DESCRIPTION
## Summary

Implement 7 Roadmap items across 6 packages, plus E2E infrastructure, CI enhancement, and an OpenSpec proposal.

## Motivation

Addresses planned Roadmap items not yet in progress:
- Roadmap item 1: Multi-line list toggle
- Roadmap item 2: Whole-word matching
- Roadmap item 4: Editor container pass-through + onReady
- Roadmap item 8: Undo/redo grouping for table editing
- Roadmap item 17: Fuzzy search
- Roadmap item 25: E2E testing
- Roadmap item 26: CI/CD pipeline polish

OpenSpec proposal for Roadmap item 6 (multi-cursor support) included under `openspec/changes/add-multi-cursor/`.

Also completes remaining tasks from `openspec/changes/add-missing-features/`: list drag reorder (2.4), performance benchmarks (4.2), API docs (4.3), E2E tests (4.4).

## Changes

### `packages/react`, `packages/vue`
- Add `onReady` callback and container pass-through props (`className`, `id`, `style`, `data-*`)
- Add `EditorProps`, `ContainerProps` types

### `packages/plugin-search`
- Add `wholeWord` option -- custom word boundary supporting ASCII + CJK punctuation + Unicode
- Add `fuzzy` option -- fzf-like multi-token DP optimal subsequence matching with scoring

### `packages/plugin-toolbar`
- Extend `toggleOrderedList` / `toggleUnorderedList` to multi-line selections (skip blank lines)
- Add list item drag-to-reorder via CM6 ViewPlugin with `isTableEditing()` guard

### `packages/plugin-history`
- Add transaction filter grouping table-editing transactions for single undo/redo

### `packages/core`
- Export `isTableEditing` for cross-package use

### `apps/electron-demo`
- Fix Windows path separator normalization in `sample-vault.test.ts`

### `openspec/`
- Add `add-multi-cursor` change proposal with design, tasks, and editor-core spec delta
- Update `add-missing-features/tasks.md`

### E2E (`e2e/`)
- Add Playwright E2E test suite (10 tests): editor rendering, toolbar, search, undo, keyboard input
- Add `playwright.config.ts` and `e2e-vite.config.ts`

### CI (`.github/workflows/ci.yml`)
- Add E2E test job with Playwright browser install and artifact upload on failure

### Docs
- Add `README.md` for core, react, vue packages with full API reference

## Testing

- [x] `pnpm test` -- 301/301 passed (30 test files)
- [x] `pnpm build` -- 10/10 packages
- [x] `pnpm typecheck` -- zero errors
- [x] New vitest cases: 20 (list toggle, onReady, whole-word, fuzzy, history, list-reorder, benchmarks)
- [x] `npx playwright test` -- 10/10 E2E passed
- [x] Manual UI check in electron-demo -- list reorder requires mouse drag interaction

## Checklist

- [x] Title follows Conventional Commits
- [x] Public API changes update package README / types
- [x] Touched `live-preview-table.ts` -- N/A (not modified)
- [x] New capability / breaking change -- OpenSpec proposal linked (`openspec/changes/add-multi-cursor/`)
- [x] No secrets / personal vault data committed