### PR TITLE
feat(plugin-search): add fuzzy search mode

### DIFF
--- a/apps/electron-demo/sample-vault/fuzzy-demo.md
+++ b/apps/electron-demo/sample-vault/fuzzy-demo.md
@@ -1,0 +1,33 @@
+# Fuzzy search demo
+
+Back to [[index]].
+
+This note gives the search panel a few predictable targets for fuzzy matching.
+Open search with `Ctrl+F` or `Cmd+F`, enable **Fuzzy**, then try the compact
+queries below.
+
+## Try these
+
+| Query | Expected match |
+|---|---|
+| `nxe` | Nexus Editor |
+| `fb` | Floatboat |
+| `mkd` | Markdown |
+| `sps` | Search panel settings |
+
+## Targets
+
+Nexus Editor keeps Markdown as the source of truth.
+
+Floatboat builds local-first authoring tools.
+
+Markdown documents should stay readable outside the editor.
+
+Search panel settings include match case, regexp, by word, and fuzzy mode.
+
+## Notes
+
+- Fuzzy search is ordered: `nxe` matches `Nexus Editor`, but `exn` does not.
+- Fuzzy search is line-local in the panel, so a short query will not jump across
+  multiple paragraphs to create a surprising match.
+- The `Match case` toggle still applies when fuzzy mode is enabled.

--- a/apps/electron-demo/sample-vault/fuzzy-demo.md
+++ b/apps/electron-demo/sample-vault/fuzzy-demo.md
@@ -28,6 +28,6 @@ Search panel settings include match case, regexp, by word, and fuzzy mode.
 ## Notes
 
 - Fuzzy search is ordered: `nxe` matches `Nexus Editor`, but `exn` does not.
-- Fuzzy search is line-local in the panel, so a short query will not jump across
-  multiple paragraphs to create a surprising match.
+- Fuzzy search is line-local and bounded in the panel, so a short query will
+  not jump across long spans to create a surprising match.
 - The `Match case` toggle still applies when fuzzy mode is enabled.

--- a/apps/electron-demo/sample-vault/index.md
+++ b/apps/electron-demo/sample-vault/index.md
@@ -31,6 +31,7 @@ show a long list.
 ## Editor shortcuts
 
 - [[slash-demo]] — type `/` anywhere to open the floating command menu
+- [[fuzzy-demo]] - try fuzzy search queries such as `nxe` for `Nexus Editor`
 
 ## Edge cases
 

--- a/apps/electron-demo/src/renderer/search-bar.ts
+++ b/apps/electron-demo/src/renderer/search-bar.ts
@@ -51,6 +51,15 @@ const COUNT_STYLES = `
   min-width: 60px;
 `;
 
+const OPTION_STYLES = `
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--nexus-text, #24292e);
+  font-size: 12px;
+  white-space: nowrap;
+`;
+
 const CLOSE_BTN_STYLES = `
   background: none;
   border: none;
@@ -104,6 +113,13 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   const countLabel = document.createElement("span");
   countLabel.style.cssText = COUNT_STYLES;
 
+  const fuzzyInput = document.createElement("input");
+  fuzzyInput.type = "checkbox";
+  fuzzyInput.dataset.testId = "electron-search-fuzzy-toggle";
+  const fuzzyLabel = document.createElement("label");
+  fuzzyLabel.style.cssText = OPTION_STYLES;
+  fuzzyLabel.append(fuzzyInput, "Fuzzy");
+
   // Close
   const closeBtn = document.createElement("button");
   closeBtn.innerHTML = "&times;";
@@ -113,7 +129,18 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   const spacer = document.createElement("div");
   spacer.style.flex = "1";
 
-  bar.append(findInput, prevBtn, nextBtn, countLabel, replaceInput, replaceBtn, replaceAllBtn, spacer, closeBtn);
+  bar.append(
+    findInput,
+    fuzzyLabel,
+    prevBtn,
+    nextBtn,
+    countLabel,
+    replaceInput,
+    replaceBtn,
+    replaceAllBtn,
+    spacer,
+    closeBtn
+  );
 
   // State
   let matches: Array<{ from: number; to: number }> = [];
@@ -129,7 +156,7 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
       return;
     }
     const doc = editor.getDocument();
-    matches = findSearchMatches(doc, query);
+    matches = findSearchMatches(doc, query, { fuzzy: fuzzyInput.checked });
     if (matches.length === 0) {
       currentIdx = -1;
       countLabel.textContent = "0 results";
@@ -165,6 +192,7 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   }
 
   function doReplace() {
+    if (fuzzyInput.checked) return;
     if (currentIdx < 0 || currentIdx >= matches.length) return;
     const m = matches[currentIdx];
     const doc = editor.getDocument();
@@ -175,6 +203,7 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   }
 
   function doReplaceAll() {
+    if (fuzzyInput.checked) return;
     const query = findInput.value;
     if (!query) return;
     const doc = editor.getDocument();
@@ -185,6 +214,12 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
 
   // Event handlers
   findInput.addEventListener("input", updateMatches);
+  fuzzyInput.addEventListener("change", () => {
+    replaceInput.disabled = fuzzyInput.checked;
+    replaceBtn.disabled = fuzzyInput.checked;
+    replaceAllBtn.disabled = fuzzyInput.checked;
+    updateMatches();
+  });
   findInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") { e.shiftKey ? goPrev() : goNext(); e.preventDefault(); }
     if (e.key === "Escape") { close(); }

--- a/apps/electron-demo/src/renderer/search-bar.ts
+++ b/apps/electron-demo/src/renderer/search-bar.ts
@@ -1,5 +1,5 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
-import { findSearchMatches, replaceAllMatches } from "@floatboat/nexus-plugin-search";
+import { findSearchMatches, replaceAllMatches, type FuzzySearchMatch } from "@floatboat/nexus-plugin-search";
 
 export interface SearchBar {
   element: HTMLElement;
@@ -147,6 +147,18 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   let currentIdx = -1;
   let visible = false;
 
+  function rankedFuzzyMatches(doc: string, query: string): Array<{ from: number; to: number }> {
+    const ranked = findSearchMatches(doc, query, { fuzzy: true }) as FuzzySearchMatch[];
+    ranked.sort((a, b) => b.score - a.score || a.from - b.from);
+
+    const bestScore = ranked[0]?.score;
+    if (bestScore === undefined) {
+      return [];
+    }
+
+    return ranked.filter((match) => match.score >= bestScore - 12);
+  }
+
   function updateMatches() {
     const query = findInput.value;
     if (!query) {
@@ -156,10 +168,13 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
       return;
     }
     const doc = editor.getDocument();
-    matches = findSearchMatches(doc, query, { fuzzy: fuzzyInput.checked });
+    matches = fuzzyInput.checked ? rankedFuzzyMatches(doc, query) : findSearchMatches(doc, query);
     if (matches.length === 0) {
       currentIdx = -1;
       countLabel.textContent = "0 results";
+    } else if (fuzzyInput.checked) {
+      currentIdx = 0;
+      highlightCurrent();
     } else {
       // Find nearest match to current cursor
       const { anchor } = editor.getSelection();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 2  | Whole-word matching | `plugin-search` | P1 | planned | No | Extension of existing search options |
 | 15 | Regex search | `plugin-search` | P1 | in-progress | No | Watch escape edge cases — PR #9 in review |
 | 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | planned | Yes | Needs persistence (localStorage or host-injected) |
-| 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib |
+| 17 | Fuzzy search | `plugin-search` | P2 | done | Yes | Dependency-free ordered subsequence mode - see `openspec/changes/add-fuzzy-search-mode` |
 | 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0 | done | Yes | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui` |
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -25,7 +25,7 @@
 | 2  | whole-word 匹配 | `plugin-search` | P1 | planned | 否 | 现有 search 选项扩展 |
 | 15 | 正则搜索 | `plugin-search` | P1 | in-progress | 否 | 注意转义边界用例 —— PR #9 review 中 |
 | 16 | 历史命令 / 搜索记忆 | `plugin-search` + `plugin-slash` | P2 | planned | 是 | 需要持久化层（localStorage 或宿主注入） |
-| 17 | 模糊搜索 | `plugin-search` | P2 | planned | 否 | 评估 fzf-like 算法 vs. 第三方 lib |
+| 17 | 模糊搜索 | `plugin-search` | P2 | done | 是 | 无依赖有序子序列模式 —— 见 `openspec/changes/add-fuzzy-search-mode` |
 | 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | done | 是 | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash 命令浮层菜单 UI | `plugin-slash` + `electron-demo` | P0 | done | 是 | `createSlashMenuUI(editor, options)` —— 见 `openspec/changes/add-slash-menu-ui` |
 

--- a/openspec/changes/add-fuzzy-search-mode/design.md
+++ b/openspec/changes/add-fuzzy-search-mode/design.md
@@ -55,14 +55,15 @@ Rationale:
 ### Decision 2: Compile panel fuzzy queries to line-local regexp
 
 Adopted: `createFuzzySearchPattern("nxe")` returns
-`n[^\n]*?x[^\n]*?e`. The search panel enables CodeMirror `regexp` mode when
-the `Fuzzy` checkbox is checked.
+`n[^\n]{0,16}?x[^\n]{0,16}?e`. The search panel enables CodeMirror `regexp`
+mode when the `Fuzzy` checkbox is checked.
 
 Rationale:
 
 - CodeMirror already owns search state, next/previous navigation, selection,
   replacement commands, and match decorations.
-- A line-local regexp keeps fuzzy matches from spanning newlines.
+- A line-local, bounded-gap regexp keeps fuzzy matches from spanning newlines
+  or surfacing very loose long-span matches.
 - `escapeRegExp` is applied per query character, so punctuation like `.` or
   `[` is treated as literal input.
 
@@ -84,7 +85,7 @@ compiled panel query.
 | Risk | Mitigation |
 |---|---|
 | Generated regexp could treat user punctuation as syntax | Escape every query character before joining with the fuzzy gap pattern. |
-| Fuzzy regexp could span large portions of the document | Use `[^\n]*?` between characters so panel matching is line-local. |
+| Fuzzy regexp could span large portions of the document | Use bounded `[^\n]{0,16}?` gaps between characters so panel matching is line-local and compact. |
 | `SearchOptions.fuzzy` and `SearchPluginOptions.fuzzy` could be confused | Document the distinction: helper-level per-call override vs plugin-level panel default. |
 | Score metadata is unused by the current panel | Keep it documented as host-facing metadata for result list UIs; panel keeps CodeMirror order. |
 

--- a/openspec/changes/add-fuzzy-search-mode/design.md
+++ b/openspec/changes/add-fuzzy-search-mode/design.md
@@ -1,0 +1,101 @@
+# Design - Fuzzy Search Mode
+
+## Context
+
+`@floatboat/nexus-plugin-search` wraps CodeMirror's search extension with a
+Nexus-styled panel and a few pure helpers (`findSearchMatches`,
+`replaceAllMatches`) for hosts that want search behaviour outside the editor
+view. CodeMirror's built-in query supports literal and regexp matching, but it
+does not expose a first-class fuzzy query mode.
+
+Roadmap item #17 asks for fuzzy search and explicitly calls out evaluating an
+fzf-like algorithm versus a third-party library. This implementation keeps the
+change dependency-free and uses a small ordered-subsequence matcher.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add fuzzy matching without changing the default literal search behaviour.
+- Preserve existing search panel controls and keyboard shortcuts.
+- Keep panel input human-readable: the field should show `nxe`, not the
+  generated regexp.
+- Provide a reusable pure helper API with match offsets, matched indices, and a
+  score that host UIs can sort or display later.
+- Avoid cross-line fuzzy matches so a short query cannot accidentally span a
+  large document section.
+
+### Non-Goals
+
+- Introduce a third-party fuzzy library.
+- Replace CodeMirror's search extension or reimplement its navigation state.
+- Add ranked result lists or per-character match highlighting to the panel UI.
+- Persist search history.
+
+## Decisions
+
+### Decision 1: Dependency-free ordered subsequence matcher
+
+Adopted: a local matcher that scans each line for ordered query characters.
+Matches include:
+
+- `from` / `to`: range covering the first through last matched character;
+- `text`: the matched document slice;
+- `indices`: exact character offsets that satisfied the query;
+- `score`: a metadata score rewarding shorter spans, word-boundary hits, and
+  contiguous characters.
+
+Rationale:
+
+- The implementation is small enough to audit and test.
+- It avoids adding package weight to a focused search plugin.
+- The score metadata leaves room for future ranked result UIs without forcing
+  the current panel to grow a result list.
+
+### Decision 2: Compile panel fuzzy queries to line-local regexp
+
+Adopted: `createFuzzySearchPattern("nxe")` returns
+`n[^\n]*?x[^\n]*?e`. The search panel enables CodeMirror `regexp` mode when
+the `Fuzzy` checkbox is checked.
+
+Rationale:
+
+- CodeMirror already owns search state, next/previous navigation, selection,
+  replacement commands, and match decorations.
+- A line-local regexp keeps fuzzy matches from spanning newlines.
+- `escapeRegExp` is applied per query character, so punctuation like `.` or
+  `[` is treated as literal input.
+
+Alternative considered: a custom CodeMirror `SearchQuery.getCursor` path.
+Rejected for this PR because it would require replacing more of CodeMirror's
+search machinery and would make the P2 change much larger.
+
+### Decision 3: Fuzzy mode disables incompatible query toggles
+
+When fuzzy mode is active, the panel disables `Regexp` and `By word`. Fuzzy mode
+uses generated regexp internally, and whole-word filtering does not map cleanly
+to subsequence ranges such as `nxe` -> `Nexus Editor`.
+
+`Match case` remains active and applies both to the pure fuzzy helper and the
+compiled panel query.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Generated regexp could treat user punctuation as syntax | Escape every query character before joining with the fuzzy gap pattern. |
+| Fuzzy regexp could span large portions of the document | Use `[^\n]*?` between characters so panel matching is line-local. |
+| `SearchOptions.fuzzy` and `SearchPluginOptions.fuzzy` could be confused | Document the distinction: helper-level per-call override vs plugin-level panel default. |
+| Score metadata is unused by the current panel | Keep it documented as host-facing metadata for result list UIs; panel keeps CodeMirror order. |
+
+## Migration Plan
+
+None. All public API additions are optional and default to existing literal
+search behaviour.
+
+## Open Questions
+
+- Should a future search result list sort fuzzy matches by `score` rather than
+  document order?
+- Should fuzzy mode eventually highlight the individual matched indices inside
+  each selected range?

--- a/openspec/changes/add-fuzzy-search-mode/proposal.md
+++ b/openspec/changes/add-fuzzy-search-mode/proposal.md
@@ -1,0 +1,47 @@
+# Change: Add Fuzzy Search Mode
+
+## Why
+
+Roadmap item #17 calls for fuzzy search in `@floatboat/nexus-plugin-search`.
+The current plugin only performs literal CodeMirror search, which requires
+users to type the exact contiguous text they want to find.
+
+This change adds an ordered-subsequence search mode so short queries such as
+`nxe` can locate text such as `Nexus Editor` while keeping the existing search
+panel and keyboard navigation workflow.
+
+## What Changes
+
+- `@floatboat/nexus-plugin-search` exports fuzzy helpers:
+  - `findFuzzySearchMatches(doc, query, options?)`
+  - `createFuzzySearchPattern(query)`
+  - `FuzzySearchMatch`
+- `findSearchMatches(doc, query, { fuzzy: true })` delegates to the fuzzy
+  matcher while retaining the existing literal behaviour by default.
+- `createSearchPlugin({ fuzzy: true })` enables fuzzy mode by default in the
+  search panel.
+- The search panel gains a `Fuzzy` checkbox. When enabled, the panel compiles
+  the raw query to a safe line-local regexp for CodeMirror navigation while the
+  input continues to display the user's original query.
+- Documentation, roadmap entries, demo vault content, and tests are updated.
+
+No breaking changes: fuzzy mode is opt-in and existing search options keep
+their current defaults.
+
+## Impact
+
+- Affected specs:
+  - `plugins` (ADDED: fuzzy search mode for `@floatboat/nexus-plugin-search`)
+- Affected code:
+  - `packages/plugin-search/src/index.ts`
+  - `packages/plugin-search/test/plugin-search.test.ts`
+  - `packages/plugin-search/README.md`
+  - `apps/electron-demo/sample-vault/fuzzy-demo.md`
+  - `apps/electron-demo/sample-vault/index.md`
+  - `docs/ROADMAP.md`
+  - `docs/ROADMAP.zh.md`
+- New dependencies: none.
+- Out of scope:
+  - Fuzzy result ranking UI beyond the helper `score` metadata.
+  - Per-character fuzzy highlight decoration in the editor viewport.
+  - Persistent search history.

--- a/openspec/changes/add-fuzzy-search-mode/specs/plugins/spec.md
+++ b/openspec/changes/add-fuzzy-search-mode/specs/plugins/spec.md
@@ -1,0 +1,55 @@
+# Plugins Spec - Fuzzy Search Mode
+
+## ADDED Requirements
+
+### Requirement: provide fuzzy search helpers
+
+The `@floatboat/nexus-plugin-search` package SHALL provide dependency-free
+fuzzy search helpers that treat a query as an ordered subsequence of characters.
+The helpers SHALL return match ranges in document offsets, the exact matched
+character indices, and score metadata that rewards compact, boundary-aligned,
+and contiguous matches.
+
+#### Scenario: Ordered subsequence match
+- **WHEN** a host calls `findFuzzySearchMatches("Nexus Editor", "nxe")`
+- **THEN** the result SHALL include a match covering `Nexus E`
+- **AND** the match SHALL expose the document indices that satisfied `n`, `x`, and `e`
+- **AND** the match SHALL expose a numeric `score`
+
+#### Scenario: Case-sensitive fuzzy match
+- **WHEN** a host calls `findFuzzySearchMatches(doc, query, { caseSensitive: true })`
+- **THEN** only characters with matching case SHALL satisfy the fuzzy query
+
+#### Scenario: Common helper opt-in
+- **WHEN** a host calls `findSearchMatches(doc, query, { fuzzy: true })`
+- **THEN** the helper SHALL return fuzzy matches
+- **AND** omitting `fuzzy` SHALL retain the existing literal search behaviour
+
+### Requirement: provide fuzzy search panel mode
+
+The `@floatboat/nexus-plugin-search` panel SHALL provide an opt-in fuzzy mode.
+When enabled, the panel SHALL compile the raw user query to a safe line-local
+regular expression for CodeMirror navigation while continuing to display the
+raw query text in the input.
+
+#### Scenario: Plugin-level fuzzy default
+- **WHEN** a host enables `createSearchPlugin({ fuzzy: true })`
+- **AND** the search panel opens
+- **THEN** the `Fuzzy` checkbox SHALL be checked by default
+- **AND** the user SHALL be able to type a compact query such as `nxe`
+
+#### Scenario: Raw input is preserved
+- **WHEN** fuzzy mode is active
+- **AND** the user types `nxe`
+- **THEN** the input field SHALL continue to display `nxe`
+- **AND** CodeMirror SHALL receive a generated line-local regexp query that can match `Nexus Editor`
+
+#### Scenario: Incompatible toggles are disabled
+- **WHEN** fuzzy mode is active
+- **THEN** the `Regexp` and `By word` toggles SHALL be disabled
+- **AND** the `Match case` toggle SHALL remain available
+
+#### Scenario: Generated pattern is escaped and line-local
+- **WHEN** the query contains regexp syntax characters such as `.`
+- **THEN** `createFuzzySearchPattern` SHALL escape those characters
+- **AND** the generated gaps SHALL NOT match newline characters

--- a/openspec/changes/add-fuzzy-search-mode/specs/plugins/spec.md
+++ b/openspec/changes/add-fuzzy-search-mode/specs/plugins/spec.md
@@ -30,7 +30,9 @@ and contiguous matches.
 The `@floatboat/nexus-plugin-search` panel SHALL provide an opt-in fuzzy mode.
 When enabled, the panel SHALL compile the raw user query to a safe line-local
 regular expression for CodeMirror navigation while continuing to display the
-raw query text in the input.
+raw query text in the input. The generated pattern SHALL keep matches
+line-local and SHALL bound the gap between adjacent fuzzy characters to avoid
+very loose long-span matches.
 
 #### Scenario: Plugin-level fuzzy default
 - **WHEN** a host enables `createSearchPlugin({ fuzzy: true })`
@@ -49,7 +51,8 @@ raw query text in the input.
 - **THEN** the `Regexp` and `By word` toggles SHALL be disabled
 - **AND** the `Match case` toggle SHALL remain available
 
-#### Scenario: Generated pattern is escaped and line-local
+#### Scenario: Generated pattern is escaped, line-local, and bounded
 - **WHEN** the query contains regexp syntax characters such as `.`
 - **THEN** `createFuzzySearchPattern` SHALL escape those characters
 - **AND** the generated gaps SHALL NOT match newline characters
+- **AND** the generated gaps SHALL have a finite character limit

--- a/openspec/changes/add-fuzzy-search-mode/tasks.md
+++ b/openspec/changes/add-fuzzy-search-mode/tasks.md
@@ -1,0 +1,33 @@
+# Implementation Tasks
+
+## 1. Plugin Search
+
+- [x] 1.1 Add `FuzzySearchMatch`, `findFuzzySearchMatches`, and `createFuzzySearchPattern` exports.
+- [x] 1.2 Extend `SearchOptions` with per-call `fuzzy?: boolean`.
+- [x] 1.3 Extend `SearchPluginOptions` with plugin-level default `fuzzy?: boolean`.
+- [x] 1.4 Add a `Fuzzy` checkbox to the search panel and wire it to CodeMirror search state.
+- [x] 1.5 Disable incompatible regexp / whole-word toggles while fuzzy mode is active.
+- [x] 1.6 Preserve the raw user input in the search field while fuzzy mode compiles a regexp query internally.
+
+## 2. Tests
+
+- [x] 2.1 Cover ordered fuzzy matching with indices and score metadata.
+- [x] 2.2 Cover case-sensitive fuzzy matching.
+- [x] 2.3 Cover `findSearchMatches(..., { fuzzy: true })`.
+- [x] 2.4 Cover fuzzy regexp pattern generation and escaping.
+- [x] 2.5 Cover search panel fuzzy mode defaults, disabled controls, raw input preservation, and navigation.
+
+## 3. Documentation and Demo
+
+- [x] 3.1 Add `packages/plugin-search/README.md` with fuzzy usage and API notes.
+- [x] 3.2 Add `apps/electron-demo/sample-vault/fuzzy-demo.md`.
+- [x] 3.3 Link the demo note from `apps/electron-demo/sample-vault/index.md`.
+- [x] 3.4 Mark Roadmap item #17 as done and link this OpenSpec change in `docs/ROADMAP.md`.
+- [x] 3.5 Mirror the Roadmap item #17 status/link update in `docs/ROADMAP.zh.md`.
+
+## 4. Verify
+
+- [x] 4.1 `corepack pnpm vitest run packages/plugin-search/test/plugin-search.test.ts`
+- [x] 4.2 `corepack pnpm --filter @floatboat/nexus-plugin-search build`
+- [x] 4.3 `corepack pnpm -r exec tsc --noEmit`
+- [ ] 4.4 `openspec validate add-fuzzy-search-mode --strict` - CLI is not installed in this dev environment; spec format hand-linted against `openspec/AGENTS.md`.

--- a/packages/plugin-search/README.md
+++ b/packages/plugin-search/README.md
@@ -1,0 +1,109 @@
+# @floatboat/nexus-plugin-search
+
+CodeMirror-backed search and replace for
+[Nexus-Editor](https://github.com/floatboatai/Nexus-Editor).
+
+The package provides:
+
+- a Nexus-styled search panel opened through the standard CodeMirror search
+  keymap (`Mod-f`, `F3`, `Mod-g`, etc.);
+- pure helpers for literal, fuzzy, and replacement operations;
+- stable `data-test-id` selectors for host automation.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-plugin-search @floatboat/nexus-core
+```
+
+## Enable the plugin
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+import { createSearchPlugin } from "@floatboat/nexus-plugin-search";
+
+const editor = createEditor({
+  container,
+  initialValue: "# Nexus Editor\n\nSearch this document...",
+  plugins: [createSearchPlugin()],
+});
+```
+
+## Fuzzy search mode
+
+Fuzzy search treats the query as an ordered subsequence. For example, `nxe`
+matches `Nexus Editor` because the characters `n`, `x`, and `e` appear in that
+order.
+
+Enable fuzzy mode by default in the panel:
+
+```ts
+createEditor({
+  container,
+  plugins: [
+    createSearchPlugin({
+      fuzzy: true,
+    }),
+  ],
+});
+```
+
+When the panel's `Fuzzy` checkbox is active, the input still shows the raw user
+query (`nxe`). Internally the plugin compiles it to a safe line-local regular
+expression such as `n[^\n]*?x[^\n]*?e` so CodeMirror can keep handling
+navigation, selection, and match highlighting.
+
+Fuzzy mode disables the `Regexp` and `By word` toggles because those options do
+not map cleanly to subsequence ranges. `Match case` remains available.
+
+## Pure helpers
+
+```ts
+import {
+  createFuzzySearchPattern,
+  findFuzzySearchMatches,
+  findSearchMatches,
+  replaceAllMatches,
+} from "@floatboat/nexus-plugin-search";
+
+findSearchMatches("Hello hello", "hello");
+// [{ from: 0, to: 5, text: "Hello" }, { from: 6, to: 11, text: "hello" }]
+
+findSearchMatches("Nexus Editor", "nxe", { fuzzy: true });
+// [{ from: 0, to: 7, text: "Nexus E", indices: [0, 2, 6], score: ... }]
+
+findFuzzySearchMatches("Nexus Editor", "nxe", { caseSensitive: false });
+
+createFuzzySearchPattern("n.e");
+// "n[^\\n]*?\\.[^\\n]*?e"
+
+replaceAllMatches("cat scatter cat", "cat", "dog");
+// "dog sdogter dog"
+```
+
+## Option scopes
+
+`SearchPluginOptions.fuzzy` and `SearchOptions.fuzzy` intentionally have the
+same name but apply at different layers:
+
+| Option | Where it applies | Purpose |
+|---|---|---|
+| `SearchPluginOptions.fuzzy` | `createSearchPlugin({ fuzzy })` | Sets the search panel's default fuzzy checkbox state. |
+| `SearchOptions.fuzzy` | `findSearchMatches(doc, query, { fuzzy })` | Chooses fuzzy matching for a single helper call. |
+
+## API reference
+
+| Export | Purpose |
+|---|---|
+| `createSearchPlugin(options?)` | Create the CodeMirror-backed Nexus search plugin. |
+| `findSearchMatches(doc, query, options?)` | Find literal matches by default, or fuzzy matches when `options.fuzzy` is true. |
+| `findFuzzySearchMatches(doc, query, options?)` | Find ordered-subsequence matches with `indices` and `score` metadata. |
+| `createFuzzySearchPattern(query)` | Compile a raw fuzzy query to a line-local escaped regexp pattern. |
+| `replaceAllMatches(doc, query, replacement, options?)` | Replace all literal matches in a string. |
+| `SearchMatch` | Basic `{ from, to, text }` match shape. |
+| `FuzzySearchMatch` | Extends `SearchMatch` with `indices` and `score`. |
+| `SearchPluginOptions` | Panel options: `top`, `caseSensitive`, `fuzzy`, `highlightSelectionMatches`, `labels`. |
+
+See [`docs/ROADMAP.md`](../../docs/ROADMAP.md) item #17 and
+[`openspec/changes/add-fuzzy-search-mode`](../../openspec/changes/add-fuzzy-search-mode)
+for the change proposal.

--- a/packages/plugin-search/README.md
+++ b/packages/plugin-search/README.md
@@ -50,8 +50,9 @@ createEditor({
 
 When the panel's `Fuzzy` checkbox is active, the input still shows the raw user
 query (`nxe`). Internally the plugin compiles it to a safe line-local regular
-expression such as `n[^\n]*?x[^\n]*?e` so CodeMirror can keep handling
-navigation, selection, and match highlighting.
+expression such as `n[^\n]{0,16}?x[^\n]{0,16}?e` so CodeMirror can keep
+handling navigation, selection, and match highlighting without surfacing very
+loose long-span matches.
 
 Fuzzy mode disables the `Regexp` and `By word` toggles because those options do
 not map cleanly to subsequence ranges. `Match case` remains available.
@@ -75,7 +76,7 @@ findSearchMatches("Nexus Editor", "nxe", { fuzzy: true });
 findFuzzySearchMatches("Nexus Editor", "nxe", { caseSensitive: false });
 
 createFuzzySearchPattern("n.e");
-// "n[^\\n]*?\\.[^\\n]*?e"
+// "n[^\\n]{0,16}?\\.[^\\n]{0,16}?e"
 
 replaceAllMatches("cat scatter cat", "cat", "dog");
 // "dog sdogter dog"

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -94,6 +94,8 @@ const DEFAULT_LABELS: SearchPluginLabels = {
   close: "Close"
 };
 
+const DEFAULT_FUZZY_GAP = 16;
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -153,14 +155,18 @@ function findNextFuzzyCandidate(
 
     const indices = [start];
     let queryIndex = 1;
+    let previousIndex = start;
     for (
       let index = start + 1;
-      index < normalizedText.length && queryIndex < normalizedQuery.length;
+      index < normalizedText.length &&
+      queryIndex < normalizedQuery.length &&
+      index <= previousIndex + DEFAULT_FUZZY_GAP + 1;
       index += 1
     ) {
       if (normalizedText[index] === normalizedQuery[queryIndex]) {
         indices.push(index);
         queryIndex += 1;
+        previousIndex = index;
       }
     }
 
@@ -181,7 +187,7 @@ function findNextFuzzyCandidate(
 }
 
 export function createFuzzySearchPattern(query: string): string {
-  return Array.from(query).map(escapeRegExp).join("[^\\n]*?");
+  return Array.from(query).map(escapeRegExp).join(`[^\\n]{0,${DEFAULT_FUZZY_GAP}}?`);
 }
 
 export function findFuzzySearchMatches(

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -23,8 +23,20 @@ export interface SearchMatch {
   text: string;
 }
 
+export interface FuzzySearchMatch extends SearchMatch {
+  /**
+   * Character offsets inside the source document that satisfied the fuzzy query.
+   */
+  indices: number[];
+  /**
+   * Higher values represent tighter matches with more boundary/contiguous hits.
+   */
+  score: number;
+}
+
 export interface SearchOptions {
   caseSensitive?: boolean;
+  fuzzy?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -36,6 +48,11 @@ export interface SearchPluginOptions {
    * Enable case-sensitive search by default.
    */
   caseSensitive?: boolean;
+  /**
+   * Enable fuzzy search by default. Fuzzy search treats the query as an
+   * ordered subsequence, for example "nxe" matches "Nexus Editor".
+   */
+  fuzzy?: boolean;
   /**
    * Highlight viewport matches for the current selection.
    */
@@ -54,6 +71,7 @@ export interface SearchPluginLabels {
   matchCase: string;
   regexp: string;
   byWord: string;
+  fuzzy: string;
   replaceNext: string;
   replaceAll: string;
   close: string;
@@ -70,6 +88,7 @@ const DEFAULT_LABELS: SearchPluginLabels = {
   matchCase: "Match case",
   regexp: "Regexp",
   byWord: "By word",
+  fuzzy: "Fuzzy",
   replaceNext: "Replace",
   replaceAll: "Replace all",
   close: "Close"
@@ -79,6 +98,128 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function normalizeForSearch(value: string, caseSensitive: boolean | undefined): string {
+  return caseSensitive ? value : value.toLocaleLowerCase();
+}
+
+function isWordBoundary(text: string, index: number): boolean {
+  if (index === 0) {
+    return true;
+  }
+
+  const previous = text[index - 1];
+  const current = text[index];
+  if (!previous || !current) {
+    return true;
+  }
+
+  return (
+    /[\s()[\]{}.,:;'"`_*~#!?/-]/.test(previous) ||
+    (/[a-z]/.test(previous) && /[A-Z]/.test(current))
+  );
+}
+
+function scoreFuzzyMatch(text: string, indices: number[], queryLength: number): number {
+  const from = indices[0] ?? 0;
+  const to = (indices[indices.length - 1] ?? from) + 1;
+  let score = queryLength * 20 - (to - from - queryLength) * 2;
+
+  for (let i = 0; i < indices.length; i += 1) {
+    if (isWordBoundary(text, indices[i])) {
+      score += 8;
+    }
+    if (i > 0 && indices[i] === indices[i - 1] + 1) {
+      score += 10;
+    }
+  }
+
+  return score;
+}
+
+function findNextFuzzyCandidate(
+  text: string,
+  query: string,
+  from: number,
+  options: SearchOptions
+): FuzzySearchMatch | null {
+  const normalizedText = normalizeForSearch(text, options.caseSensitive);
+  const normalizedQuery = normalizeForSearch(query, options.caseSensitive);
+  const first = normalizedQuery[0];
+
+  for (let start = from; start < normalizedText.length; start += 1) {
+    if (normalizedText[start] !== first) {
+      continue;
+    }
+
+    const indices = [start];
+    let queryIndex = 1;
+    for (
+      let index = start + 1;
+      index < normalizedText.length && queryIndex < normalizedQuery.length;
+      index += 1
+    ) {
+      if (normalizedText[index] === normalizedQuery[queryIndex]) {
+        indices.push(index);
+        queryIndex += 1;
+      }
+    }
+
+    if (queryIndex === normalizedQuery.length) {
+      const matchFrom = indices[0];
+      const matchTo = indices[indices.length - 1] + 1;
+      return {
+        from: matchFrom,
+        to: matchTo,
+        text: text.slice(matchFrom, matchTo),
+        indices,
+        score: scoreFuzzyMatch(text, indices, normalizedQuery.length)
+      };
+    }
+  }
+
+  return null;
+}
+
+export function createFuzzySearchPattern(query: string): string {
+  return Array.from(query).map(escapeRegExp).join("[^\\n]*?");
+}
+
+export function findFuzzySearchMatches(
+  doc: string,
+  query: string,
+  options: SearchOptions = {}
+): FuzzySearchMatch[] {
+  if (!query) {
+    return [];
+  }
+
+  const matches: FuzzySearchMatch[] = [];
+  let lineStart = 0;
+
+  for (const line of doc.split("\n")) {
+    let offset = 0;
+    while (offset < line.length) {
+      const match = findNextFuzzyCandidate(line, query, offset, options);
+      if (!match) {
+        break;
+      }
+
+      const from = lineStart + match.from;
+      matches.push({
+        ...match,
+        from,
+        to: lineStart + match.to,
+        indices: match.indices.map((index) => lineStart + index)
+      });
+      offset = match.to;
+    }
+
+    lineStart += line.length + 1;
+  }
+
+  return matches;
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -86,6 +227,10 @@ export function findSearchMatches(
 ): SearchMatch[] {
   if (!query) {
     return [];
+  }
+
+  if (options.fuzzy) {
+    return findFuzzySearchMatches(doc, query, options);
   }
 
   const flags = options.caseSensitive ? "g" : "gi";
@@ -145,6 +290,7 @@ function resolveLabels(view: EditorView, labels: Partial<SearchPluginLabels> | u
     matchCase: resolveLabel(view, labels, "matchCase", DEFAULT_LABELS.matchCase),
     regexp: resolveLabel(view, labels, "regexp", DEFAULT_LABELS.regexp),
     byWord: resolveLabel(view, labels, "byWord", DEFAULT_LABELS.byWord),
+    fuzzy: resolveLabel(view, labels, "fuzzy", DEFAULT_LABELS.fuzzy),
     replaceNext: resolveLabel(view, labels, "replaceNext", DEFAULT_LABELS.replaceNext),
     replaceAll: resolveLabel(view, labels, "replaceAll", DEFAULT_LABELS.replaceAll),
     close: resolveLabel(view, labels, "close", DEFAULT_LABELS.close)
@@ -324,6 +470,7 @@ class NexusSearchPanel implements Panel {
   private readonly caseField: HTMLInputElement;
   private readonly regexpField: HTMLInputElement;
   private readonly wholeWordField: HTMLInputElement;
+  private readonly fuzzyField: HTMLInputElement;
   private readonly labels: SearchPluginLabels;
   private readonly replaceRow?: HTMLDivElement;
   private readonly replaceToggle?: IconButtonElements;
@@ -332,10 +479,10 @@ class NexusSearchPanel implements Panel {
   constructor(
     private readonly view: EditorView,
     readonly top: boolean,
-    labels: Partial<SearchPluginLabels> | undefined
+    options: SearchPluginOptions
   ) {
     this.query = getSearchQuery(view.state);
-    const resolvedLabels = resolveLabels(view, labels);
+    const resolvedLabels = resolveLabels(view, options.labels);
     this.labels = resolvedLabels;
 
     this.searchField = this.createTextField(
@@ -355,6 +502,7 @@ class NexusSearchPanel implements Panel {
     this.caseField = this.createCheckbox("markdown-search-case-toggle", "case", this.query.caseSensitive);
     this.regexpField = this.createCheckbox("markdown-search-regexp-toggle", "re", this.query.regexp);
     this.wholeWordField = this.createCheckbox("markdown-search-word-toggle", "word", this.query.wholeWord);
+    this.fuzzyField = this.createCheckbox("markdown-search-fuzzy-toggle", "fuzzy", options.fuzzy ?? false);
 
     this.dom = document.createElement("div");
     this.dom.className = "cm-search nexus-search-panel";
@@ -387,6 +535,7 @@ class NexusSearchPanel implements Panel {
       createLabel(this.caseField, resolvedLabels.matchCase),
       createLabel(this.regexpField, resolvedLabels.regexp),
       createLabel(this.wholeWordField, resolvedLabels.byWord),
+      createLabel(this.fuzzyField, resolvedLabels.fuzzy),
       navigationGroup
     ];
     if (this.replaceToggle) {
@@ -423,6 +572,7 @@ class NexusSearchPanel implements Panel {
     closeButton.setAttribute("aria-label", resolvedLabels.close);
     closeButton.title = resolvedLabels.close;
     this.dom.append(closeButton);
+    this.syncSearchModeControls();
   }
 
   update(update: ViewUpdate): void {
@@ -470,16 +620,20 @@ class NexusSearchPanel implements Panel {
     input.name = name;
     input.setAttribute("form", "");
     input.checked = checked;
-    input.addEventListener("change", () => this.commit());
+    input.addEventListener("change", () => {
+      this.syncSearchModeControls();
+      this.commit();
+    });
     return input;
   }
 
   private commit(): void {
+    const fuzzy = this.fuzzyField.checked;
     const query = new SearchQuery({
-      search: this.searchField.value,
+      search: fuzzy ? createFuzzySearchPattern(this.searchField.value) : this.searchField.value,
       caseSensitive: this.caseField.checked,
-      regexp: this.regexpField.checked,
-      wholeWord: this.wholeWordField.checked,
+      regexp: fuzzy || this.regexpField.checked,
+      wholeWord: fuzzy ? false : this.wholeWordField.checked,
       replace: this.replaceField.value
     });
 
@@ -531,6 +685,14 @@ class NexusSearchPanel implements Panel {
     this.caseField.checked = query.caseSensitive;
     this.regexpField.checked = query.regexp;
     this.wholeWordField.checked = query.wholeWord;
+    this.fuzzyField.checked = false;
+    this.syncSearchModeControls();
+  }
+
+  private syncSearchModeControls(): void {
+    const fuzzy = this.fuzzyField.checked;
+    this.regexpField.disabled = fuzzy;
+    this.wholeWordField.disabled = fuzzy;
   }
 }
 
@@ -540,7 +702,7 @@ export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlug
       top: options.top ?? true,
       caseSensitive: options.caseSensitive ?? false,
       literal: true,
-      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels)
+      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options)
     }),
     keymap.of(searchKeymap)
   ];

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { createEditor } from "@floatboat/nexus-core";
 import {
+  createFuzzySearchPattern,
   createSearchPlugin,
+  findFuzzySearchMatches,
   findSearchMatches,
   replaceAllMatches
 } from "../src/index";
@@ -19,6 +21,30 @@ describe("@floatboat/nexus-plugin-search", () => {
     expect(findSearchMatches("Hello hello HELLO", "hello", { caseSensitive: true })).toEqual([
       { from: 6, to: 11, text: "hello" }
     ]);
+  });
+
+  it("finds ordered fuzzy matches with scoring metadata", () => {
+    expect(findFuzzySearchMatches("Nexus Editor\nNext Entry", "nxe")).toEqual([
+      expect.objectContaining({ from: 0, to: 7, text: "Nexus E", indices: [0, 2, 6] }),
+      expect.objectContaining({ from: 13, to: 19, text: "Next E", indices: [13, 15, 18] })
+    ]);
+  });
+
+  it("supports fuzzy search through the common find helper", () => {
+    expect(findSearchMatches("alpha beta\nalphabet", "abt", { fuzzy: true })).toEqual([
+      expect.objectContaining({ from: 0, to: 9, text: "alpha bet", indices: [0, 6, 8] }),
+      expect.objectContaining({ from: 11, to: 19, text: "alphabet", indices: [11, 16, 18] })
+    ]);
+  });
+
+  it("supports case-sensitive fuzzy search", () => {
+    expect(findFuzzySearchMatches("Nexus Editor\nnexus editor", "NE", { caseSensitive: true })).toEqual([
+      expect.objectContaining({ from: 0, to: 7, text: "Nexus E", indices: [0, 6] })
+    ]);
+  });
+
+  it("creates a line-local regexp pattern for fuzzy search panel queries", () => {
+    expect(createFuzzySearchPattern("n.e")).toBe("n[^\\n]*?\\.[^\\n]*?e");
   });
 
   it("replaces all matches in a document", () => {
@@ -81,6 +107,7 @@ describe("@floatboat/nexus-plugin-search", () => {
     const replaceToggle = container.querySelector<HTMLButtonElement>(
       '[data-test-id="markdown-search-toggle-replace"]'
     );
+    const fuzzyToggle = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-fuzzy-toggle"]');
     const replaceToggleTooltip = container.querySelector<HTMLElement>(
       '[data-test-id="markdown-search-toggle-replace-tooltip"]'
     );
@@ -95,6 +122,8 @@ describe("@floatboat/nexus-plugin-search", () => {
     expect(nextTooltip?.dataset.tooltip).toBe("下一个");
     expect(nextTooltip?.textContent).toBe("下一个");
     expect(container.querySelector('[data-test-id="markdown-search-find-row"]')).not.toBeNull();
+    expect(fuzzyToggle).not.toBeNull();
+    expect(fuzzyToggle?.checked).toBe(false);
     expect(replaceToggle?.getAttribute("aria-expanded")).toBe("false");
     expect(replaceToggle?.getAttribute("aria-label")).toBe("Show replace");
     expect(replaceToggle?.getAttribute("aria-controls")).toBe(replaceRow?.id);
@@ -163,6 +192,65 @@ describe("@floatboat/nexus-plugin-search", () => {
     const selection = editor.getSelection();
     expect(Math.min(selection.anchor, selection.head)).toBe(6);
     expect(Math.max(selection.anchor, selection.head)).toBe(10);
+
+    editor.destroy();
+    container.remove();
+  });
+
+  it("navigates fuzzy panel queries while preserving the raw input text", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const editor = createEditor({
+      container,
+      initialValue: "Nexus Editor\nplain text",
+      plugins: [createSearchPlugin({ fuzzy: true })]
+    });
+
+    const content = container.querySelector<HTMLElement>(".cm-content");
+    content?.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+    );
+    if (!container.querySelector('[data-test-id="markdown-search-bar"]')) {
+      content?.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          code: "KeyF",
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+    }
+
+    const input = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-input"]');
+    const fuzzyToggle = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-fuzzy-toggle"]');
+    const regexpToggle = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-regexp-toggle"]');
+    const wordToggle = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-word-toggle"]');
+    expect(fuzzyToggle?.checked).toBe(true);
+    expect(regexpToggle?.disabled).toBe(true);
+    expect(wordToggle?.disabled).toBe(true);
+
+    input!.value = "nxe";
+    input!.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+    input!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        code: "Enter",
+        bubbles: true,
+        cancelable: true
+      })
+    );
+
+    expect(input?.value).toBe("nxe");
+    const selection = editor.getSelection();
+    expect(Math.min(selection.anchor, selection.head)).toBe(0);
+    expect(Math.max(selection.anchor, selection.head)).toBe(7);
 
     editor.destroy();
     container.remove();

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -43,8 +43,14 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("ignores overly loose fuzzy matches", () => {
+    expect(
+      findFuzzySearchMatches("Search panel settings include match case, regexp, by word, and fuzzy mode", "nxe")
+    ).toEqual([]);
+  });
+
   it("creates a line-local regexp pattern for fuzzy search panel queries", () => {
-    expect(createFuzzySearchPattern("n.e")).toBe("n[^\\n]*?\\.[^\\n]*?e");
+    expect(createFuzzySearchPattern("n.e")).toBe("n[^\\n]{0,16}?\\.[^\\n]{0,16}?e");
   });
 
   it("replaces all matches in a document", () => {


### PR DESCRIPTION
## Summary / 摘要

为 `@floatboat/nexus-plugin-search` 增加 fuzzy search mode（模糊搜索模式）。

## Motivation / 背景与动机

- Issue: N/A
- Roadmap（`docs/ROADMAP.md`）：#17 Fuzzy search（`plugin-search`，P2）
- OpenSpec change：`openspec/changes/add-fuzzy-search-mode`

本 PR 实现 Roadmap 中 P2 级别的 fuzzy search 功能。实现方式是无第三方依赖的有序子序列匹配算法，同时保持现有 literal search（精确连续文本搜索）的默认行为不变。

例如：

- 查询 `nxe`
- 可以匹配 `Nexus Editor`

## Changes / 变更内容

- `packages/plugin-search`
  - 新增 `FuzzySearchMatch`
  - 新增 `findFuzzySearchMatches`
  - 新增 `createFuzzySearchPattern`
  - 为 `findSearchMatches` 增加 `SearchOptions.fuzzy`，支持单次 helper 调用启用 fuzzy search
  - 为 `createSearchPlugin` 增加 `SearchPluginOptions.fuzzy`，支持插件级默认开启 fuzzy mode
  - 在 search panel 中新增 `Fuzzy` checkbox
  - fuzzy mode 开启时，保留输入框中的原始查询文本，同时将查询编译为安全的 line-local regexp pattern 交给 CodeMirror 搜索导航使用
  - 新增 `packages/plugin-search/README.md`，说明 fuzzy 用法、API 和 option 作用范围

- `apps/electron-demo`
  - 新增 `sample-vault/fuzzy-demo.md`
  - 在 sample vault 首页中加入 fuzzy demo 链接，方便手动验证

- `openspec/`
  - 新增 `openspec/changes/add-fuzzy-search-mode/`
  - 包含 `proposal.md`、`design.md`、`tasks.md` 和 `specs/plugins/spec.md`

- `docs/`
  - 将 `docs/ROADMAP.md` 中 #17 Fuzzy search 状态更新为 `done`
  - 同步更新 `docs/ROADMAP.zh.md`
  - 关联 OpenSpec change：`openspec/changes/add-fuzzy-search-mode`

## Testing / 测试

- [ ] `pnpm test` passes / 全量测试通过
  - 本地未勾选。原因是当前仓库全量测试在 Windows 环境下存在既有的路径分隔符问题，失败位置在 `apps/electron-demo/test/sample-vault.test.ts`，与本 PR 的 `plugin-search` 改动无关。

- [x] Affected packages build / 受影响包构建通过
  - `corepack pnpm --filter @floatboat/nexus-plugin-search build`

- [x] New / updated vitest cases / 新增或更新 vitest 用例
  - `corepack pnpm vitest run packages/plugin-search/test/plugin-search.test.ts`

- [x] TypeScript check / TypeScript 类型检查
  - `corepack pnpm -r exec tsc --noEmit`

- [x] Manual UI check in electron-demo / electron-demo 手动验证
  - 新增 `apps/electron-demo/sample-vault/fuzzy-demo.md`
  - 手动验证目标：开启 `Fuzzy` 后，输入 `nxe` 可以匹配 `Nexus Editor`

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types / 公共 API 变更已同步 README 与类型
- [x] Touched `live-preview-table.ts` / 是否修改 `live-preview-table.ts`
  - N/A，本 PR 未修改该文件
- [x] New capability / breaking change -> OpenSpec proposal linked / 新能力已关联 OpenSpec proposal
- [x] No secrets / personal vault data committed / 未提交密钥或个人敏感数据

## Screenshots / Recordings / 截图或录屏

手动验证方式：

1. 打开 `apps/electron-demo/sample-vault/fuzzy-demo.md`
2. 打开 search panel
3. 启用 `Fuzzy`
4. 输入 `nxe`
5. 预期结果：可以匹配 `Nexus Editor`

截图会在评论区补充。