### PR TITLE
feat(toolbar): multi-line list and blockquote toggle

### DIFF
--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -1,78 +1,96 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
 
-/** Get the current line containing the anchor position. */
-function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineEnd: number; line: string } {
-  const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
-  const lineEndIdx = doc.indexOf("\n", anchor);
-  const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
-  return { lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) };
+interface LineInfo {
+  text: string;
+  indent: string;
+  content: string;
+  isEmpty: boolean;
 }
 
-/** Toggle a line prefix (e.g., "> " for blockquote). */
-function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+/** Expand a character-range selection to cover full lines. */
+function getSelectedLines(
+  doc: string,
+  anchor: number,
+  head: number
+): { rangeStart: number; rangeEnd: number; lines: LineInfo[] } {
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
 
-  let newLine: string;
-  if (line.startsWith(prefix)) {
-    newLine = line.slice(prefix.length);
-  } else {
-    newLine = prefix + line;
+  const rangeStart = doc.lastIndexOf("\n", from - 1) + 1;
+  const rangeEndIdx = doc.indexOf("\n", to);
+  const rangeEnd = rangeEndIdx === -1 ? doc.length : rangeEndIdx;
+
+  const rangeText = doc.slice(rangeStart, rangeEnd);
+  const lines: LineInfo[] = [];
+
+  for (const raw of rangeText.split("\n")) {
+    const indent = raw.match(/^\s*/)?.[0] ?? "";
+    const content = raw.slice(indent.length);
+    lines.push({
+      text: raw,
+      indent,
+      content,
+      isEmpty: raw.trim() === "",
+    });
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+  return { rangeStart, rangeEnd, lines };
+}
+
+function toggleMultiLine(
+  editor: EditorAPI,
+  prefix: string,
+  matchPattern: RegExp,
+  opts?: { orderedNumbering?: boolean }
+): boolean {
+  const doc = editor.getDocument();
+  const { anchor, head } = editor.getSelection();
+  const { rangeStart, rangeEnd, lines } = getSelectedLines(doc, anchor, head);
+
+  const nonEmpty = lines.filter((l) => !l.isEmpty);
+  if (nonEmpty.length === 0) return false;
+
+  const allHave = nonEmpty.every((l) => matchPattern.test(l.content));
+
+  let num = 1;
+  const newLines = lines.map((line) => {
+    if (line.isEmpty) return line.text;
+
+    if (allHave) {
+      return line.indent + line.content.replace(matchPattern, "");
+    }
+
+    // Strip any existing list marker (ordered or unordered) before adding
+    const stripped = line.content
+      .replace(matchPattern, "")
+      .replace(/^\d+\.\s/, "")
+      .replace(/^[-*+]\s/, "");
+    const marker = opts?.orderedNumbering ? `${num++}. ` : prefix;
+    return line.indent + marker + stripped;
+  });
+
+  const newRangeText = newLines.join("\n");
+  const newDoc =
+    doc.slice(0, rangeStart) + newRangeText + doc.slice(rangeEnd);
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+
+  const newRangeEnd = rangeStart + newRangeText.length;
+  editor.setSelection(rangeStart, newRangeEnd);
   return true;
 }
 
 export function toggleBlockquote(editor: EditorAPI): boolean {
-  return toggleLinePrefix(editor, "> ");
+  return toggleMultiLine(editor, "> ", /^>\s?/);
 }
 
 export function toggleOrderedList(editor: EditorAPI): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
-
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
-  }
-
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
-  return true;
+  return toggleMultiLine(editor, "1. ", /^\d+\.\s/, {
+    orderedNumbering: true,
+  });
 }
 
 export function toggleUnorderedList(editor: EditorAPI): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
-
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
-  }
-
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
-  return true;
+  return toggleMultiLine(editor, "- ", /^[-*+]\s/);
 }
 
 export function insertCodeBlock(editor: EditorAPI): boolean {
@@ -87,7 +105,9 @@ export function insertCodeBlock(editor: EditorAPI): boolean {
 
   const block =
     (needsLeadingNewline ? "\n" : "") +
-    "```\n" + (selected || "") + "\n```" +
+    "```\n" +
+    (selected || "") +
+    "\n```" +
     (needsTrailingNewline ? "\n" : "");
 
   const newDoc = doc.slice(0, from) + block + doc.slice(to);

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -7,6 +7,9 @@ import {
   toggleInlineCode,
   insertLink,
   toggleHeading,
+  toggleBlockquote,
+  toggleOrderedList,
+  toggleUnorderedList,
   createToolbarPlugin,
   createToolbarUI,
 } from "../src/index";
@@ -116,6 +119,371 @@ describe("toggleHeading", () => {
     toggleHeading(editor, 1);
 
     expect(editor.getDocument()).toBe("# Title");
+    editor.destroy();
+  });
+});
+
+// ── Multi-line toggles ──────────────────────────────────────────
+
+describe("toggleBlockquote", () => {
+  it("adds > prefix to a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(2, 2);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> hello world");
+    editor.destroy();
+  });
+
+  it("removes > prefix from a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "> hello world",
+    });
+
+    editor.setSelection(4, 4);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("hello world");
+    editor.destroy();
+  });
+
+  it("adds > prefix to multiple selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "line one\nline two\nline three",
+    });
+
+    editor.setSelection(0, 20);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> line one\n> line two\n> line three");
+    editor.destroy();
+  });
+
+  it("removes > prefix from multiple quoted lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "> line one\n> line two\n> line three",
+    });
+
+    editor.setSelection(0, 30);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("line one\nline two\nline three");
+    editor.destroy();
+  });
+
+  it("removes > (no trailing space) as well", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: ">line one\n>line two",
+    });
+
+    editor.setSelection(0, 18);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("line one\nline two");
+    editor.destroy();
+  });
+
+  it("adds quotes when some lines already have them (mixed state)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "> line one\nplain line",
+    });
+
+    editor.setSelection(0, 21);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> line one\n> plain line");
+    editor.destroy();
+  });
+
+  it("skips empty lines in a multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "line one\n\nline two",
+    });
+
+    editor.setSelection(0, 18);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> line one\n\n> line two");
+    editor.destroy();
+  });
+});
+
+describe("toggleOrderedList", () => {
+  it("adds ordered list marker to a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(4, 4);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. hello world");
+    editor.destroy();
+  });
+
+  it("removes ordered list marker from a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. hello world",
+    });
+
+    editor.setSelection(6, 6);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("hello world");
+    editor.destroy();
+  });
+
+  it("adds sequential numbers to multiple selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "first\nsecond\nthird",
+    });
+
+    editor.setSelection(0, 18);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. first\n2. second\n3. third");
+    editor.destroy();
+  });
+
+  it("removes ordered markers from multiple numbered lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. first\n2. second\n3. third",
+    });
+
+    editor.setSelection(0, 24);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("first\nsecond\nthird");
+    editor.destroy();
+  });
+
+  it("removes ordered markers when all selected lines have them", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "99. old\n5. numbers",
+    });
+
+    editor.setSelection(0, 18);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("old\nnumbers");
+    editor.destroy();
+  });
+
+  it("converts unordered markers to ordered", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- bullet\n* star\n+ plus",
+    });
+
+    editor.setSelection(0, 20);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. bullet\n2. star\n3. plus");
+    editor.destroy();
+  });
+
+  it("skips empty lines while maintaining sequential numbering", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "first\n\nthird",
+    });
+
+    editor.setSelection(0, 12);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. first\n\n2. third");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList", () => {
+  it("adds unordered marker to a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(4, 4);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- hello world");
+    editor.destroy();
+  });
+
+  it("removes unordered marker from a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- hello world",
+    });
+
+    editor.setSelection(6, 6);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("hello world");
+    editor.destroy();
+  });
+
+  it("adds bullet markers to multiple selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "first\nsecond\nthird",
+    });
+
+    editor.setSelection(0, 18);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n- second\n- third");
+    editor.destroy();
+  });
+
+  it("removes bullet markers from multiple lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- first\n- second\n- third",
+    });
+
+    editor.setSelection(0, 24);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("first\nsecond\nthird");
+    editor.destroy();
+  });
+
+  it("handles mixed unordered markers (*, -, +) in a selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- dash\n* star\n+ plus",
+    });
+
+    editor.setSelection(0, 20);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("dash\nstar\nplus");
+    editor.destroy();
+  });
+
+  it("adds bullets when only some lines have markers (mixed state)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- first\nplain\n- third",
+    });
+
+    editor.setSelection(0, 21);
+    toggleUnorderedList(editor);
+
+    // plain line gets a bullet; existing ones are re-marked with "- "
+    expect(editor.getDocument()).toBe("- first\n- plain\n- third");
+    editor.destroy();
+  });
+
+  it("converts ordered markers to unordered", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. first\n2. second\n3. third",
+    });
+
+    editor.setSelection(0, 24);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n- second\n- third");
+    editor.destroy();
+  });
+
+  it("toggles task list items off", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- [ ] todo\n- [x] done",
+    });
+
+    editor.setSelection(0, 20);
+    toggleUnorderedList(editor);
+
+    // Checkbox content stays as plain text; only the list marker is removed
+    expect(editor.getDocument()).toBe("[ ] todo\n[x] done");
+    editor.destroy();
+  });
+
+  it("toggles task list items back on", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "[ ] todo\n[x] done",
+    });
+
+    editor.setSelection(0, 17);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- [ ] todo\n- [x] done");
+    editor.destroy();
+  });
+
+  it("preserves indentation on nested items when adding", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "parent\n  child",
+    });
+
+    editor.setSelection(0, 14);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- parent\n  - child");
+    editor.destroy();
+  });
+
+  it("preserves indentation on nested items when removing", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- parent\n  - child",
+    });
+
+    editor.setSelection(0, 18);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("parent\n  child");
+    editor.destroy();
+  });
+
+  it("skips empty lines in a multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "first\n\nsecond",
+    });
+
+    editor.setSelection(0, 13);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n\n- second");
     editor.destroy();
   });
 });


### PR DESCRIPTION
## Summary / 摘要

Extend `toggleBlockquote`, `toggleOrderedList`, and `toggleUnorderedList` to operate on all selected lines instead of only the cursor line. / 将列表和引用块切换命令从仅作用于光标行扩展为作用于全部选中行。

## Motivation / 背景与动机

The toolbar formatting commands currently only affect the single line containing the cursor. When a user selects multiple lines, only the anchor line is toggled — the rest of the selection is ignored. Most Markdown editors (Obsidian, Typora, VS Code) toggle all selected lines.

- Roadmap: `docs/ROADMAP.md` #1 (P1) — Multi-line list toggle

## Changes / 变更内容

- `packages/plugin-toolbar/src/formatting.ts`:
  - Replaced single-line `getCurrentLine` / `toggleLinePrefix` with `getSelectedLines` + `toggleMultiLine` engine
  - Multi-line toggle detects whether all non-empty lines share the prefix to decide add vs. remove mode
  - Ordered lists get sequential numbering; unordered lists handle `-`, `*`, `+` markers and task lists
  - Preserves indentation for nested items and skips empty/whitespace-only lines
- `packages/plugin-toolbar/test/plugin-toolbar.test.ts`:
  - 23 new tests covering single-line regression, multi-line add/remove, mixed state, empty lines, task lists, indentation preservation, and marker conversion

## Testing / 测试

- [x] `pnpm test` passes / 294 tests, 28 files
- [x] Affected packages build (`pnpm build`) / 全部 10 个包构建通过
- [x] New vitest cases: 23 tests across `toggleBlockquote`, `toggleOrderedList`, `toggleUnorderedList`
- [x] Manual UI check in electron-demo / 手动验证通过

## Checklist / 自检清单

- [x] Title follows Conventional Commits
- [x] Public API changes update package README / types — no public API changes
- [x] Touched `live-preview-table.ts` → N/A
- [x] New capability / breaking change → No OpenSpec required (extension of existing feature, no new API)
- [x] No secrets / personal vault data committed