### PR TITLE
fix(electron): 提升 dev-electron 启动稳定性

### DIFF
--- a/apps/electron-demo/scripts/dev-electron.mjs
+++ b/apps/electron-demo/scripts/dev-electron.mjs
@@ -1,8 +1,11 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
+import path from "node:path";
 import { build } from "tsup";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 await build({
   entry: ["electron/main.ts", "electron/preload.ts"],
@@ -14,16 +17,44 @@ await build({
   silent: true,
 });
 
-// Wait briefly for Vite dev server (started in parallel by npm-run-all)
-await new Promise((resolve) => setTimeout(resolve, 2000));
+const devServerUrl = "http://localhost:5173";
+
+async function waitForDevServer(url, timeoutMs = 30000) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The Vite server is still booting.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Timed out waiting for Vite dev server at ${url}`);
+}
+
+await waitForDevServer(devServerUrl);
 
 const electronPath = require("electron");
-const child = spawn(String(electronPath), ["dist-electron/main.js"], {
+const childEnv = { ...process.env };
+delete childEnv.ELECTRON_RUN_AS_NODE;
+delete childEnv.ELECTRON_NO_ASAR;
+
+const child = spawn(String(electronPath), ["."], {
+  cwd: appRoot,
   stdio: "inherit",
   env: {
-    ...process.env,
-    VITE_DEV_SERVER_URL: "http://localhost:5173",
+    ...childEnv,
+    VITE_DEV_SERVER_URL: devServerUrl,
   },
+});
+
+child.on("error", (error) => {
+  console.error("[dev-electron] Failed to start Electron:", error);
+  process.exit(1);
 });
 
 child.on("close", () => process.exit());


### PR DESCRIPTION
## 修改背景

在本地启动 Electron demo 过程中，我发现开发态启动流程有两个明显的不稳定点：

1. 启动 Electron 前只固定等待 2 秒，依赖 Vite 启动速度
2. 如果终端环境中存在 `ELECTRON_RUN_AS_NODE`，Electron 会退化成 Node 进程，导致应用无法正常拉起

这会让开发启动过程依赖本机环境和时序，稳定性比较差。

## 本次修改

我对 `dev-electron.mjs` 做了以下调整：

1. 将固定等待改为显式等待 Vite dev server 可访问
2. 启动 Electron 时从应用根目录进入，减少入口调用方式带来的脆弱性
3. 在启动前清理 `ELECTRON_RUN_AS_NODE` 等冲突环境变量
4. 增加子进程错误输出，方便定位启动失败原因

## 效果

修改后，Electron demo 的开发态启动流程：
- 不再依赖固定等待时间
- 对本地 shell 环境污染更有容错能力
- 启动问题更容易定位

## 验证

我做了以下验证：

- 启动 renderer dev server
- 运行 `npm run --prefix apps/electron-demo dev:electron`
- 确认 Electron 主进程和 renderer 进程能够正常拉起

## 说明

这个改动只影响开发态启动流程，不涉及公开 API，也不改变编辑器运行时逻辑。


<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue:
- Roadmap (docs/ROADMAP.md):
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
- `apps/electron-demo`:
- `openspec/`:

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Checklist / 自检清单

- [ ] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [ ] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
