### PR TITLE
feat(search): 增加整词匹配支持

### DIFF
--- a/apps/electron-demo/src/renderer/search-bar.ts
+++ b/apps/electron-demo/src/renderer/search-bar.ts
@@ -100,6 +100,16 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   replaceAllBtn.title = "Replace all";
   replaceAllBtn.style.cssText = BTN_STYLES;
 
+  const wholeWordToggle = document.createElement("input");
+  wholeWordToggle.type = "checkbox";
+  wholeWordToggle.id = "nexus-search-whole-word";
+
+  const wholeWordLabel = document.createElement("label");
+  wholeWordLabel.htmlFor = wholeWordToggle.id;
+  wholeWordLabel.textContent = "Whole word";
+  wholeWordLabel.style.cssText = "display:flex;align-items:center;gap:4px;color:var(--nexus-text-muted, #666);";
+  wholeWordLabel.prepend(wholeWordToggle);
+
   // Count label
   const countLabel = document.createElement("span");
   countLabel.style.cssText = COUNT_STYLES;
@@ -113,7 +123,18 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   const spacer = document.createElement("div");
   spacer.style.flex = "1";
 
-  bar.append(findInput, prevBtn, nextBtn, countLabel, replaceInput, replaceBtn, replaceAllBtn, spacer, closeBtn);
+  bar.append(
+    findInput,
+    prevBtn,
+    nextBtn,
+    countLabel,
+    wholeWordLabel,
+    replaceInput,
+    replaceBtn,
+    replaceAllBtn,
+    spacer,
+    closeBtn
+  );
 
   // State
   let matches: Array<{ from: number; to: number }> = [];
@@ -129,7 +150,9 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
       return;
     }
     const doc = editor.getDocument();
-    matches = findSearchMatches(doc, query);
+    matches = findSearchMatches(doc, query, {
+      wholeWord: wholeWordToggle.checked,
+    });
     if (matches.length === 0) {
       currentIdx = -1;
       countLabel.textContent = "0 results";
@@ -178,13 +201,16 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
     const query = findInput.value;
     if (!query) return;
     const doc = editor.getDocument();
-    const newDoc = replaceAllMatches(doc, query, replaceInput.value);
+    const newDoc = replaceAllMatches(doc, query, replaceInput.value, {
+      wholeWord: wholeWordToggle.checked,
+    });
     editor.setDocument(newDoc);
     updateMatches();
   }
 
   // Event handlers
   findInput.addEventListener("input", updateMatches);
+  wholeWordToggle.addEventListener("change", updateMatches);
   findInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") { e.shiftKey ? goPrev() : goNext(); e.preventDefault(); }
     if (e.key === "Escape") { close(); }

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,6 +25,7 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  wholeWord?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -79,6 +80,15 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function createSearchPattern(query: string, options: SearchOptions = {}): RegExp {
+  const escaped = escapeRegExp(query);
+  const source = options.wholeWord
+    ? `(?<![\\p{L}\\p{N}_])${escaped}(?![\\p{L}\\p{N}_])`
+    : escaped;
+  const flags = options.caseSensitive ? "gu" : "giu";
+  return new RegExp(source, flags);
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -88,8 +98,7 @@ export function findSearchMatches(
     return [];
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  const pattern = new RegExp(escapeRegExp(query), flags);
+  const pattern = createSearchPattern(query, options);
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {
@@ -116,8 +125,7 @@ export function replaceAllMatches(
     return doc;
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  return doc.replace(new RegExp(escapeRegExp(query), flags), replacement);
+  return doc.replace(createSearchPattern(query, options), replacement);
 }
 
 function resolveLabel(

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -21,8 +21,23 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("supports whole-word matching", () => {
+    expect(findSearchMatches("cat scatter cat cat_ cat-cat", "cat", { wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" },
+      { from: 12, to: 15, text: "cat" },
+      { from: 21, to: 24, text: "cat" },
+      { from: 25, to: 28, text: "cat" }
+    ]);
+  });
+
   it("replaces all matches in a document", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
+  });
+
+  it("replaces only whole-word matches when requested", () => {
+    expect(replaceAllMatches("cat scatter cat cat_ cat-cat", "cat", "dog", { wholeWord: true })).toBe(
+      "dog scatter dog cat_ dog-dog"
+    );
   });
 
   it("creates a search plugin descriptor", () => {


### PR DESCRIPTION
## 修改背景

我在阅读 `plugin-search` 和 Electron demo 搜索栏实现时，发现搜索面板 UI 已经有 “By word / 整词匹配” 入口，但底层辅助函数 `findSearchMatches` 和 `replaceAllMatches` 还没有真正支持整词匹配。

这会导致：
- 插件 UI 能表达整词匹配能力
- 但外部复用这些辅助函数时，行为并不完整

## 本次修改

我主要做了三件事：

1. 在 `SearchOptions` 中补充 `wholeWord` 选项
2. 统一搜索正则构造逻辑，让查找和替换行为保持一致
3. 补充整词匹配相关测试，并把 Electron demo 搜索栏接上该能力

## 效果

例如搜索 `cat`：

`cat scatter cat cat_ cat-cat`

开启整词匹配后：
- 会命中独立出现的 `cat`
- 会命中 `cat-cat` 中被标点分隔的 `cat`
- 不会误命中 `scatter` 中的 `cat`
- 不会误命中 `cat_` 这种标识符片段

## 验证

我做了以下验证：

- 运行 `packages/plugin-search/test/plugin-search.test.ts`
- 检查 `packages/plugin-search` 的 TypeScript 类型
- 检查 `apps/electron-demo` 的 TypeScript 类型

## 说明

这个改动不涉及破坏性 API 变更，属于对现有搜索能力的补全，也让插件层和 demo 层的行为更一致。




<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue:
- Roadmap (docs/ROADMAP.md):
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
- `apps/electron-demo`:
- `openspec/`:

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Checklist / 自检清单

- [ ] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [ ] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
