### PR TITLE
feat(react,vue): add controlled document mode to Editor

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,6 +58,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
 | 4 | `<Editor />` container pass-through props + `onReady` callback | `react` (and `vue` in lockstep) | P0 | planned | No | Public API addition; semantics must match across bindings |
+| 28 | Controlled document `value` / `v-model` | `react` + `vue` | P0 | in-progress | No | PR #30 — parent-owned markdown via silent `setDocument` sync |
 
 ## 7. Collaboration
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -58,6 +58,7 @@
 | # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
 |---|---|---|---|---|---|---|
 | 4 | `<Editor />` 容器属性透传 + `onReady` 回调 | `react`（同步补 `vue`） | P0 | planned | 否 | 公共 API 增量，两端语义需一致 |
+| 28 | 受控文档 `value` / `v-model` | `react` + `vue` | P0 | in-progress | 否 | PR #30 — 父组件驱动 Markdown，`setDocument(..., { silent: true })` 防反馈环 |
 
 ## 7. 协作
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,77 @@
+# @floatboat/nexus-react
+
+React bindings for Nexus Editor.
+
+## Installation
+
+```bash
+pnpm add @floatboat/nexus-react @floatboat/nexus-core @floatboat/nexus-preset-gfm
+```
+
+## Uncontrolled usage
+
+`initialValue` seeds the document once; the editor owns subsequent edits until you call `EditorAPI` methods.
+
+```tsx
+import { Editor } from "@floatboat/nexus-react";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
+
+export function NoteEditor() {
+  return (
+    <Editor
+      initialValue="# Hello"
+      plugins={[createGfmPreset()]}
+      onChange={(doc) => console.log(doc)}
+    />
+  );
+}
+```
+
+## Controlled usage
+
+Pass `value` and update it from `onChange` when the parent must own the markdown string (AI rewrite, file switch, form state).
+
+```tsx
+import { useState } from "react";
+import { Editor } from "@floatboat/nexus-react";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
+
+export function ControlledNoteEditor() {
+  const [value, setValue] = useState("# Hello");
+
+  return (
+    <Editor
+      value={value}
+      plugins={[createGfmPreset()]}
+      onChange={(doc) => setValue(doc)}
+    />
+  );
+}
+```
+
+External updates to `value` are applied with a silent `setDocument` so the editor does not echo another `onChange` for the same content.
+
+## `useEditor` hook
+
+Same configuration as `<Editor />`, plus a container ref:
+
+```tsx
+const { containerRef, editor } = useEditor({
+  value: markdown,
+  onChange: (doc) => setMarkdown(doc),
+  plugins: [createGfmPreset()]
+});
+
+return <div ref={containerRef} style={{ minHeight: 240 }} />;
+```
+
+`editor` is `null` until the first mount effect runs.
+
+## How external sync works
+
+Controlled updates use core `setDocument(text, { silent: true })` so the editor does not emit a duplicate `onChange`. Logic lives in `src/controlled-document.ts` (unit-tested).
+
+| Mode | Prop | Parent updates |
+|------|------|----------------|
+| Controlled | `value` | Pass new `value`; keep state in sync via `onChange` |
+| Uncontrolled | `initialValue` | Optional; editor owns edits until you call `EditorAPI` |

--- a/packages/react/src/controlled-document.ts
+++ b/packages/react/src/controlled-document.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure helpers for React controlled-document sync (tested in isolation).
+ */
+
+export function isControlledDocument(value: string | undefined): boolean {
+  return value !== undefined;
+}
+
+export function resolveInitialDocument(
+  value: string | undefined,
+  initialValue: string | undefined
+): string {
+  return value !== undefined ? value : (initialValue ?? "");
+}
+
+/** Whether an external `value` prop should trigger silent setDocument. */
+export function shouldSyncControlledDocument(
+  next: string,
+  lastSynced: string | null
+): boolean {
+  return lastSynced !== next;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -4,7 +4,14 @@ import type {
 } from "@floatboat/nexus-core";
 import type { RefObject } from "react";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export type UseEditorConfig = Omit<EditorConfig, "container"> & {
+  /**
+   * Controlled markdown document. When provided, the parent owns the string and
+   * should update it from `onChange`. External updates are applied with a silent
+   * `setDocument` to avoid feedback loops.
+   */
+  value?: string;
+};
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -1,13 +1,32 @@
 import { createEditor } from "@floatboat/nexus-core";
+import type { Root } from "mdast";
 import { useEffect, useRef, useState } from "react";
 
+import { resolveInitialDocument, shouldSyncControlledDocument } from "./controlled-document";
 import type { UseEditorConfig, UseEditorResult } from "./types";
+
+function buildCreateConfig(
+  container: HTMLDivElement,
+  config: UseEditorConfig,
+  onDocChange: (doc: string, ast: Root) => void
+) {
+  const { value, initialValue, onChange, ...rest } = config;
+
+  return {
+    container,
+    ...rest,
+    initialValue: resolveInitialDocument(value, initialValue),
+    onChange: onDocChange
+  };
+}
 
 export function useEditor(config: UseEditorConfig): UseEditorResult {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<ReturnType<typeof createEditor> | null>(null);
   const [editor, setEditor] = useState<ReturnType<typeof createEditor> | null>(null);
+  const [, setSyncRevision] = useState(0);
   const configRef = useRef(config);
+  const lastSyncedDocRef = useRef<string | null>(null);
 
   configRef.current = config;
 
@@ -18,10 +37,18 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
-    const instance = createEditor({
-      container,
-      ...configRef.current
-    });
+    const onDocChange = (doc: string, ast: Root) => {
+      lastSyncedDocRef.current = doc;
+      setSyncRevision((revision) => revision + 1);
+      configRef.current.onChange?.(doc, ast);
+    };
+
+    const instance = createEditor(buildCreateConfig(container, configRef.current, onDocChange));
+
+    lastSyncedDocRef.current = resolveInitialDocument(
+      configRef.current.value,
+      configRef.current.initialValue
+    );
 
     editorRef.current = instance;
     setEditor(instance);
@@ -29,8 +56,27 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
     return () => {
       instance.destroy();
       editorRef.current = null;
+      setEditor(null);
+      lastSyncedDocRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    const instance = editorRef.current;
+    const { value } = config;
+
+    if (!instance || value === undefined) {
+      return;
+    }
+
+    if (!shouldSyncControlledDocument(value, lastSyncedDocRef.current)) {
+      return;
+    }
+
+    instance.setDocument(value, { silent: true });
+    lastSyncedDocRef.current = value;
+    setSyncRevision((revision) => revision + 1);
+  }, [config.value, editor]);
 
   return {
     containerRef,

--- a/packages/react/test/controlled-document.test.ts
+++ b/packages/react/test/controlled-document.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  isControlledDocument,
+  resolveInitialDocument,
+  shouldSyncControlledDocument
+} from "../src/controlled-document";
+
+describe("controlled-document helpers", () => {
+  it("detects controlled mode when value is defined", () => {
+    expect(isControlledDocument(undefined)).toBe(false);
+    expect(isControlledDocument("")).toBe(true);
+  });
+
+  it("resolves initial document from value or initialValue", () => {
+    expect(resolveInitialDocument("live", "seed")).toBe("live");
+    expect(resolveInitialDocument(undefined, "seed")).toBe("seed");
+    expect(resolveInitialDocument(undefined, undefined)).toBe("");
+  });
+
+  it("skips sync when last synced doc already matches", () => {
+    expect(shouldSyncControlledDocument("same", "same")).toBe(false);
+    expect(shouldSyncControlledDocument("next", "prev")).toBe(true);
+    expect(shouldSyncControlledDocument("fresh", null)).toBe(true);
+  });
+});

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,6 +1,6 @@
-import { render } from "@testing-library/react";
-import { useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { useEffect, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-react", () => {
@@ -36,5 +36,177 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("uses value as the initial document when controlled", async () => {
+    function Harness() {
+      const { containerRef, editor } = useEditor({ value: "controlled-start" });
+      return (
+        <div ref={containerRef} data-doc={editor?.getDocument() ?? ""} />
+      );
+    }
+
+    const { container } = render(<Harness />);
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-doc]")?.getAttribute("data-doc")).toBe(
+        "controlled-start"
+      );
+    });
+  });
+
+  it("syncs the editor when the controlled value prop changes", async () => {
+    function Harness({ value }: { value: string }) {
+      const { containerRef, editor } = useEditor({ value, onChange: () => {} });
+      return (
+        <div ref={containerRef} data-doc={editor?.getDocument() ?? ""} />
+      );
+    }
+
+    const { container, rerender } = render(<Harness value="first" />);
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-doc]")?.getAttribute("data-doc")).toBe("first");
+    });
+
+    rerender(<Harness value="second" />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("second");
+    });
+  });
+
+  it("forwards document changes to onChange in controlled mode", async () => {
+    const onChange = vi.fn();
+
+    function Harness() {
+      const { containerRef, editor } = useEditor({
+        value: "start",
+        onChange
+      });
+
+      useEffect(() => {
+        if (!editor) {
+          return;
+        }
+
+        editor.setDocument("edited");
+      }, [editor]);
+
+      return <div ref={containerRef} />;
+    }
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+      const lastCall = onChange.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe("edited");
+    });
+  });
+
+  it("skips silent setDocument when controlled value already matches the last change", async () => {
+    const silentDocs: string[] = [];
+
+    function Harness() {
+      const [value, setValue] = useState("alpha");
+      const { containerRef, editor } = useEditor({
+        value,
+        onChange: (doc) => setValue(doc)
+      });
+
+      useEffect(() => {
+        if (!editor) {
+          return;
+        }
+
+        const original = editor.setDocument.bind(editor);
+        editor.setDocument = (next, opts) => {
+          if (opts?.silent === true) {
+            silentDocs.push(next);
+          }
+          return original(next, opts);
+        };
+
+        editor.setDocument("beta");
+      }, [editor]);
+
+      return <div ref={containerRef} />;
+    }
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(silentDocs.filter((doc) => doc === "beta")).toHaveLength(0);
+    });
+  });
+
+  it("Editor component syncs when the value prop changes", async () => {
+    const { container, rerender } = render(
+      <Editor value="one" onChange={() => {}} plugins={[]} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("one");
+    });
+
+    rerender(<Editor value="two" onChange={() => {}} plugins={[]} />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("two");
+    });
+  });
+
+  it("applies rapid external value updates without leaving stale content", async () => {
+    function Harness({ value }: { value: string }) {
+      const { containerRef } = useEditor({ value, onChange: () => {} });
+      return <div ref={containerRef} />;
+    }
+
+    const { container, rerender } = render(<Harness value="v1" />);
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("v1");
+    });
+
+    rerender(<Harness value="v2" />);
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("v2");
+    });
+
+    rerender(<Harness value="v3" />);
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("v3");
+    });
+  });
+
+  it("supports readOnly together with a controlled value", async () => {
+    const { container } = render(
+      <Editor value="# Locked" readOnly onChange={() => {}} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line")?.textContent).toBe("# Locked");
+    });
+
+    expect(container.querySelector(".cm-content")?.getAttribute("contenteditable")).toBe(
+      "false"
+    );
+  });
+
+  it("keeps initialValue behavior in uncontrolled mode", async () => {
+    function Harness() {
+      const { containerRef, editor } = useEditor({ initialValue: "uncontrolled" });
+      return (
+        <div ref={containerRef} data-doc={editor?.getDocument() ?? ""} />
+      );
+    }
+
+    const { container } = render(<Harness />);
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-doc]")?.getAttribute("data-doc")).toBe(
+        "uncontrolled"
+      );
+    });
   });
 });

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,73 @@
+# @floatboat/nexus-vue
+
+Vue 3 bindings for Nexus Editor.
+
+## Installation
+
+```bash
+pnpm add @floatboat/nexus-vue @floatboat/nexus-core @floatboat/nexus-preset-gfm
+```
+
+## Uncontrolled usage
+
+```vue
+<script setup>
+import { Editor } from "@floatboat/nexus-vue";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
+</script>
+
+<template>
+  <Editor
+    initial-value="# Hello"
+    :plugins="[createGfmPreset()]"
+    @change="(doc) => console.log(doc)"
+  />
+</template>
+```
+
+## Controlled usage (`v-model`)
+
+```vue
+<script setup>
+import { ref } from "vue";
+import { Editor } from "@floatboat/nexus-vue";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
+
+const markdown = ref("# Hello");
+</script>
+
+<template>
+  <Editor v-model="markdown" :plugins="[createGfmPreset()]" />
+</template>
+```
+
+External updates to `modelValue` sync into the editor with a silent `setDocument` to avoid feedback loops.
+
+## `useEditor` composable
+
+```vue
+<script setup>
+import { useEditor } from "@floatboat/nexus-vue";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
+
+const markdown = ref("# Hello");
+
+const { containerRef, editor } = useEditor(() => ({
+  modelValue: markdown.value,
+  onChange: (doc) => {
+    markdown.value = doc;
+  },
+  plugins: [createGfmPreset()]
+}));
+</script>
+
+<template>
+  <div ref="containerRef" style="min-height: 240px" />
+</template>
+```
+
+Pass a getter (or `computed`) so `modelValue` changes are observed after mount.
+
+## How external sync works
+
+Same as React: silent `setDocument` for external `modelValue` changes; user edits emit `onChange` / `update:modelValue`. See `src/controlled-document.ts` (unit-tested).

--- a/packages/vue/src/controlled-document.ts
+++ b/packages/vue/src/controlled-document.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure helpers for Vue controlled-document sync (tested in isolation).
+ */
+
+export function isControlledDocument(modelValue: string | undefined): boolean {
+  return modelValue !== undefined;
+}
+
+export function resolveInitialDocument(
+  modelValue: string | undefined,
+  initialValue: string | undefined
+): string {
+  return modelValue !== undefined ? modelValue : (initialValue ?? "");
+}
+
+export function shouldSyncControlledDocument(
+  next: string,
+  lastSynced: string | null
+): boolean {
+  return lastSynced !== next;
+}

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -1,17 +1,43 @@
-import { defineComponent, h } from "vue";
+import { computed, defineComponent, h } from "vue";
 
 import { useEditor } from "./use-editor";
+
+import type { UseEditorConfig } from "./types";
 
 export const Editor = defineComponent({
   name: "NexusEditor",
   props: {
+    modelValue: {
+      type: String,
+      required: false
+    },
     initialValue: {
       type: String,
       required: false
     }
   },
-  setup(props) {
-    const { containerRef } = useEditor(props);
+  emits: {
+    "update:modelValue": (_value: string) => true
+  },
+  setup(props, { emit, attrs }) {
+    const editorConfig = computed<UseEditorConfig>(() => {
+      const { modelValue, initialValue } = props;
+      const { onChange: userOnChange, ...passthrough } = attrs as UseEditorConfig;
+
+      return {
+        ...passthrough,
+        initialValue,
+        modelValue,
+        onChange: (doc, ast) => {
+          if (modelValue !== undefined) {
+            emit("update:modelValue", doc);
+          }
+          userOnChange?.(doc, ast);
+        }
+      };
+    });
+
+    const { containerRef } = useEditor(editorConfig);
 
     return () => h("div", { ref: containerRef });
   }

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -4,7 +4,13 @@ import type {
 } from "@floatboat/nexus-core";
 import type { Ref, ShallowRef } from "vue";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export type UseEditorConfig = Omit<EditorConfig, "container"> & {
+  /**
+   * Controlled markdown document (use with `v-model`). When provided, the
+   * parent owns the string; external updates use silent `setDocument`.
+   */
+  modelValue?: string;
+};
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -1,26 +1,84 @@
 import { createEditor } from "@floatboat/nexus-core";
-import { onBeforeUnmount, onMounted, ref, shallowRef } from "vue";
+import type { Root } from "mdast";
+import {
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  toValue,
+  watch,
+  type MaybeRefOrGetter
+} from "vue";
 
+import { resolveInitialDocument, shouldSyncControlledDocument } from "./controlled-document";
 import type { UseEditorConfig, UseEditorResult } from "./types";
 
-export function useEditor(config: UseEditorConfig): UseEditorResult {
+function buildCreateConfig(
+  container: HTMLDivElement,
+  config: UseEditorConfig,
+  onDocChange: (doc: string, ast: Root) => void
+) {
+  const { modelValue, initialValue, onChange, ...rest } = config;
+
+  return {
+    container,
+    ...rest,
+    initialValue: resolveInitialDocument(modelValue, initialValue),
+    onChange: onDocChange
+  };
+}
+
+export function useEditor(config: MaybeRefOrGetter<UseEditorConfig>): UseEditorResult {
   const containerRef = ref<HTMLDivElement | null>(null);
   const editor = shallowRef<ReturnType<typeof createEditor> | null>(null);
+  const lastSyncedDocRef = ref<string | null>(null);
+  const syncRevision = ref(0);
+
+  const resolveConfig = () => toValue(config);
 
   onMounted(() => {
     if (!containerRef.value || editor.value) {
       return;
     }
 
-    editor.value = createEditor({
-      container: containerRef.value,
-      ...config
-    });
+    const current = resolveConfig();
+    const onDocChange = (doc: string, ast: Root) => {
+      lastSyncedDocRef.value = doc;
+      syncRevision.value += 1;
+      resolveConfig().onChange?.(doc, ast);
+    };
+
+    editor.value = createEditor(buildCreateConfig(containerRef.value, current, onDocChange));
+
+    lastSyncedDocRef.value = resolveInitialDocument(
+      current.modelValue,
+      current.initialValue
+    );
   });
+
+  watch(
+    () => resolveConfig().modelValue,
+    (value) => {
+      const instance = editor.value;
+
+      if (!instance || value === undefined) {
+        return;
+      }
+
+      if (!shouldSyncControlledDocument(value, lastSyncedDocRef.value)) {
+        return;
+      }
+
+      instance.setDocument(value, { silent: true });
+      lastSyncedDocRef.value = value;
+      syncRevision.value += 1;
+    }
+  );
 
   onBeforeUnmount(() => {
     editor.value?.destroy();
     editor.value = null;
+    lastSyncedDocRef.value = null;
   });
 
   return {

--- a/packages/vue/test/controlled-document.test.ts
+++ b/packages/vue/test/controlled-document.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  isControlledDocument,
+  resolveInitialDocument,
+  shouldSyncControlledDocument
+} from "../src/controlled-document";
+
+describe("controlled-document helpers (vue)", () => {
+  it("detects controlled mode when modelValue is defined", () => {
+    expect(isControlledDocument(undefined)).toBe(false);
+    expect(isControlledDocument("")).toBe(true);
+  });
+
+  it("resolves initial document from modelValue or initialValue", () => {
+    expect(resolveInitialDocument("live", "seed")).toBe("live");
+    expect(resolveInitialDocument(undefined, "seed")).toBe("seed");
+  });
+
+  it("skips sync when last synced doc already matches", () => {
+    expect(shouldSyncControlledDocument("same", "same")).toBe(false);
+    expect(shouldSyncControlledDocument("next", "prev")).toBe(true);
+  });
+});

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
-import { defineComponent, h, nextTick, onMounted } from "vue";
-import { describe, expect, it } from "vitest";
+import { defineComponent, h, nextTick, onMounted, ref } from "vue";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-vue", () => {
@@ -44,5 +44,166 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("uses modelValue as the initial document when controlled", async () => {
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef, editor } = useEditor({ modelValue: "controlled-start" });
+        return () =>
+          h("div", {
+            ref: containerRef,
+            "data-doc": editor.value?.getDocument() ?? ""
+          });
+      }
+    });
+
+    const wrapper = mount(Harness);
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(wrapper.attributes("data-doc")).toBe("controlled-start");
+    });
+  });
+
+  it("syncs the editor when modelValue changes", async () => {
+    const Harness = defineComponent({
+      props: {
+        modelValue: {
+          type: String,
+          required: true
+        }
+      },
+      setup(props) {
+        const { containerRef } = useEditor(
+          () => ({
+            modelValue: props.modelValue,
+            onChange: () => {}
+          })
+        );
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    const wrapper = mount(Harness, { props: { modelValue: "first" } });
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("first");
+    });
+
+    await wrapper.setProps({ modelValue: "second" });
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("second");
+    });
+  });
+
+  it("forwards document changes through onChange in controlled mode", async () => {
+    const onChange = vi.fn();
+
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef, editor } = useEditor({
+          modelValue: "start",
+          onChange
+        });
+
+        onMounted(() => {
+          editor.value?.setDocument("edited");
+        });
+
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    mount(Harness);
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls.at(-1)?.[0]).toBe("edited");
+    });
+  });
+
+  it("supports v-model on the Editor component", async () => {
+    const doc = ref("alpha");
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          h(Editor, {
+            modelValue: doc.value,
+            "onUpdate:modelValue": (next: string) => {
+              doc.value = next;
+            }
+          });
+      }
+    });
+
+    const wrapper = mount(Parent);
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("alpha");
+    });
+
+    doc.value = "beta";
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("beta");
+    });
+  });
+
+  it("applies rapid modelValue updates", async () => {
+    const Harness = defineComponent({
+      props: { modelValue: { type: String, required: true } },
+      setup(props) {
+        const { containerRef } = useEditor(() => ({
+          modelValue: props.modelValue,
+          onChange: () => {}
+        }));
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    const wrapper = mount(Harness, { props: { modelValue: "v1" } });
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("v1");
+    });
+
+    await wrapper.setProps({ modelValue: "v2" });
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("v2");
+    });
+  });
+
+  it("supports readOnly with v-model", async () => {
+    const wrapper = mount(Editor, {
+      props: {
+        modelValue: "# Locked",
+        readOnly: true
+      }
+    });
+
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("# Locked");
+      expect(wrapper.element.querySelector(".cm-content")?.getAttribute("contenteditable")).toBe(
+        "false"
+      );
+    });
+  });
+
+  it("keeps initialValue behavior in uncontrolled mode", async () => {
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "uncontrolled"
+      }
+    });
+
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("uncontrolled");
+    });
   });
 });


### PR DESCRIPTION
## Summary / 摘要

为 `@floatboat/nexus-react` / `@floatboat/nexus-vue` 增加受控文档模式：React 使用 `value` + `onChange`，Vue 使用 `v-model`。父组件可持有 Markdown 正文；用户编辑通过 `onChange` 回传；外部更新时使用 `setDocument(..., { silent: true })`，避免多余的 `onChange`。

## Motivation / 背景与动机

常见场景包括切换笔记、外部回填正文、表单与编辑器联动等，需要由父组件 state 驱动文档。`initialValue` 仅在首次挂载生效，后续 props 变化无法同步到编辑器。

Core 已支持 `setDocument(..., { silent: true })`（例如宿主打开文件时）。本 PR 在 React/Vue 绑定层接上该机制，**不修改** `packages/core`，**不包含** electron-demo 改动。

- Issue: —
- Roadmap: **§6 #28** 受控文档 `value` / `v-model`（`docs/ROADMAP.md` / `ROADMAP.zh.md`，`in-progress`）；与 **#4** `onReady` 无关
- OpenSpec: N/A（非破坏性变更，新增可选 props）

## Changes / 变更内容

**packages/react**
- `UseEditorConfig` 增加可选 `value?: string`
- `useEditor` 在外部 `value` 变化时 silent `setDocument`，`lastSyncedDocRef` 避免 onChange 循环
- 新增 `controlled-document.ts` 及单测
- 新增 `README.md`（受控 / 非受控示例）
- 扩展 `editor-react.test.tsx`

**packages/vue**
- `<Editor />` 支持 `modelValue` / `update:modelValue`
- `useEditor` 通过 `watch` 同步 `modelValue`，与 React 语义一致
- 新增 `controlled-document.ts`、单测与 `README.md`
- 扩展 `editor-vue.test.ts`

**docs**
- 按 Roadmap 维护流程在 §6 登记 **#28**（`in-progress`，备注 PR #30）

## Testing / 测试

```bash
pnpm test
pnpm build
```

- [x] `pnpm test` passes / 全仓 vitest（含 react/vue controlled 用例）
- [x] `pnpm build` passes / 各包构建通过
- [x] 新增 vitest：`controlled-document.test.ts`、`editor-react.test.tsx`、`editor-vue.test.ts` 等

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题符合规范
- [x] Public API changes update package README / types
- [x] Touched `live-preview-table.ts` → N/A
- [x] New capability / breaking change → N/A（无需 OpenSpec）
- [x] No secrets / personal vault data committed
- [x] Roadmap 新增条目 #28 已登记（维护流程 §「新增条目」）
- [x] Scope 仅限 `packages/react`、`packages/vue`、`docs/ROADMAP*`

## Screenshots / 录屏

<!-- 可选：README 受控示例或 vitest 通过截图 -->
