### PR TITLE
feat: initial CAL-AGENT panel integration

### DIFF
--- a/apps/electron-demo/dist-electron/main.js
+++ b/apps/electron-demo/dist-electron/main.js
@@ -26,24 +26,223 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // electron/main.ts
 var main_exports = {};
 module.exports = __toCommonJS(main_exports);
-var import_electron = require("electron");
+var import_electron2 = require("electron");
 var import_promises = require("fs/promises");
-var import_node_fs = require("fs");
+var import_node_fs2 = require("fs");
 var import_node_path = __toESM(require("path"));
 var import_node_url = require("url");
-import_electron.protocol.registerSchemesAsPrivileged([
+
+// electron/cal-agent-controller.ts
+var import_electron = require("electron");
+var import_node_child_process = require("child_process");
+var import_node_fs = require("fs");
+var CAL_AGENT_ROOT = process.env.CAL_AGENT_ROOT ?? "/Users/wangqiao/workspace/CAL-AGENT";
+var CAL_AGENT_URL = process.env.CAL_AGENT_URL ?? "http://127.0.0.1:3000";
+var STARTUP_TIMEOUT_MS = 3e4;
+var PROBE_INTERVAL_MS = 1e3;
+var PROBE_TIMEOUT_MS = 2e3;
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function probeUrl(url, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { signal: controller.signal, cache: "no-store" });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+function formatStartError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+function createCalAgentController(options) {
+  let processHandle = null;
+  let launchToken = 0;
+  let disposed = false;
+  let stopRequested = false;
+  let status = {
+    status: "idle",
+    url: CAL_AGENT_URL
+  };
+  function broadcast(next) {
+    status = next;
+    const win = options.getWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send("cal-agent:status-changed", next);
+    }
+  }
+  function ensureRootExists() {
+    if (!(0, import_node_fs.existsSync)(CAL_AGENT_ROOT)) {
+      throw new Error(`CAL-AGENT root not found: ${CAL_AGENT_ROOT}`);
+    }
+  }
+  function clearProcess(proc) {
+    if (processHandle === proc) {
+      processHandle = null;
+    }
+  }
+  function attachProcessHandlers(proc, token) {
+    proc.once("error", (error) => {
+      clearProcess(proc);
+      if (disposed || token !== launchToken || stopRequested) return;
+      broadcast({
+        status: "error",
+        url: CAL_AGENT_URL,
+        message: `Failed to start CAL-AGENT: ${formatStartError(error)}`
+      });
+    });
+    proc.once("exit", (code, signal) => {
+      clearProcess(proc);
+      if (disposed || stopRequested) return;
+      if (token !== launchToken) return;
+      broadcast({
+        status: "error",
+        url: CAL_AGENT_URL,
+        message: `CAL-AGENT exited early${code !== null ? ` with code ${code}` : signal ? ` (${signal})` : ""}`
+      });
+    });
+  }
+  async function stopProcess() {
+    const proc = processHandle;
+    if (!proc) return;
+    stopRequested = true;
+    processHandle = null;
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      stopRequested = false;
+      return;
+    }
+    await new Promise((resolve) => {
+      const finish = () => {
+        proc.off("exit", finish);
+        proc.off("close", finish);
+        proc.off("error", finish);
+        stopRequested = false;
+        resolve();
+      };
+      proc.once("exit", finish);
+      proc.once("close", finish);
+      proc.once("error", finish);
+      try {
+        proc.kill();
+      } catch {
+        finish();
+        return;
+      }
+      setTimeout(() => {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+          }
+        }
+      }, 2e3);
+    });
+  }
+  async function launchProcess() {
+    if (disposed) return status;
+    await stopProcess();
+    ensureRootExists();
+    const token = ++launchToken;
+    broadcast({
+      status: "starting",
+      url: CAL_AGENT_URL,
+      message: "Starting CAL-AGENT workbench..."
+    });
+    const proc = (0, import_node_child_process.spawn)("npm", ["run", "web:dev"], {
+      cwd: CAL_AGENT_ROOT,
+      env: {
+        ...process.env,
+        CAL_AGENT_ROOT,
+        CAL_AGENT_URL
+      },
+      stdio: "inherit",
+      shell: process.platform === "win32"
+    });
+    processHandle = proc;
+    attachProcessHandlers(proc, token);
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+    while (!disposed && token === launchToken) {
+      if (!processHandle) {
+        return status;
+      }
+      if (await probeUrl(CAL_AGENT_URL, PROBE_TIMEOUT_MS)) {
+        const ready = {
+          status: "ready",
+          url: CAL_AGENT_URL,
+          message: "CAL-AGENT is ready"
+        };
+        broadcast(ready);
+        return ready;
+      }
+      if (Date.now() >= deadline) {
+        broadcast({
+          status: "error",
+          url: CAL_AGENT_URL,
+          message: `CAL-AGENT did not become ready within ${Math.round(STARTUP_TIMEOUT_MS / 1e3)}s`
+        });
+        await stopProcess();
+        return status;
+      }
+      await delay(PROBE_INTERVAL_MS);
+    }
+    return status;
+  }
+  import_electron.ipcMain.handle("cal-agent:get-status", async () => status);
+  import_electron.ipcMain.handle("cal-agent:start", async () => launchProcess());
+  import_electron.ipcMain.handle("cal-agent:retry", async () => launchProcess());
+  import_electron.ipcMain.handle("cal-agent:open-external", async () => {
+    await import_electron.shell.openExternal(CAL_AGENT_URL);
+  });
+  return {
+    async start() {
+      if (status.status === "starting" || status.status === "ready") {
+        return status;
+      }
+      return launchProcess();
+    },
+    async retry() {
+      return launchProcess();
+    },
+    getStatus() {
+      return status;
+    },
+    async openExternal() {
+      await import_electron.shell.openExternal(CAL_AGENT_URL);
+    },
+    dispose() {
+      disposed = true;
+      stopRequested = true;
+      const proc = processHandle;
+      processHandle = null;
+      if (proc) {
+        try {
+          proc.kill();
+        } catch {
+        }
+      }
+    }
+  };
+}
+
+// electron/main.ts
+import_electron2.protocol.registerSchemesAsPrivileged([
   {
     scheme: "nexus-vault",
     privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, bypassCSP: true }
   }
 ]);
 var mainWindow = null;
+var calAgentController = null;
 var SUPPORTED_EXT = /* @__PURE__ */ new Set([".md", ".markdown", ".txt"]);
 var SKIP_DIRS = /* @__PURE__ */ new Set(["node_modules", ".git", ".svn", ".hg", ".DS_Store"]);
 var activeVault = null;
 var activeWatcher = null;
 function createWindow() {
-  mainWindow = new import_electron.BrowserWindow({
+  mainWindow = new import_electron2.BrowserWindow({
     width: 1024,
     height: 768,
     // Hide until the renderer has painted — avoids the white-flash window and
@@ -77,9 +276,9 @@ function createWindow() {
     }
   });
 }
-import_electron.ipcMain.handle("demo:open-file", async () => {
+import_electron2.ipcMain.handle("demo:open-file", async () => {
   if (!mainWindow) return null;
-  const result = await import_electron.dialog.showOpenDialog(mainWindow, {
+  const result = await import_electron2.dialog.showOpenDialog(mainWindow, {
     properties: ["openFile"],
     filters: [
       { name: "Markdown", extensions: ["md", "markdown", "txt"] },
@@ -91,18 +290,18 @@ import_electron.ipcMain.handle("demo:open-file", async () => {
   const content = await (0, import_promises.readFile)(filePath, "utf-8");
   return { path: filePath, content };
 });
-import_electron.ipcMain.handle(
+import_electron2.ipcMain.handle(
   "demo:save-file",
   async (_event, filePath, content) => {
     await (0, import_promises.writeFile)(filePath, content, "utf-8");
     return { path: filePath };
   }
 );
-import_electron.ipcMain.handle(
+import_electron2.ipcMain.handle(
   "demo:save-file-as",
   async (_event, content) => {
     if (!mainWindow) return null;
-    const result = await import_electron.dialog.showSaveDialog(mainWindow, {
+    const result = await import_electron2.dialog.showSaveDialog(mainWindow, {
       filters: [
         { name: "Markdown", extensions: ["md"] },
         { name: "All Files", extensions: ["*"] }
@@ -179,10 +378,10 @@ function startWatcher(vaultPath) {
     mainWindow?.webContents.send("vault:changed", { vault: vaultPath });
   }, 150);
   try {
-    activeWatcher = (0, import_node_fs.watch)(vaultPath, { recursive: true }, () => notify());
+    activeWatcher = (0, import_node_fs2.watch)(vaultPath, { recursive: true }, () => notify());
   } catch (err) {
     try {
-      activeWatcher = (0, import_node_fs.watch)(vaultPath, () => notify());
+      activeWatcher = (0, import_node_fs2.watch)(vaultPath, () => notify());
     } catch (innerErr) {
       console.warn("[vault] watcher init failed:", innerErr);
       activeWatcher = null;
@@ -190,11 +389,11 @@ function startWatcher(vaultPath) {
   }
 }
 function vaultStatePath() {
-  return import_node_path.default.join(import_electron.app.getPath("userData"), "vault.json");
+  return import_node_path.default.join(import_electron2.app.getPath("userData"), "vault.json");
 }
 async function readVaultState() {
   const file = vaultStatePath();
-  if (!(0, import_node_fs.existsSync)(file)) return { lastVault: null, recents: [] };
+  if (!(0, import_node_fs2.existsSync)(file)) return { lastVault: null, recents: [] };
   try {
     const raw = await (0, import_promises.readFile)(file, "utf-8");
     const parsed = JSON.parse(raw);
@@ -209,15 +408,15 @@ async function readVaultState() {
 async function writeVaultState(state) {
   await (0, import_promises.writeFile)(vaultStatePath(), JSON.stringify(state, null, 2), "utf-8");
 }
-import_electron.ipcMain.handle("vault:pick", async () => {
+import_electron2.ipcMain.handle("vault:pick", async () => {
   if (!mainWindow) return null;
-  const result = await import_electron.dialog.showOpenDialog(mainWindow, {
+  const result = await import_electron2.dialog.showOpenDialog(mainWindow, {
     properties: ["openDirectory", "createDirectory"]
   });
   if (result.canceled || result.filePaths.length === 0) return null;
   return { path: result.filePaths[0] };
 });
-import_electron.ipcMain.handle("vault:list", async (_event, vaultPath) => {
+import_electron2.ipcMain.handle("vault:list", async (_event, vaultPath) => {
   const abs = import_node_path.default.resolve(vaultPath);
   const info = await (0, import_promises.stat)(abs);
   if (!info.isDirectory()) throw new Error(`Not a directory: ${abs}`);
@@ -225,7 +424,7 @@ import_electron.ipcMain.handle("vault:list", async (_event, vaultPath) => {
   startWatcher(abs);
   return scanDirectory(abs);
 });
-import_electron.ipcMain.handle("vault:read", async (_event, filePath) => {
+import_electron2.ipcMain.handle("vault:read", async (_event, filePath) => {
   const abs = assertInsideVault(filePath);
   const content = await (0, import_promises.readFile)(abs, "utf-8");
   return { path: abs, content };
@@ -245,7 +444,7 @@ async function collectFiles(dir, acc) {
     }
   }
 }
-import_electron.ipcMain.handle("vault:read-all", async () => {
+import_electron2.ipcMain.handle("vault:read-all", async () => {
   if (!activeVault) return [];
   const paths = [];
   await collectFiles(activeVault, paths);
@@ -267,12 +466,12 @@ import_electron.ipcMain.handle("vault:read-all", async () => {
   await Promise.all(Array.from({ length: Math.min(CONCURRENCY, paths.length) }, worker));
   return out;
 });
-import_electron.ipcMain.handle("vault:write", async (_event, filePath, content) => {
+import_electron2.ipcMain.handle("vault:write", async (_event, filePath, content) => {
   const abs = assertInsideVault(filePath);
   await (0, import_promises.writeFile)(abs, content, "utf-8");
   return { path: abs };
 });
-import_electron.ipcMain.handle(
+import_electron2.ipcMain.handle(
   "vault:create-file",
   async (_event, parentDir, name) => {
     const safeInput = name.trim() || "untitled";
@@ -293,7 +492,7 @@ import_electron.ipcMain.handle(
     const stem = baseName.slice(0, baseName.length - ext.length);
     let candidate = import_node_path.default.join(parent, baseName);
     let suffix = 1;
-    while ((0, import_node_fs.existsSync)(candidate)) {
+    while ((0, import_node_fs2.existsSync)(candidate)) {
       candidate = import_node_path.default.join(parent, `${stem}-${suffix}${ext}`);
       suffix += 1;
     }
@@ -302,20 +501,20 @@ import_electron.ipcMain.handle(
     return { path: finalPath };
   }
 );
-import_electron.ipcMain.handle(
+import_electron2.ipcMain.handle(
   "vault:create-folder",
   async (_event, parentDir, name) => {
     const parent = assertInsideVault(parentDir);
     const safeName = name.trim() || "new-folder";
     const target = assertInsideVault(import_node_path.default.join(parent, safeName));
-    if ((0, import_node_fs.existsSync)(target)) {
+    if ((0, import_node_fs2.existsSync)(target)) {
       throw new Error(`Folder already exists: ${safeName}`);
     }
     await (0, import_promises.mkdir)(target, { recursive: false });
     return { path: target };
   }
 );
-import_electron.ipcMain.handle(
+import_electron2.ipcMain.handle(
   "vault:rename",
   async (_event, oldPath, newName) => {
     const src = assertInsideVault(oldPath);
@@ -326,38 +525,38 @@ import_electron.ipcMain.handle(
       throw new Error("New name cannot contain path separators");
     }
     const target = assertInsideVault(import_node_path.default.join(parent, trimmed));
-    if ((0, import_node_fs.existsSync)(target) && target !== src) {
+    if ((0, import_node_fs2.existsSync)(target) && target !== src) {
       throw new Error(`Target already exists: ${trimmed}`);
     }
     await (0, import_promises.rename)(src, target);
     return { path: target };
   }
 );
-import_electron.ipcMain.handle("vault:delete", async (_event, targetPath) => {
+import_electron2.ipcMain.handle("vault:delete", async (_event, targetPath) => {
   const abs = assertInsideVault(targetPath);
-  await import_electron.shell.trashItem(abs);
+  await import_electron2.shell.trashItem(abs);
   return { ok: true };
 });
-import_electron.ipcMain.handle("vault:get-last", async () => {
+import_electron2.ipcMain.handle("vault:get-last", async () => {
   const state = await readVaultState();
-  if (state.lastVault && !(0, import_node_fs.existsSync)(state.lastVault)) {
+  if (state.lastVault && !(0, import_node_fs2.existsSync)(state.lastVault)) {
     const cleaned = {
       lastVault: null,
-      recents: state.recents.filter((r) => (0, import_node_fs.existsSync)(r))
+      recents: state.recents.filter((r) => (0, import_node_fs2.existsSync)(r))
     };
     await writeVaultState(cleaned);
     return cleaned;
   }
   return state;
 });
-import_electron.ipcMain.handle("vault:set-last", async (_event, vaultPath) => {
+import_electron2.ipcMain.handle("vault:set-last", async (_event, vaultPath) => {
   const current = await readVaultState();
   const recents = [vaultPath, ...current.recents.filter((r) => r !== vaultPath)].slice(0, 10);
   await writeVaultState({ lastVault: vaultPath, recents });
   return { ok: true };
 });
-import_electron.app.whenReady().then(() => {
-  import_electron.protocol.handle("nexus-vault", async (request) => {
+import_electron2.app.whenReady().then(() => {
+  import_electron2.protocol.handle("nexus-vault", async (request) => {
     try {
       if (!activeVault) return new Response("No active vault", { status: 404 });
       const url = new URL(request.url);
@@ -368,15 +567,23 @@ import_electron.app.whenReady().then(() => {
       if (rel.startsWith("..") || import_node_path.default.isAbsolute(rel)) {
         return new Response("Path escapes vault", { status: 403 });
       }
-      if (!(0, import_node_fs.existsSync)(abs)) return new Response("Not found", { status: 404 });
-      return import_electron.net.fetch((0, import_node_url.pathToFileURL)(abs).toString());
+      if (!(0, import_node_fs2.existsSync)(abs)) return new Response("Not found", { status: 404 });
+      return import_electron2.net.fetch((0, import_node_url.pathToFileURL)(abs).toString());
     } catch (err) {
       return new Response(String(err), { status: 500 });
     }
   });
   createWindow();
+  calAgentController = createCalAgentController({
+    getWindow: () => mainWindow
+  });
+  void calAgentController.start();
 });
-import_electron.app.on("window-all-closed", () => {
+import_electron2.app.on("window-all-closed", () => {
+  calAgentController?.dispose();
   stopWatcher();
-  import_electron.app.quit();
+  import_electron2.app.quit();
+});
+import_electron2.app.on("before-quit", () => {
+  calAgentController?.dispose();
 });

--- a/apps/electron-demo/dist-electron/main.js
+++ b/apps/electron-demo/dist-electron/main.js
@@ -255,6 +255,7 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
+      webviewTag: true,
       preload: import_node_path.default.join(__dirname, "preload.js")
     }
   });

--- a/apps/electron-demo/dist-electron/preload.js
+++ b/apps/electron-demo/dist-electron/preload.js
@@ -69,6 +69,27 @@ var bridge = {
   saveFileAs(content) {
     return import_electron.ipcRenderer.invoke("demo:save-file-as", content);
   },
+  calAgent: {
+    start() {
+      return import_electron.ipcRenderer.invoke("cal-agent:start");
+    },
+    retry() {
+      return import_electron.ipcRenderer.invoke("cal-agent:retry");
+    },
+    getStatus() {
+      return import_electron.ipcRenderer.invoke("cal-agent:get-status");
+    },
+    openExternal() {
+      return import_electron.ipcRenderer.invoke("cal-agent:open-external");
+    },
+    onStatusChange(cb) {
+      const listener = (_event, payload) => cb(payload);
+      import_electron.ipcRenderer.on("cal-agent:status-changed", listener);
+      return () => {
+        import_electron.ipcRenderer.off("cal-agent:status-changed", listener);
+      };
+    }
+  },
   vault: vaultBridge
 };
 import_electron.contextBridge.exposeInMainWorld("nexusDemo", bridge);

--- a/apps/electron-demo/electron/cal-agent-controller.ts
+++ b/apps/electron-demo/electron/cal-agent-controller.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, ipcMain, shell } from "electron";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -29,6 +29,12 @@ const STARTUP_TIMEOUT_MS = 30_000;
 const PROBE_INTERVAL_MS = 1_000;
 const PROBE_TIMEOUT_MS = 2_000;
 
+function getPort(url: string): number {
+  const parsed = new URL(url);
+  if (parsed.port) return Number(parsed.port);
+  return parsed.protocol === "https:" ? 443 : 80;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -43,6 +49,25 @@ async function probeUrl(url: string, timeoutMs: number): Promise<boolean> {
     return false;
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+async function killExistingListener(url: string): Promise<void> {
+  const port = getPort(url);
+  const result = spawnSync("lsof", ["-ti", `tcp:${port}`], { encoding: "utf-8" });
+  if (result.error || result.status !== 0) return;
+
+  const pids = result.stdout
+    .split(/\s+/)
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isInteger(value) && value > 0);
+
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* noop */
+    }
   }
 }
 
@@ -152,6 +177,7 @@ export function createCalAgentController(options: CalAgentControllerOptions): Ca
 
     await stopProcess();
     ensureRootExists();
+    await killExistingListener(CAL_AGENT_URL);
 
     const token = ++launchToken;
     broadcast({

--- a/apps/electron-demo/electron/cal-agent-controller.ts
+++ b/apps/electron-demo/electron/cal-agent-controller.ts
@@ -1,0 +1,246 @@
+import { app, BrowserWindow, ipcMain, shell } from "electron";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+export type CalAgentPanelStatus = "idle" | "starting" | "ready" | "error";
+
+export interface CalAgentStatusPayload {
+  status: CalAgentPanelStatus;
+  url: string;
+  message?: string;
+}
+
+export interface CalAgentController {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): CalAgentStatusPayload;
+  openExternal(): Promise<void>;
+  dispose(): void;
+}
+
+interface CalAgentControllerOptions {
+  getWindow: () => BrowserWindow | null;
+}
+
+const CAL_AGENT_ROOT = process.env.CAL_AGENT_ROOT ?? "/Users/wangqiao/workspace/CAL-AGENT";
+const CAL_AGENT_URL = process.env.CAL_AGENT_URL ?? "http://127.0.0.1:3000";
+const STARTUP_TIMEOUT_MS = 30_000;
+const PROBE_INTERVAL_MS = 1_000;
+const PROBE_TIMEOUT_MS = 2_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function probeUrl(url: string, timeoutMs: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { signal: controller.signal, cache: "no-store" });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function formatStartError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createCalAgentController(options: CalAgentControllerOptions): CalAgentController {
+  let processHandle: ChildProcessWithoutNullStreams | null = null;
+  let launchToken = 0;
+  let disposed = false;
+  let stopRequested = false;
+  let status: CalAgentStatusPayload = {
+    status: "idle",
+    url: CAL_AGENT_URL,
+  };
+
+  function broadcast(next: CalAgentStatusPayload): void {
+    status = next;
+    const win = options.getWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send("cal-agent:status-changed", next);
+    }
+  }
+
+  function ensureRootExists(): void {
+    if (!existsSync(CAL_AGENT_ROOT)) {
+      throw new Error(`CAL-AGENT root not found: ${CAL_AGENT_ROOT}`);
+    }
+  }
+
+  function clearProcess(proc: ChildProcessWithoutNullStreams): void {
+    if (processHandle === proc) {
+      processHandle = null;
+    }
+  }
+
+  function attachProcessHandlers(proc: ChildProcessWithoutNullStreams, token: number): void {
+    proc.once("error", (error) => {
+      clearProcess(proc);
+      if (disposed || token !== launchToken || stopRequested) return;
+      broadcast({
+        status: "error",
+        url: CAL_AGENT_URL,
+        message: `Failed to start CAL-AGENT: ${formatStartError(error)}`,
+      });
+    });
+
+    proc.once("exit", (code, signal) => {
+      clearProcess(proc);
+      if (disposed || stopRequested) return;
+      if (token !== launchToken) return;
+      broadcast({
+        status: "error",
+        url: CAL_AGENT_URL,
+        message: `CAL-AGENT exited early${code !== null ? ` with code ${code}` : signal ? ` (${signal})` : ""}`,
+      });
+    });
+  }
+
+  async function stopProcess(): Promise<void> {
+    const proc = processHandle;
+    if (!proc) return;
+
+    stopRequested = true;
+    processHandle = null;
+
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      stopRequested = false;
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        proc.off("exit", finish);
+        proc.off("close", finish);
+        proc.off("error", finish);
+        stopRequested = false;
+        resolve();
+      };
+
+      proc.once("exit", finish);
+      proc.once("close", finish);
+      proc.once("error", finish);
+
+      try {
+        proc.kill();
+      } catch {
+        finish();
+        return;
+      }
+
+      setTimeout(() => {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            /* noop */
+          }
+        }
+      }, 2_000);
+    });
+  }
+
+  async function launchProcess(): Promise<CalAgentStatusPayload> {
+    if (disposed) return status;
+
+    await stopProcess();
+    ensureRootExists();
+
+    const token = ++launchToken;
+    broadcast({
+      status: "starting",
+      url: CAL_AGENT_URL,
+      message: "Starting CAL-AGENT workbench...",
+    });
+
+    const proc = spawn("npm", ["run", "web:dev"], {
+      cwd: CAL_AGENT_ROOT,
+      env: {
+        ...process.env,
+        CAL_AGENT_ROOT,
+        CAL_AGENT_URL,
+      },
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    processHandle = proc;
+    attachProcessHandlers(proc, token);
+
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+    while (!disposed && token === launchToken) {
+      if (!processHandle) {
+        return status;
+      }
+
+      if (await probeUrl(CAL_AGENT_URL, PROBE_TIMEOUT_MS)) {
+        const ready = {
+          status: "ready" as const,
+          url: CAL_AGENT_URL,
+          message: "CAL-AGENT is ready",
+        };
+        broadcast(ready);
+        return ready;
+      }
+
+      if (Date.now() >= deadline) {
+        broadcast({
+          status: "error",
+          url: CAL_AGENT_URL,
+          message: `CAL-AGENT did not become ready within ${Math.round(STARTUP_TIMEOUT_MS / 1000)}s`,
+        });
+        await stopProcess();
+        return status;
+      }
+
+      await delay(PROBE_INTERVAL_MS);
+    }
+
+    return status;
+  }
+
+  ipcMain.handle("cal-agent:get-status", async () => status);
+  ipcMain.handle("cal-agent:start", async () => launchProcess());
+  ipcMain.handle("cal-agent:retry", async () => launchProcess());
+  ipcMain.handle("cal-agent:open-external", async () => {
+    await shell.openExternal(CAL_AGENT_URL);
+  });
+
+  return {
+    async start() {
+      if (status.status === "starting" || status.status === "ready") {
+        return status;
+      }
+      return launchProcess();
+    },
+    async retry() {
+      return launchProcess();
+    },
+    getStatus() {
+      return status;
+    },
+    async openExternal() {
+      await shell.openExternal(CAL_AGENT_URL);
+    },
+    dispose() {
+      disposed = true;
+      stopRequested = true;
+      const proc = processHandle;
+      processHandle = null;
+      if (proc) {
+        try {
+          proc.kill();
+        } catch {
+          /* noop */
+        }
+      }
+    },
+  };
+}

--- a/apps/electron-demo/electron/cal-agent-manager.ts
+++ b/apps/electron-demo/electron/cal-agent-manager.ts
@@ -1,0 +1,238 @@
+export type CalAgentPanelStatus = "idle" | "starting" | "ready" | "error";
+
+export interface CalAgentStatusPayload {
+  status: CalAgentPanelStatus;
+  url: string;
+  message?: string;
+}
+
+export interface CalAgentManagerOptions {
+  spawn: (command: string, args: string[], options: { cwd: string; shell?: boolean }) => {
+    once(event: string, cb: (...args: any[]) => void): unknown;
+    kill(signal?: string): unknown;
+    exitCode?: number | null;
+    signalCode?: string | null;
+  };
+  probeUrl: (url: string) => Promise<boolean>;
+  pollIntervalMs: number;
+  startupTimeoutMs: number;
+  command: string;
+  args: string[];
+  cwd: string;
+  url: string;
+}
+
+interface LaunchState {
+  token: number;
+  promise: Promise<CalAgentStatusPayload>;
+  resolve: (payload: CalAgentStatusPayload) => void;
+  settled: boolean;
+  cancel: () => void;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createDeferredLaunch(): LaunchState {
+  let resolve!: (payload: CalAgentStatusPayload) => void;
+  const promise = new Promise<CalAgentStatusPayload>((next) => {
+    resolve = next;
+  });
+  return {
+    token: 0,
+    promise,
+    resolve,
+    settled: false,
+    cancel() {
+      /* replaced per-launch */
+    },
+  };
+}
+
+export function createCalAgentManager(options: CalAgentManagerOptions) {
+  let child: ReturnType<CalAgentManagerOptions["spawn"]> | null = null;
+  let currentStatus: CalAgentStatusPayload = {
+    status: "idle",
+    url: options.url,
+  };
+  let activeLaunch: LaunchState | null = null;
+  let launchToken = 0;
+
+  function setStatus(next: CalAgentStatusPayload): void {
+    currentStatus = next;
+  }
+
+  function finishLaunch(next: CalAgentStatusPayload): CalAgentStatusPayload {
+    setStatus(next);
+    if (activeLaunch && !activeLaunch.settled) {
+      activeLaunch.settled = true;
+      activeLaunch.resolve(next);
+    }
+    activeLaunch = null;
+    return next;
+  }
+
+  function startLaunchToken(): LaunchState {
+    const launch = createDeferredLaunch();
+    launch.token = ++launchToken;
+    let cancelResolve: (() => void) | null = null;
+    const cancelPromise = new Promise<void>((resolve) => {
+      cancelResolve = resolve;
+    });
+    launch.cancel = () => {
+      cancelResolve?.();
+    };
+    activeLaunch = launch;
+    return launch;
+  }
+
+  async function stopChild(): Promise<void> {
+    const proc = child;
+    child = null;
+    if (!proc) return;
+
+    try {
+      proc.kill();
+    } catch {
+      return;
+    }
+
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const done = () => resolve();
+      proc.once("exit", done);
+      proc.once("close", done);
+      proc.once("error", done);
+      setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          /* noop */
+        }
+      }, 2_000);
+    });
+  }
+
+  async function launch(restart = false): Promise<CalAgentStatusPayload> {
+    if (!restart) {
+      if (currentStatus.status === "ready" && child) {
+        return currentStatus;
+      }
+      if (currentStatus.status === "starting" && activeLaunch) {
+        return activeLaunch.promise;
+      }
+    }
+
+    if (restart) {
+      activeLaunch?.cancel();
+      await stopChild();
+    }
+
+    if (!restart && child) {
+      await stopChild();
+    }
+
+    const launchState = startLaunchToken();
+    const childProcess = options.spawn(options.command, options.args, {
+      cwd: options.cwd,
+      shell: process.platform === "win32",
+    });
+    child = childProcess;
+    setStatus({
+      status: "starting",
+      url: options.url,
+      message: "Starting CAL-AGENT workbench...",
+    });
+
+    childProcess.once("exit", (code, signal) => {
+      if (launchState.settled) return;
+      launchState.cancel();
+      child = null;
+      finishLaunch({
+        status: "error",
+        url: options.url,
+        message: `CAL-AGENT exited early${code !== null ? ` with code ${code}` : signal ? ` (${signal})` : ""}`,
+      });
+    });
+
+    childProcess.once("error", (error) => {
+      if (launchState.settled) return;
+      launchState.cancel();
+      child = null;
+      finishLaunch({
+        status: "error",
+        url: options.url,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+    const deadline = Date.now() + options.startupTimeoutMs;
+    while (launchState.token === launchToken && !launchState.settled) {
+      const probeResult = await Promise.race([
+        options.probeUrl(options.url).then((ok) => (ok ? "ready" : "not-ready") as const),
+        new Promise<"cancelled">((resolve) => {
+          const cancel = launchState.cancel;
+          launchState.cancel = () => {
+            cancel();
+            resolve("cancelled");
+          };
+        }),
+      ]);
+
+      if (probeResult === "cancelled") {
+        return currentStatus;
+      }
+
+      if (probeResult === "ready") {
+        return finishLaunch({
+          status: "ready",
+          url: options.url,
+          message: "CAL-AGENT is ready",
+        });
+      }
+
+      if (Date.now() >= deadline) {
+        finishLaunch({
+          status: "error",
+          url: options.url,
+          message: `CAL-AGENT did not become ready within ${Math.round(options.startupTimeoutMs / 1000)}s`,
+        });
+        await stopChild();
+        return currentStatus;
+      }
+
+      const waitResult = await Promise.race([
+        delay(options.pollIntervalMs).then(() => "tick" as const),
+        new Promise<"cancelled">((resolve) => {
+          const cancel = launchState.cancel;
+          launchState.cancel = () => {
+            cancel();
+            resolve("cancelled");
+          };
+        }),
+      ]);
+
+      if (waitResult === "cancelled") {
+        return currentStatus;
+      }
+    }
+
+    return currentStatus;
+  }
+
+  return {
+    start() {
+      return launch(false);
+    },
+    retry() {
+      return launch(true);
+    },
+    getStatus() {
+      return currentStatus;
+    },
+  };
+}

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile, readdir, mkdir, rename, stat } from "node:fs/promi
 import { existsSync, watch, type FSWatcher } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { createCalAgentController, type CalAgentController } from "./cal-agent-controller";
 
 // Must be called before app ready — declares our custom scheme as privileged
 // so images served via nexus-vault:// pass fetch/<img> with credentials / CORS.
@@ -14,6 +15,7 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 let mainWindow: BrowserWindow | null = null;
+let calAgentController: CalAgentController | null = null;
 
 export interface VaultNode {
   name: string;
@@ -435,9 +437,18 @@ app.whenReady().then(() => {
     }
   });
   createWindow();
+  calAgentController = createCalAgentController({
+    getWindow: () => mainWindow,
+  });
+  void calAgentController.start();
 });
 
 app.on("window-all-closed", () => {
+  calAgentController?.dispose();
   stopWatcher();
   app.quit();
+});
+
+app.on("before-quit", () => {
+  calAgentController?.dispose();
 });

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -49,6 +49,7 @@ function createWindow(): void {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
+      webviewTag: true,
       preload: path.join(__dirname, "preload.js"),
     },
   });

--- a/apps/electron-demo/electron/preload.ts
+++ b/apps/electron-demo/electron/preload.ts
@@ -36,7 +36,22 @@ export interface DemoBridge {
   openFile(): Promise<DemoFileHandle | null>;
   saveFile(path: string, content: string): Promise<{ path: string }>;
   saveFileAs(content: string): Promise<{ path: string } | null>;
+  calAgent: CalAgentBridge;
   vault: VaultBridge;
+}
+
+export interface CalAgentStatusPayload {
+  status: "idle" | "starting" | "ready" | "error";
+  url: string;
+  message?: string;
+}
+
+export interface CalAgentBridge {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): Promise<CalAgentStatusPayload>;
+  openExternal(): Promise<void>;
+  onStatusChange(cb: (payload: CalAgentStatusPayload) => void): () => void;
 }
 
 const vaultBridge: VaultBridge = {
@@ -91,6 +106,27 @@ const bridge: DemoBridge = {
   },
   saveFileAs(content: string) {
     return ipcRenderer.invoke("demo:save-file-as", content);
+  },
+  calAgent: {
+    start() {
+      return ipcRenderer.invoke("cal-agent:start");
+    },
+    retry() {
+      return ipcRenderer.invoke("cal-agent:retry");
+    },
+    getStatus() {
+      return ipcRenderer.invoke("cal-agent:get-status");
+    },
+    openExternal() {
+      return ipcRenderer.invoke("cal-agent:open-external");
+    },
+    onStatusChange(cb) {
+      const listener = (_event: Electron.IpcRendererEvent, payload: CalAgentStatusPayload) => cb(payload);
+      ipcRenderer.on("cal-agent:status-changed", listener);
+      return () => {
+        ipcRenderer.off("cal-agent:status-changed", listener);
+      };
+    },
   },
   vault: vaultBridge,
 };

--- a/apps/electron-demo/scripts/dev-electron.mjs
+++ b/apps/electron-demo/scripts/dev-electron.mjs
@@ -3,6 +3,38 @@ import { createRequire } from "node:module";
 import { build } from "tsup";
 
 const require = createRequire(import.meta.url);
+const RENDERER_PORTS = [5173, 5174, 5175, 5176, 5177, 5178, 5179, 5180];
+const RENDERER_READY_TIMEOUT_MS = 30_000;
+const RENDERER_PROBE_INTERVAL_MS = 250;
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function findRendererUrl() {
+  const deadline = Date.now() + RENDERER_READY_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    for (const port of RENDERER_PORTS) {
+      const url = `http://localhost:${port}`;
+      try {
+        const response = await fetch(url, { cache: "no-store" });
+        if (!response.ok) continue;
+
+        const html = await response.text();
+        if (html.includes("<title>Nexus Editor Demo</title>") && html.includes('<div id="app"></div>')) {
+          return url;
+        }
+      } catch {
+        // Keep probing until Vite becomes ready.
+      }
+    }
+
+    await delay(RENDERER_PROBE_INTERVAL_MS);
+  }
+
+  throw new Error("Could not detect Nexus renderer dev server URL within 30s");
+}
 
 await build({
   entry: ["electron/main.ts", "electron/preload.ts"],
@@ -14,15 +46,14 @@ await build({
   silent: true,
 });
 
-// Wait briefly for Vite dev server (started in parallel by npm-run-all)
-await new Promise((resolve) => setTimeout(resolve, 2000));
+const rendererUrl = await findRendererUrl();
 
 const electronPath = require("electron");
 const child = spawn(String(electronPath), ["dist-electron/main.js"], {
   stdio: "inherit",
   env: {
     ...process.env,
-    VITE_DEV_SERVER_URL: "http://localhost:5173",
+    VITE_DEV_SERVER_URL: rendererUrl,
   },
 });
 

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -19,6 +19,10 @@ let searchBar: SearchBar;
 let vault: VaultPanel;
 let backlinks: BacklinksPanel;
 let calAgentPanel: CalAgentPanel;
+let appRootEl: HTMLElement | null = null;
+let mainAreaEl: HTMLElement | null = null;
+let editorColumnEl: HTMLElement | null = null;
+let calAgentMaximized = false;
 
 const linkIndex = new LinkIndex();
 state.linkIndex = linkIndex;
@@ -70,7 +74,14 @@ function createAppToolbar(): HTMLElement {
   const calAgentBtn = document.createElement("button");
   calAgentBtn.textContent = "Agent";
   calAgentBtn.title = "Toggle CAL-AGENT panel";
-  calAgentBtn.addEventListener("click", toggleCalAgent);
+  calAgentBtn.addEventListener("click", (event) => {
+    if (event.detail !== 1) return;
+    toggleCalAgent();
+  });
+  calAgentBtn.addEventListener("dblclick", (event) => {
+    event.preventDefault();
+    toggleCalAgentMaximized();
+  });
 
   const searchBtn = document.createElement("button");
   searchBtn.textContent = "\uD83D\uDD0D"; // 🔍
@@ -211,7 +222,45 @@ function toggleBacklinks(): void {
 }
 
 function toggleCalAgent(): void {
+  if (calAgentMaximized) {
+    calAgentMaximized = false;
+    syncCalAgentLayout();
+  }
   togglePanel(calAgentPanel.element);
+}
+
+function syncCalAgentLayout(): void {
+  if (!appRootEl || !mainAreaEl || !editorColumnEl) return;
+
+  appRootEl.classList.toggle("is-cal-agent-maximized", calAgentMaximized);
+  mainAreaEl.classList.toggle("is-cal-agent-maximized", calAgentMaximized);
+  calAgentPanel.setMaximized(calAgentMaximized);
+
+  for (const child of Array.from(mainAreaEl.children)) {
+    if (!(child instanceof HTMLElement)) continue;
+    if (calAgentMaximized) {
+      if (!child.dataset.prevDisplay) {
+        child.dataset.prevDisplay = child.style.display;
+      }
+      child.style.display = child === calAgentPanel.element ? "flex" : "none";
+      continue;
+    }
+
+    if (child.dataset.prevDisplay !== undefined) {
+      child.style.display = child.dataset.prevDisplay;
+      delete child.dataset.prevDisplay;
+    }
+  }
+
+  editorColumnEl.style.display = calAgentMaximized ? "none" : editorColumnEl.dataset.prevDisplay ?? "";
+}
+
+function toggleCalAgentMaximized(): void {
+  calAgentMaximized = !calAgentMaximized;
+  if (calAgentMaximized) {
+    calAgentPanel.setVisible(true);
+  }
+  syncCalAgentLayout();
 }
 
 async function handleVaultFileOpen(filePath: string): Promise<void> {
@@ -354,22 +403,22 @@ async function tryRestoreLastVault(): Promise<void> {
 
 function boot(): void {
   const bootScope = perfStart("boot");
-  const root = document.getElementById("app");
-  if (!root) throw new Error("Missing #app element");
+  appRootEl = document.getElementById("app");
+  if (!appRootEl) throw new Error("Missing #app element");
 
   const appToolbar = createAppToolbar();
   const statusLine = createStatusLine();
 
-  const mainArea = document.createElement("div");
-  mainArea.className = "main-area";
+  mainAreaEl = document.createElement("div");
+  mainAreaEl.className = "main-area";
 
-  const editorColumn = document.createElement("div");
-  editorColumn.className = "editor-column";
+  editorColumnEl = document.createElement("div");
+  editorColumnEl.className = "editor-column";
 
   const editorContainer = document.createElement("div");
   editorContainer.className = "editor-container";
 
-  root.append(appToolbar, mainArea, statusLine);
+  appRootEl.append(appToolbar, mainAreaEl, statusLine);
 
   shell = createEditorShell({
     container: editorContainer,
@@ -421,8 +470,9 @@ function boot(): void {
 
   calAgentPanel = createCalAgentPanel();
 
-  editorColumn.append(searchBar.element, editorContainer);
-  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element, calAgentPanel.element);
+  editorColumnEl.append(searchBar.element, editorContainer);
+  mainAreaEl.append(vault.element, editorColumnEl, outline.element, backlinks.element, calAgentPanel.element);
+  syncCalAgentLayout();
 
   // External file changes → re-seed the index (cheap for typical vaults).
   window.nexusDemo.vault.onChanged(() => {

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -4,6 +4,7 @@ import { loadSettings, createSettingsPanel, type EditorSettings } from "./settin
 import { createOutlinePanel, type OutlinePanel } from "./outline-panel";
 import { createSearchBar, type SearchBar } from "./search-bar";
 import { createVaultPanel, type VaultPanel } from "./vault-panel";
+import { createCalAgentPanel, type CalAgentPanel } from "./cal-agent-panel";
 import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
 import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
 import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
@@ -17,6 +18,7 @@ let outline: OutlinePanel;
 let searchBar: SearchBar;
 let vault: VaultPanel;
 let backlinks: BacklinksPanel;
+let calAgentPanel: CalAgentPanel;
 
 const linkIndex = new LinkIndex();
 state.linkIndex = linkIndex;
@@ -65,6 +67,11 @@ function createAppToolbar(): HTMLElement {
   backlinksBtn.style.fontSize = "14px";
   backlinksBtn.addEventListener("click", toggleBacklinks);
 
+  const calAgentBtn = document.createElement("button");
+  calAgentBtn.textContent = "Agent";
+  calAgentBtn.title = "Toggle CAL-AGENT panel";
+  calAgentBtn.addEventListener("click", toggleCalAgent);
+
   const searchBtn = document.createElement("button");
   searchBtn.textContent = "\uD83D\uDD0D"; // 🔍
   searchBtn.title = "Search (Ctrl+F)";
@@ -86,6 +93,7 @@ function createAppToolbar(): HTMLElement {
     vaultToggleBtn,
     outlineBtn,
     backlinksBtn,
+    calAgentBtn,
     searchBtn,
     settingsBtn
   );
@@ -200,6 +208,10 @@ function toggleVault(): void {
 
 function toggleBacklinks(): void {
   togglePanel(backlinks.element, () => backlinks.refresh());
+}
+
+function toggleCalAgent(): void {
+  togglePanel(calAgentPanel.element);
 }
 
 async function handleVaultFileOpen(filePath: string): Promise<void> {
@@ -407,8 +419,10 @@ function boot(): void {
     getActiveFile: () => state.activeFile,
   });
 
+  calAgentPanel = createCalAgentPanel();
+
   editorColumn.append(searchBar.element, editorContainer);
-  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element);
+  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element, calAgentPanel.element);
 
   // External file changes → re-seed the index (cheap for typical vaults).
   window.nexusDemo.vault.onChanged(() => {

--- a/apps/electron-demo/src/renderer/bridge.d.ts
+++ b/apps/electron-demo/src/renderer/bridge.d.ts
@@ -34,7 +34,22 @@ interface DemoBridge {
   openFile(): Promise<DemoFileHandle | null>;
   saveFile(path: string, content: string): Promise<{ path: string }>;
   saveFileAs(content: string): Promise<{ path: string } | null>;
+  calAgent: CalAgentBridge;
   vault: VaultBridge;
+}
+
+interface CalAgentStatusPayload {
+  status: "idle" | "starting" | "ready" | "error";
+  url: string;
+  message?: string;
+}
+
+interface CalAgentBridge {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): Promise<CalAgentStatusPayload>;
+  openExternal(): Promise<void>;
+  onStatusChange(cb: (payload: CalAgentStatusPayload) => void): () => void;
 }
 
 interface Window {

--- a/apps/electron-demo/src/renderer/cal-agent-panel.ts
+++ b/apps/electron-demo/src/renderer/cal-agent-panel.ts
@@ -57,13 +57,13 @@ export function createCalAgentPanel(): CalAgentPanel {
   hint.className = "cal-agent-panel__hint";
   hint.textContent = "Waiting for CAL-AGENT to become ready...";
 
-  const iframe = document.createElement("iframe");
-  iframe.className = "cal-agent-panel__frame";
-  iframe.title = "CAL-AGENT workbench";
-  iframe.loading = "lazy";
-  iframe.referrerPolicy = "no-referrer";
+  const webview = document.createElement("webview");
+  webview.className = "cal-agent-panel__frame";
+  webview.setAttribute("partition", "persist:cal-agent");
+  webview.setAttribute("allowpopups", "");
+  webview.setAttribute("webpreferences", "contextIsolation=yes");
 
-  body.append(hint, iframe);
+  body.append(hint, webview);
   root.append(header, body);
 
   let current: CalAgentStatusPayload = {
@@ -80,13 +80,14 @@ export function createCalAgentPanel(): CalAgentPanel {
     hint.style.display = next.status === "ready" ? "none" : "block";
 
     if (next.status === "ready") {
-      if (iframe.src !== next.url) {
-        iframe.src = next.url;
+      const currentSrc = webview.getAttribute("src");
+      if (currentSrc !== next.url) {
+        webview.setAttribute("src", next.url);
       }
-      iframe.style.display = "block";
+      webview.style.display = "block";
     } else {
-      iframe.removeAttribute("src");
-      iframe.style.display = "none";
+      webview.removeAttribute("src");
+      webview.style.display = "none";
     }
   }
 

--- a/apps/electron-demo/src/renderer/cal-agent-panel.ts
+++ b/apps/electron-demo/src/renderer/cal-agent-panel.ts
@@ -1,0 +1,133 @@
+interface CalAgentStatusPayload {
+  status: "idle" | "starting" | "ready" | "error";
+  url: string;
+  message?: string;
+}
+
+export interface CalAgentPanel {
+  element: HTMLElement;
+  setVisible(next: boolean): void;
+  destroy(): void;
+}
+
+function statusText(status: CalAgentStatusPayload["status"]): string {
+  if (status === "starting") return "Starting workbench...";
+  if (status === "ready") return "Connected";
+  if (status === "error") return "Unavailable";
+  return "Idle";
+}
+
+export function createCalAgentPanel(): CalAgentPanel {
+  const root = document.createElement("section");
+  root.className = "cal-agent-panel";
+
+  const header = document.createElement("div");
+  header.className = "cal-agent-panel__header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "cal-agent-panel__title-wrap";
+
+  const title = document.createElement("div");
+  title.className = "cal-agent-panel__title";
+  title.textContent = "Calendar Agent";
+
+  const status = document.createElement("div");
+  status.className = "cal-agent-panel__status";
+
+  titleWrap.append(title, status);
+
+  const actions = document.createElement("div");
+  actions.className = "cal-agent-panel__actions";
+
+  const retryBtn = document.createElement("button");
+  retryBtn.type = "button";
+  retryBtn.textContent = "Retry";
+
+  const openBtn = document.createElement("button");
+  openBtn.type = "button";
+  openBtn.textContent = "Open in Browser";
+
+  actions.append(retryBtn, openBtn);
+  header.append(titleWrap, actions);
+
+  const body = document.createElement("div");
+  body.className = "cal-agent-panel__body";
+
+  const hint = document.createElement("div");
+  hint.className = "cal-agent-panel__hint";
+  hint.textContent = "Waiting for CAL-AGENT to become ready...";
+
+  const iframe = document.createElement("iframe");
+  iframe.className = "cal-agent-panel__frame";
+  iframe.title = "CAL-AGENT workbench";
+  iframe.loading = "lazy";
+  iframe.referrerPolicy = "no-referrer";
+
+  body.append(hint, iframe);
+  root.append(header, body);
+
+  let current: CalAgentStatusPayload = {
+    status: "idle",
+    url: "http://127.0.0.1:3000",
+  };
+  let unsubscribe: (() => void) | null = null;
+
+  function render(next: CalAgentStatusPayload): void {
+    current = next;
+    root.dataset.state = next.status;
+    status.textContent = statusText(next.status);
+    hint.textContent = next.message ?? "";
+    hint.style.display = next.status === "ready" ? "none" : "block";
+
+    if (next.status === "ready") {
+      if (iframe.src !== next.url) {
+        iframe.src = next.url;
+      }
+      iframe.style.display = "block";
+    } else {
+      iframe.removeAttribute("src");
+      iframe.style.display = "none";
+    }
+  }
+
+  retryBtn.addEventListener("click", () => {
+    void window.nexusDemo.calAgent.retry().then(render).catch((error) => {
+      render({
+        status: "error",
+        url: current.url,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+
+  openBtn.addEventListener("click", () => {
+    void window.nexusDemo.calAgent.openExternal();
+  });
+
+  async function bootstrap(): Promise<void> {
+    try {
+      render(await window.nexusDemo.calAgent.getStatus());
+      render(await window.nexusDemo.calAgent.start());
+    } catch (error) {
+      render({
+        status: "error",
+        url: current.url,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  unsubscribe = window.nexusDemo.calAgent.onStatusChange(render);
+  void bootstrap();
+
+  return {
+    element: root,
+    setVisible(next) {
+      root.style.display = next ? "" : "none";
+    },
+    destroy() {
+      unsubscribe?.();
+      unsubscribe = null;
+    },
+  };
+}

--- a/apps/electron-demo/src/renderer/cal-agent-panel.ts
+++ b/apps/electron-demo/src/renderer/cal-agent-panel.ts
@@ -7,7 +7,18 @@ interface CalAgentStatusPayload {
 export interface CalAgentPanel {
   element: HTMLElement;
   setVisible(next: boolean): void;
+  setMaximized(next: boolean): void;
   destroy(): void;
+}
+
+function buildEmbedUrl(url: string, embedded: boolean): string {
+  const parsed = new URL(url);
+  if (embedded) {
+    parsed.searchParams.set("embed", "1");
+  } else {
+    parsed.searchParams.delete("embed");
+  }
+  return parsed.toString();
 }
 
 function statusText(status: CalAgentStatusPayload["status"]): string {
@@ -70,6 +81,7 @@ export function createCalAgentPanel(): CalAgentPanel {
     status: "idle",
     url: "http://127.0.0.1:3000",
   };
+  let maximized = false;
   let unsubscribe: (() => void) | null = null;
 
   function render(next: CalAgentStatusPayload): void {
@@ -80,9 +92,10 @@ export function createCalAgentPanel(): CalAgentPanel {
     hint.style.display = next.status === "ready" ? "none" : "block";
 
     if (next.status === "ready") {
+      const targetUrl = buildEmbedUrl(next.url, maximized);
       const currentSrc = webview.getAttribute("src");
-      if (currentSrc !== next.url) {
-        webview.setAttribute("src", next.url);
+      if (currentSrc !== targetUrl) {
+        webview.setAttribute("src", targetUrl);
       }
       webview.style.display = "block";
     } else {
@@ -125,6 +138,12 @@ export function createCalAgentPanel(): CalAgentPanel {
     element: root,
     setVisible(next) {
       root.style.display = next ? "" : "none";
+    },
+    setMaximized(next) {
+      maximized = next;
+      if (current.status === "ready") {
+        webview.setAttribute("src", buildEmbedUrl(current.url, maximized));
+      }
     },
     destroy() {
       unsubscribe?.();

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -36,6 +36,81 @@ body,
   overflow: hidden;
 }
 
+.cal-agent-panel {
+  flex: 0 0 360px;
+  min-width: 300px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid #ddd;
+  background: #fff;
+  overflow: hidden;
+}
+
+.cal-agent-panel__header {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 10px 12px;
+  border-bottom: 1px solid #eee;
+  background: #fafafa;
+  flex-shrink: 0;
+}
+
+.cal-agent-panel__title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cal-agent-panel__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.cal-agent-panel__status {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.cal-agent-panel__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cal-agent-panel__actions button {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.cal-agent-panel__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.cal-agent-panel__hint {
+  padding: 10px 12px;
+  font-size: 13px;
+  color: #6b7280;
+  border-bottom: 1px solid #eee;
+}
+
+.cal-agent-panel__frame {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}
+
 .editor-column {
   flex: 1;
   display: flex;

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -16,6 +16,15 @@ body,
   font-family: system-ui, sans-serif;
 }
 
+#app.is-cal-agent-maximized > .toolbar,
+#app.is-cal-agent-maximized > .status-line {
+  display: none;
+}
+
+#app.is-cal-agent-maximized > .main-area {
+  flex: 1 1 auto;
+}
+
 .toolbar {
   display: flex;
   gap: 8px;
@@ -34,6 +43,29 @@ body,
   flex: 1;
   display: flex;
   overflow: hidden;
+}
+
+.main-area.is-cal-agent-maximized > :not(.cal-agent-panel) {
+  display: none;
+}
+
+.main-area.is-cal-agent-maximized .cal-agent-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  border-left: 0;
+  height: 100%;
+}
+
+.main-area.is-cal-agent-maximized .cal-agent-panel__header {
+  display: none;
+}
+
+.main-area.is-cal-agent-maximized .cal-agent-panel__body {
+  height: 100%;
+}
+
+.main-area.is-cal-agent-maximized .cal-agent-panel__frame {
+  height: 100%;
 }
 
 .cal-agent-panel {

--- a/apps/electron-demo/test/cal-agent-manager.test.ts
+++ b/apps/electron-demo/test/cal-agent-manager.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCalAgentManager } from "../electron/cal-agent-manager";
+
+function createFakeChild() {
+  const listeners = new Map<string, Array<(...args: any[]) => void>>();
+  return {
+    pid: 4321,
+    once(event: string, cb: (...args: any[]) => void) {
+      listeners.set(event, [...(listeners.get(event) ?? []), cb]);
+      return this;
+    },
+    emit(event: string, ...args: any[]) {
+      for (const cb of listeners.get(event) ?? []) cb(...args);
+    },
+    kill: vi.fn(() => true),
+  };
+}
+
+describe("createCalAgentManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("transitions from starting to ready after the health probe succeeds", async () => {
+    const child = createFakeChild();
+    const spawn = vi.fn(() => child as any);
+    const probeUrl = vi
+      .fn<(url: string) => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const manager = createCalAgentManager({
+      spawn,
+      probeUrl,
+      pollIntervalMs: 100,
+      startupTimeoutMs: 1000,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000",
+    });
+
+    const startPromise = manager.start();
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(startPromise).resolves.toMatchObject({ status: "ready" });
+    expect(manager.getStatus().status).toBe("ready");
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not spawn a second child while already starting", () => {
+    const child = createFakeChild();
+    const spawn = vi.fn(() => child as any);
+
+    const manager = createCalAgentManager({
+      spawn,
+      probeUrl: vi.fn(() => new Promise<boolean>(() => {})),
+      pollIntervalMs: 100,
+      startupTimeoutMs: 5000,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000",
+    });
+
+    void manager.start();
+    void manager.start();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves to error on startup timeout and allows retry", async () => {
+    const firstChild = createFakeChild();
+    const secondChild = createFakeChild();
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(firstChild as any)
+      .mockReturnValueOnce(secondChild as any);
+    const probeUrl = vi.fn<(url: string) => Promise<boolean>>().mockResolvedValue(false);
+
+    const manager = createCalAgentManager({
+      spawn,
+      probeUrl,
+      pollIntervalMs: 100,
+      startupTimeoutMs: 300,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000",
+    });
+
+    const first = manager.start();
+    await vi.advanceTimersByTimeAsync(400);
+    await expect(first).resolves.toMatchObject({ status: "error" });
+
+    probeUrl.mockResolvedValueOnce(true);
+    const retry = manager.retry();
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(retry).resolves.toMatchObject({ status: "ready" });
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("moves to error when the child exits before readiness", async () => {
+    const child = createFakeChild();
+    const spawn = vi.fn(() => child as any);
+
+    const manager = createCalAgentManager({
+      spawn,
+      probeUrl: vi.fn<(url: string) => Promise<boolean>>().mockResolvedValue(false),
+      pollIntervalMs: 100,
+      startupTimeoutMs: 5000,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000",
+    });
+
+    const startPromise = manager.start();
+    child.emit("exit", 1);
+
+    await expect(startPromise).resolves.toMatchObject({ status: "error" });
+    expect(manager.getStatus().status).toBe("error");
+  });
+});

--- a/docs/superpowers/plans/2026-05-27-cal-agent-embedded-panel-poc.md
+++ b/docs/superpowers/plans/2026-05-27-cal-agent-embedded-panel-poc.md
@@ -1,0 +1,910 @@
+# CAL-AGENT Embedded Panel POC Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use the `subagent-driven-development` agent (recommended) or `executing-plans` agent to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a development-only CAL-AGENT side panel to the Electron demo that auto-starts the external web app from the main process, shows startup and failure states in the renderer, embeds the existing CAL-AGENT UI when reachable, and keeps the editor usable if CAL-AGENT fails.
+
+**Architecture:** Keep the process boundary explicit. A new main-process manager owns `npm run web:dev`, readiness polling, retry, duplicate-start suppression, and shutdown cleanup. A narrow preload bridge exposes status and actions to a new right-side renderer panel that renders `starting`, `ready`, and `error` states and embeds `http://127.0.0.1:3000` via `iframe` unless the manual smoke test proves embedding is blocked.
+
+**Tech Stack:** TypeScript, Electron 35, Vite renderer, plain DOM UI modules, Vitest, Node `child_process`, Electron IPC
+
+---
+
+## File Structure
+
+- Create: `apps/electron-demo/electron/cal-agent-types.ts`
+  Responsibility: shared status payloads, manager state, and bridge-facing TypeScript types for CAL-AGENT.
+- Create: `apps/electron-demo/electron/cal-agent-config.ts`
+  Responsibility: development-only constants for repo path, target URL, command, and startup timeout so the fixed local path stays in one place.
+- Create: `apps/electron-demo/electron/cal-agent-manager.ts`
+  Responsibility: own child-process spawn, health polling, state transitions, duplicate-start suppression, retry, observer notifications, and cleanup.
+- Create: `apps/electron-demo/electron/cal-agent-preload.ts`
+  Responsibility: build the renderer-safe bridge over `ipcRenderer` and isolate preload logic from `preload.ts` side effects.
+- Create: `apps/electron-demo/electron/cal-agent-main-ipc.ts`
+  Responsibility: register CAL-AGENT IPC handlers and status broadcasts against `ipcMain`, `BrowserWindow`, and `shell` without bloating `electron/main.ts` further.
+- Modify: `apps/electron-demo/electron/main.ts`
+  Responsibility: instantiate the CAL-AGENT manager at app startup, register IPC, start the manager after `app.whenReady()`, and dispose it during shutdown.
+- Modify: `apps/electron-demo/electron/preload.ts`
+  Responsibility: expose `window.nexusDemo.calAgent` next to the existing vault and file bridge.
+- Modify: `apps/electron-demo/src/renderer/bridge.d.ts`
+  Responsibility: type the new bridge surface in the renderer.
+- Create: `apps/electron-demo/src/renderer/cal-agent-panel.ts`
+  Responsibility: render the right-side panel shell, status indicator, `Retry`, `Open in Browser`, and embedded `iframe`.
+- Create: `apps/electron-demo/src/renderer/cal-agent-controller.ts`
+  Responsibility: bind the panel to the preload bridge, request initial status, subscribe to updates, and keep the panel non-blocking.
+- Modify: `apps/electron-demo/src/renderer/app.ts`
+  Responsibility: mount the new panel into the existing `main-area`, add a toolbar toggle, and boot CAL-AGENT asynchronously so editor startup still completes.
+- Modify: `apps/electron-demo/src/renderer/style.css`
+  Responsibility: add layout and panel styles only where shared CSS is better than inline styles.
+- Create: `apps/electron-demo/test/cal-agent-manager.test.ts`
+  Responsibility: focused manager-state regressions for ready, timeout, duplicate start, retry, and cleanup.
+- Create: `apps/electron-demo/test/cal-agent-preload.test.ts`
+  Responsibility: bridge contract tests for IPC names, status payload flow, and unsubscribe behavior.
+- Create: `apps/electron-demo/test/cal-agent-panel.test.ts`
+  Responsibility: jsdom coverage for renderer state rendering and action wiring.
+- Create: `apps/electron-demo/test/cal-agent-main-ipc.test.ts`
+  Responsibility: validate IPC registration and external-browser action without needing to boot Electron.
+
+## Delivery Sequence
+
+1. Build the main-process manager first so process ownership, timeout behavior, and retry semantics are stable before wiring UI.
+2. Expose the preload bridge second so renderer work can proceed against a typed contract instead of raw IPC strings.
+3. Build the renderer panel and controller third so UI states can be verified in jsdom before touching the app shell.
+4. Wire Electron main and renderer boot fourth, then do an early smoke test immediately.
+5. Use the smoke result as the CSP checkpoint: if the `iframe` renders, continue to manual validation and cleanup checks; if it is blocked, stop and switch to the fallback branch described in the risk section instead of pushing deeper into the wrong approach.
+
+### Task 1: Build the CAL-AGENT manager core
+
+**Purpose:** Lock down the high-risk behavior first: process ownership, readiness polling, timeout, duplicate-start suppression, retry, and shutdown cleanup.
+
+**Files:**
+- Create: `apps/electron-demo/electron/cal-agent-types.ts`
+- Create: `apps/electron-demo/electron/cal-agent-config.ts`
+- Create: `apps/electron-demo/electron/cal-agent-manager.ts`
+- Test: `apps/electron-demo/test/cal-agent-manager.test.ts`
+
+- [ ] **Step 1: Write the failing manager regression tests**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCalAgentManager } from "../electron/cal-agent-manager";
+
+function createFakeChild() {
+  const listeners = new Map<string, Function[]>();
+  return {
+    pid: 4321,
+    once(event: string, cb: Function) {
+      listeners.set(event, [...(listeners.get(event) ?? []), cb]);
+      return this;
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const cb of listeners.get(event) ?? []) cb(...args);
+    },
+    kill: vi.fn(() => true)
+  };
+}
+
+describe("createCalAgentManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("transitions from starting to ready after the health probe succeeds", async () => {
+    const child = createFakeChild();
+    const spawn = vi.fn(() => child as any);
+    const probe = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const manager = createCalAgentManager({
+      spawn,
+      probeUrl: probe,
+      pollIntervalMs: 100,
+      startupTimeoutMs: 1_000,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000"
+    });
+
+    const startPromise = manager.start();
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(startPromise).resolves.toMatchObject({ status: "ready" });
+    expect(manager.getStatus().status).toBe("ready");
+  });
+
+  it("does not spawn a second child while already starting", async () => {
+    const child = createFakeChild();
+    const manager = createCalAgentManager({
+      spawn: vi.fn(() => child as any),
+      probeUrl: vi.fn(() => new Promise<boolean>(() => {})),
+      pollIntervalMs: 100,
+      startupTimeoutMs: 5_000,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000"
+    });
+
+    void manager.start();
+    void manager.start();
+
+    expect(manager.dependencies.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves to error on startup timeout and allows retry", async () => {
+    const firstChild = createFakeChild();
+    const secondChild = createFakeChild();
+    const spawn = vi.fn()
+      .mockReturnValueOnce(firstChild as any)
+      .mockReturnValueOnce(secondChild as any);
+    const probe = vi.fn().mockResolvedValue(false);
+
+    const manager = createCalAgentManager({
+      spawn,
+      probeUrl: probe,
+      pollIntervalMs: 100,
+      startupTimeoutMs: 300,
+      command: "npm",
+      args: ["run", "web:dev"],
+      cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+      url: "http://127.0.0.1:3000"
+    });
+
+    const first = manager.start();
+    await vi.advanceTimersByTimeAsync(400);
+    await expect(first).resolves.toMatchObject({ status: "error" });
+
+    probe.mockResolvedValueOnce(true);
+    const retry = manager.retry();
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(retry).resolves.toMatchObject({ status: "ready" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused manager test to verify it fails**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-manager.test.ts`
+Expected: FAIL because the manager module and shared CAL-AGENT types do not exist yet.
+
+- [ ] **Step 3: Implement the minimal manager, shared types, and config constants**
+
+```ts
+// apps/electron-demo/electron/cal-agent-types.ts
+export type CalAgentPanelStatus = "idle" | "starting" | "ready" | "error";
+
+export interface CalAgentStatusPayload {
+  status: CalAgentPanelStatus;
+  url: string;
+  message?: string;
+}
+
+export interface CalAgentManager {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): CalAgentStatusPayload;
+  subscribe(listener: (payload: CalAgentStatusPayload) => void): () => void;
+  dispose(): void;
+}
+```
+
+```ts
+// apps/electron-demo/electron/cal-agent-config.ts
+export const CAL_AGENT_CONFIG = {
+  cwd: "/Users/wangqiao/workspace/CAL-AGENT",
+  command: "npm",
+  args: ["run", "web:dev"],
+  url: "http://127.0.0.1:3000",
+  pollIntervalMs: 500,
+  startupTimeoutMs: 45_000
+} as const;
+```
+
+```ts
+// apps/electron-demo/electron/cal-agent-manager.ts
+import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import type { CalAgentManager, CalAgentStatusPayload } from "./cal-agent-types";
+
+export function createCalAgentManager(dependencies = {
+  spawn: nodeSpawn,
+  probeUrl: async (url: string) => {
+    const response = await fetch(url);
+    return response.ok;
+  },
+  ...CAL_AGENT_CONFIG
+}) {
+  let child: ChildProcessWithoutNullStreams | null = null;
+  let inFlightStart: Promise<CalAgentStatusPayload> | null = null;
+  let status: CalAgentStatusPayload = { status: "idle", url: dependencies.url };
+  const listeners = new Set<(payload: CalAgentStatusPayload) => void>();
+
+  const publish = (next: CalAgentStatusPayload) => {
+    status = next;
+    for (const listener of listeners) listener(status);
+  };
+
+  async function waitUntilReady(): Promise<CalAgentStatusPayload> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < dependencies.startupTimeoutMs) {
+      if (await dependencies.probeUrl(dependencies.url)) {
+        publish({ status: "ready", url: dependencies.url });
+        return status;
+      }
+      await delay(dependencies.pollIntervalMs);
+    }
+    publish({ status: "error", url: dependencies.url, message: "CAL-AGENT startup timed out." });
+    return status;
+  }
+
+  return {
+    dependencies,
+    getStatus() {
+      return status;
+    },
+    subscribe(listener: (payload: CalAgentStatusPayload) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    async start() {
+      if (inFlightStart) return inFlightStart;
+      if (status.status === "ready") return status;
+
+      publish({ status: "starting", url: dependencies.url, message: "Starting CAL-AGENT…" });
+      child = dependencies.spawn(dependencies.command, dependencies.args, {
+        cwd: dependencies.cwd,
+        env: process.env,
+        stdio: "pipe"
+      }) as ChildProcessWithoutNullStreams;
+
+      child.once("exit", (code) => {
+        if (status.status !== "ready") {
+          publish({ status: "error", url: dependencies.url, message: `CAL-AGENT exited early (${code ?? "signal"}).` });
+        }
+      });
+
+      inFlightStart = waitUntilReady().finally(() => {
+        inFlightStart = null;
+      });
+
+      return inFlightStart;
+    },
+    async retry() {
+      if (child) child.kill();
+      child = null;
+      publish({ status: "idle", url: dependencies.url });
+      return this.start();
+    },
+    dispose() {
+      if (child) child.kill();
+      child = null;
+      publish({ status: "idle", url: dependencies.url });
+    }
+  } satisfies CalAgentManager & { dependencies: typeof dependencies };
+}
+```
+
+- [ ] **Step 4: Run the focused manager test to verify it passes**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-manager.test.ts`
+Expected: PASS with manager state transitions, timeout, duplicate-start suppression, and retry behavior covered.
+
+- [ ] **Step 5: Commit the manager slice**
+
+```bash
+git add apps/electron-demo/electron/cal-agent-types.ts apps/electron-demo/electron/cal-agent-config.ts apps/electron-demo/electron/cal-agent-manager.ts apps/electron-demo/test/cal-agent-manager.test.ts
+git commit -m "feat(electron-demo): add cal-agent manager core"
+```
+
+### Task 2: Expose a narrow preload bridge
+
+**Purpose:** Freeze the renderer contract before touching UI so the panel code can consume a typed API instead of inline IPC strings.
+
+**Files:**
+- Create: `apps/electron-demo/electron/cal-agent-preload.ts`
+- Modify: `apps/electron-demo/electron/preload.ts`
+- Modify: `apps/electron-demo/src/renderer/bridge.d.ts`
+- Test: `apps/electron-demo/test/cal-agent-preload.test.ts`
+
+- [ ] **Step 1: Write the failing preload bridge tests**
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { createCalAgentBridge } from "../electron/cal-agent-preload";
+
+describe("createCalAgentBridge", () => {
+  it("invokes the expected IPC channels", async () => {
+    const invoke = vi.fn().mockResolvedValue({ status: "idle", url: "http://127.0.0.1:3000" });
+    const on = vi.fn();
+    const off = vi.fn();
+    const bridge = createCalAgentBridge({ invoke, on, off } as any);
+
+    await bridge.start();
+    await bridge.retry();
+    await bridge.getStatus();
+    await bridge.openExternal();
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "cal-agent:start");
+    expect(invoke).toHaveBeenNthCalledWith(2, "cal-agent:retry");
+    expect(invoke).toHaveBeenNthCalledWith(3, "cal-agent:get-status");
+    expect(invoke).toHaveBeenNthCalledWith(4, "cal-agent:open-external");
+  });
+
+  it("returns an unsubscribe function for status changes", () => {
+    const on = vi.fn();
+    const off = vi.fn();
+    const bridge = createCalAgentBridge({ invoke: vi.fn(), on, off } as any);
+
+    const dispose = bridge.onStatusChange(() => undefined);
+    dispose();
+
+    expect(on).toHaveBeenCalledWith("cal-agent:status", expect.any(Function));
+    expect(off).toHaveBeenCalledWith("cal-agent:status", expect.any(Function));
+  });
+});
+```
+
+- [ ] **Step 2: Run the bridge test to verify it fails**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-preload.test.ts`
+Expected: FAIL because the CAL-AGENT preload factory and renderer bridge typing do not exist yet.
+
+- [ ] **Step 3: Implement the preload bridge and expose it on `window.nexusDemo`**
+
+```ts
+// apps/electron-demo/electron/cal-agent-preload.ts
+import type { IpcRenderer } from "electron";
+import type { CalAgentStatusPayload } from "./cal-agent-types";
+
+export interface CalAgentBridge {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): Promise<CalAgentStatusPayload>;
+  openExternal(): Promise<void>;
+  onStatusChange(cb: (payload: CalAgentStatusPayload) => void): () => void;
+}
+
+export function createCalAgentBridge(ipcRenderer: Pick<IpcRenderer, "invoke" | "on" | "off">): CalAgentBridge {
+  return {
+    start() {
+      return ipcRenderer.invoke("cal-agent:start");
+    },
+    retry() {
+      return ipcRenderer.invoke("cal-agent:retry");
+    },
+    getStatus() {
+      return ipcRenderer.invoke("cal-agent:get-status");
+    },
+    openExternal() {
+      return ipcRenderer.invoke("cal-agent:open-external");
+    },
+    onStatusChange(cb) {
+      const listener = (_event: Electron.IpcRendererEvent, payload: CalAgentStatusPayload) => cb(payload);
+      ipcRenderer.on("cal-agent:status", listener);
+      return () => ipcRenderer.off("cal-agent:status", listener);
+    }
+  };
+}
+```
+
+```ts
+// apps/electron-demo/electron/preload.ts
+import { createCalAgentBridge } from "./cal-agent-preload";
+
+const bridge: DemoBridge = {
+  openFile() {
+    return ipcRenderer.invoke("demo:open-file");
+  },
+  saveFile(path: string, content: string) {
+    return ipcRenderer.invoke("demo:save-file", path, content);
+  },
+  saveFileAs(content: string) {
+    return ipcRenderer.invoke("demo:save-file-as", content);
+  },
+  vault: vaultBridge,
+  calAgent: createCalAgentBridge(ipcRenderer)
+};
+```
+
+```ts
+// apps/electron-demo/src/renderer/bridge.d.ts
+interface CalAgentStatusPayload {
+  status: "idle" | "starting" | "ready" | "error";
+  url: string;
+  message?: string;
+}
+
+interface CalAgentBridge {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): Promise<CalAgentStatusPayload>;
+  openExternal(): Promise<void>;
+  onStatusChange(cb: (payload: CalAgentStatusPayload) => void): () => void;
+}
+
+interface DemoBridge {
+  openFile(): Promise<DemoFileHandle | null>;
+  saveFile(path: string, content: string): Promise<{ path: string }>;
+  saveFileAs(content: string): Promise<{ path: string } | null>;
+  vault: VaultBridge;
+  calAgent: CalAgentBridge;
+}
+```
+
+- [ ] **Step 4: Run the bridge test to verify it passes**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-preload.test.ts`
+Expected: PASS with stable IPC channel names and unsubscribe behavior.
+
+- [ ] **Step 5: Commit the preload slice**
+
+```bash
+git add apps/electron-demo/electron/cal-agent-preload.ts apps/electron-demo/electron/preload.ts apps/electron-demo/src/renderer/bridge.d.ts apps/electron-demo/test/cal-agent-preload.test.ts
+git commit -m "feat(electron-demo): expose cal-agent preload bridge"
+```
+
+### Task 3: Build the renderer panel and controller
+
+**Purpose:** Get the visible panel states working in isolation before wiring them into the full app shell.
+
+**Files:**
+- Create: `apps/electron-demo/src/renderer/cal-agent-panel.ts`
+- Create: `apps/electron-demo/src/renderer/cal-agent-controller.ts`
+- Modify: `apps/electron-demo/src/renderer/style.css`
+- Test: `apps/electron-demo/test/cal-agent-panel.test.ts`
+
+- [ ] **Step 1: Write the failing renderer tests for state rendering and action wiring**
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { createCalAgentPanel } from "../src/renderer/cal-agent-panel";
+import { createCalAgentController } from "../src/renderer/cal-agent-controller";
+
+describe("createCalAgentPanel", () => {
+  it("shows starting and error states without blocking the rest of the DOM", () => {
+    const panel = createCalAgentPanel();
+
+    panel.render({ status: "starting", url: "http://127.0.0.1:3000", message: "Starting CAL-AGENT…" });
+    expect(panel.element.textContent).toContain("Starting CAL-AGENT");
+
+    panel.render({ status: "error", url: "http://127.0.0.1:3000", message: "Timed out" });
+    expect(panel.element.textContent).toContain("Timed out");
+    expect(panel.element.querySelector("button[data-action='retry']")).not.toBeNull();
+  });
+
+  it("embeds the app with an iframe once ready", () => {
+    const panel = createCalAgentPanel();
+    panel.render({ status: "ready", url: "http://127.0.0.1:3000" });
+
+    const frame = panel.element.querySelector("iframe[data-cal-agent-frame]") as HTMLIFrameElement | null;
+    expect(frame?.src).toBe("http://127.0.0.1:3000/");
+  });
+});
+
+describe("createCalAgentController", () => {
+  it("loads current status, subscribes to updates, and forwards retry/open actions", async () => {
+    const panel = createCalAgentPanel();
+    const bridge = {
+      getStatus: vi.fn().mockResolvedValue({ status: "starting", url: "http://127.0.0.1:3000" }),
+      retry: vi.fn().mockResolvedValue({ status: "starting", url: "http://127.0.0.1:3000" }),
+      openExternal: vi.fn().mockResolvedValue(undefined),
+      onStatusChange: vi.fn((cb) => {
+        cb({ status: "ready", url: "http://127.0.0.1:3000" });
+        return () => undefined;
+      })
+    };
+
+    const controller = createCalAgentController({ panel, bridge: bridge as any });
+    await controller.boot();
+
+    expect(panel.element.textContent).toContain("Ready");
+
+    (panel.element.querySelector("button[data-action='retry']") as HTMLButtonElement).click();
+    (panel.element.querySelector("button[data-action='open-external']") as HTMLButtonElement).click();
+
+    expect(bridge.retry).toHaveBeenCalled();
+    expect(bridge.openExternal).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the renderer test to verify it fails**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-panel.test.ts`
+Expected: FAIL because the panel and controller modules do not exist yet.
+
+- [ ] **Step 3: Implement the panel, controller, and panel-specific styles**
+
+```ts
+// apps/electron-demo/src/renderer/cal-agent-panel.ts
+interface CalAgentPanel {
+  element: HTMLElement;
+  render(payload: CalAgentStatusPayload): void;
+  onRetry(cb: () => void): void;
+  onOpenExternal(cb: () => void): void;
+}
+
+export function createCalAgentPanel(): CalAgentPanel {
+  const panel = document.createElement("aside");
+  panel.className = "cal-agent-panel";
+
+  const header = document.createElement("div");
+  header.className = "cal-agent-panel__header";
+  header.innerHTML = `
+    <div class="cal-agent-panel__title">Calendar Agent</div>
+    <div class="cal-agent-panel__status" data-cal-agent-status>Idle</div>
+    <button type="button" data-action="retry">Retry</button>
+    <button type="button" data-action="open-external">Open in Browser</button>
+  `;
+
+  const body = document.createElement("div");
+  body.className = "cal-agent-panel__body";
+  panel.append(header, body);
+
+  return {
+    element: panel,
+    render(payload) {
+      const statusEl = header.querySelector("[data-cal-agent-status]") as HTMLElement;
+      statusEl.textContent = payload.status === "ready" ? "Ready" : payload.status;
+
+      if (payload.status === "ready") {
+        body.innerHTML = `<iframe data-cal-agent-frame src="${payload.url}" title="Calendar Agent"></iframe>`;
+        return;
+      }
+
+      body.innerHTML = `<div class="cal-agent-panel__message">${payload.message ?? "Waiting for CAL-AGENT…"}</div>`;
+    },
+    onRetry(cb) {
+      header.querySelector("[data-action='retry']")?.addEventListener("click", cb);
+    },
+    onOpenExternal(cb) {
+      header.querySelector("[data-action='open-external']")?.addEventListener("click", cb);
+    }
+  };
+}
+```
+
+```ts
+// apps/electron-demo/src/renderer/cal-agent-controller.ts
+export function createCalAgentController({ panel, bridge }: { panel: CalAgentPanel; bridge: CalAgentBridge }) {
+  let disposeStatus: (() => void) | null = null;
+
+  panel.onRetry(() => {
+    void bridge.retry();
+  });
+
+  panel.onOpenExternal(() => {
+    void bridge.openExternal();
+  });
+
+  return {
+    async boot() {
+      panel.render(await bridge.getStatus());
+      disposeStatus = bridge.onStatusChange((payload) => panel.render(payload));
+    },
+    destroy() {
+      disposeStatus?.();
+      disposeStatus = null;
+    }
+  };
+}
+```
+
+```css
+/* apps/electron-demo/src/renderer/style.css */
+.cal-agent-panel {
+  width: 320px;
+  flex-shrink: 0;
+  border-left: 1px solid #eee;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.cal-agent-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid #eee;
+}
+
+.cal-agent-panel__title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.cal-agent-panel__body {
+  flex: 1;
+  min-height: 0;
+}
+
+.cal-agent-panel__body iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+```
+
+- [ ] **Step 4: Run the renderer test to verify it passes**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-panel.test.ts`
+Expected: PASS with `starting`, `ready`, and `error` rendering plus `Retry` and `Open in Browser` action wiring covered.
+
+- [ ] **Step 5: Commit the renderer panel slice**
+
+```bash
+git add apps/electron-demo/src/renderer/cal-agent-panel.ts apps/electron-demo/src/renderer/cal-agent-controller.ts apps/electron-demo/src/renderer/style.css apps/electron-demo/test/cal-agent-panel.test.ts
+git commit -m "feat(electron-demo): add cal-agent renderer panel"
+```
+
+### Task 4: Register main-process IPC and lifecycle wiring
+
+**Purpose:** Connect the tested manager to Electron without turning `electron/main.ts` into a second monolith.
+
+**Files:**
+- Create: `apps/electron-demo/electron/cal-agent-main-ipc.ts`
+- Modify: `apps/electron-demo/electron/main.ts`
+- Test: `apps/electron-demo/test/cal-agent-main-ipc.test.ts`
+
+- [ ] **Step 1: Write the failing IPC wiring tests**
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { registerCalAgentMainIpc } from "../electron/cal-agent-main-ipc";
+
+describe("registerCalAgentMainIpc", () => {
+  it("registers start, retry, get-status, and open-external handlers", () => {
+    const handle = vi.fn();
+    const manager = {
+      start: vi.fn(),
+      retry: vi.fn(),
+      getStatus: vi.fn(),
+      subscribe: vi.fn(() => () => undefined)
+    };
+
+    registerCalAgentMainIpc({
+      ipcMain: { handle } as any,
+      shell: { openExternal: vi.fn() } as any,
+      manager,
+      getWindow: () => ({ webContents: { send: vi.fn() } }) as any
+    });
+
+    expect(handle).toHaveBeenCalledWith("cal-agent:start", expect.any(Function));
+    expect(handle).toHaveBeenCalledWith("cal-agent:retry", expect.any(Function));
+    expect(handle).toHaveBeenCalledWith("cal-agent:get-status", expect.any(Function));
+    expect(handle).toHaveBeenCalledWith("cal-agent:open-external", expect.any(Function));
+  });
+
+  it("opens the current CAL-AGENT URL in the external browser", async () => {
+    const handlers = new Map<string, Function>();
+    const shell = { openExternal: vi.fn().mockResolvedValue(undefined) };
+    const manager = {
+      start: vi.fn(),
+      retry: vi.fn(),
+      getStatus: vi.fn(() => ({ status: "ready", url: "http://127.0.0.1:3000" })),
+      subscribe: vi.fn(() => () => undefined)
+    };
+
+    registerCalAgentMainIpc({
+      ipcMain: { handle: (channel: string, fn: Function) => handlers.set(channel, fn) } as any,
+      shell: shell as any,
+      manager,
+      getWindow: () => null
+    });
+
+    await handlers.get("cal-agent:open-external")?.();
+    expect(shell.openExternal).toHaveBeenCalledWith("http://127.0.0.1:3000");
+  });
+});
+```
+
+- [ ] **Step 2: Run the IPC test to verify it fails**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-main-ipc.test.ts`
+Expected: FAIL because the IPC registration helper does not exist yet.
+
+- [ ] **Step 3: Implement IPC registration and wire it into `electron/main.ts`**
+
+```ts
+// apps/electron-demo/electron/cal-agent-main-ipc.ts
+import type { IpcMain, BrowserWindow, Shell } from "electron";
+import type { CalAgentManager } from "./cal-agent-types";
+
+export function registerCalAgentMainIpc({
+  ipcMain,
+  shell,
+  manager,
+  getWindow
+}: {
+  ipcMain: Pick<IpcMain, "handle">;
+  shell: Pick<Shell, "openExternal">;
+  manager: CalAgentManager;
+  getWindow: () => BrowserWindow | null;
+}) {
+  manager.subscribe((payload) => {
+    getWindow()?.webContents.send("cal-agent:status", payload);
+  });
+
+  ipcMain.handle("cal-agent:start", () => manager.start());
+  ipcMain.handle("cal-agent:retry", () => manager.retry());
+  ipcMain.handle("cal-agent:get-status", () => manager.getStatus());
+  ipcMain.handle("cal-agent:open-external", async () => {
+    await shell.openExternal(manager.getStatus().url);
+  });
+}
+```
+
+```ts
+// apps/electron-demo/electron/main.ts
+import { createCalAgentManager } from "./cal-agent-manager";
+import { registerCalAgentMainIpc } from "./cal-agent-main-ipc";
+
+let calAgentManager: ReturnType<typeof createCalAgentManager> | null = null;
+
+app.whenReady().then(() => {
+  calAgentManager = createCalAgentManager();
+  registerCalAgentMainIpc({
+    ipcMain,
+    shell,
+    manager: calAgentManager,
+    getWindow: () => mainWindow
+  });
+
+  createWindow();
+  void calAgentManager.start();
+});
+
+app.on("before-quit", () => {
+  calAgentManager?.dispose();
+});
+```
+
+- [ ] **Step 4: Run the IPC test to verify it passes**
+
+Run: `pnpm --dir apps/electron-demo test -- test/cal-agent-main-ipc.test.ts`
+Expected: PASS with handler registration and external-browser behavior covered.
+
+- [ ] **Step 5: Commit the main-process wiring slice**
+
+```bash
+git add apps/electron-demo/electron/cal-agent-main-ipc.ts apps/electron-demo/electron/main.ts apps/electron-demo/test/cal-agent-main-ipc.test.ts
+git commit -m "feat(electron-demo): wire cal-agent ipc in main process"
+```
+
+### Task 5: Mount the panel in the app shell and run the smoke checkpoints
+
+**Purpose:** Integrate the panel into the existing plain-DOM layout with the smallest possible renderer-surface change, then validate the real startup path before spending time on polish.
+
+**Files:**
+- Modify: `apps/electron-demo/src/renderer/app.ts`
+- Modify: `apps/electron-demo/src/renderer/style.css`
+- Reuse: `apps/electron-demo/src/renderer/cal-agent-panel.ts`
+- Reuse: `apps/electron-demo/src/renderer/cal-agent-controller.ts`
+
+- [ ] **Step 1: Mount the CAL-AGENT panel and toolbar toggle in `app.ts`**
+
+```ts
+// apps/electron-demo/src/renderer/app.ts
+import { createCalAgentPanel } from "./cal-agent-panel";
+import { createCalAgentController } from "./cal-agent-controller";
+
+let calAgentController: ReturnType<typeof createCalAgentController>;
+
+function toggleCalAgent(): void {
+  togglePanel(document.querySelector(".cal-agent-panel") as HTMLElement);
+}
+
+function createAppToolbar(): HTMLElement {
+  const toolbar = document.createElement("div");
+  toolbar.className = "toolbar";
+
+  const calAgentBtn = document.createElement("button");
+  calAgentBtn.textContent = "\uD83D\uDCC5";
+  calAgentBtn.title = "Toggle Calendar Agent panel";
+  calAgentBtn.addEventListener("click", toggleCalAgent);
+
+  toolbar.append(
+    vaultBtn,
+    openBtn,
+    saveBtn,
+    saveAsBtn,
+    spacer,
+    vaultToggleBtn,
+    outlineBtn,
+    backlinksBtn,
+    calAgentBtn,
+    searchBtn,
+    settingsBtn
+  );
+
+  return toolbar;
+}
+
+function boot(): void {
+  // existing setup omitted
+  const calAgentPanel = createCalAgentPanel();
+  calAgentController = createCalAgentController({
+    panel: calAgentPanel,
+    bridge: window.nexusDemo.calAgent
+  });
+
+  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element, calAgentPanel.element);
+
+  void calAgentController.boot();
+}
+```
+
+- [ ] **Step 2: Run a narrow build check before the first manual smoke**
+
+Run: `pnpm --dir apps/electron-demo build`
+Expected: PASS with Electron entrypoints, preload bridge, and renderer modules type-checking and bundling together.
+
+- [ ] **Step 3: Run the ready-path smoke test immediately after wiring**
+
+Run: `pnpm --dir apps/electron-demo dev`
+Expected: the Electron demo opens, the editor remains interactive during startup, the new right-side `Calendar Agent` panel shows `starting`, then switches to `ready`, and the embedded CAL-AGENT page appears in the panel.
+
+- [ ] **Step 4: Run the failure and retry smoke test before any extra polish**
+
+Run: close the Electron app, temporarily break the CAL-AGENT command in `apps/electron-demo/electron/cal-agent-config.ts`, restart `pnpm --dir apps/electron-demo dev`, confirm the panel shows `error`, click `Retry`, restore the correct command, and confirm the panel reaches `ready`.
+Expected: the editor remains usable in both failure and recovery paths, and `Retry` reuses the main-process manager instead of requiring a full Electron restart.
+
+- [ ] **Step 5: Run the external-browser and shutdown cleanup smoke test, then commit**
+
+Run: with the app in `ready`, click `Open in Browser`, confirm `http://127.0.0.1:3000` opens externally, then quit Electron and run `lsof -iTCP:3000 -sTCP:LISTEN`.
+Expected: the browser opens the same URL and the port is no longer owned by the CAL-AGENT child that Nexus launched.
+
+```bash
+git add apps/electron-demo/src/renderer/app.ts apps/electron-demo/src/renderer/style.css
+git commit -m "feat(electron-demo): mount cal-agent panel in app shell"
+```
+
+## Risk List And Mitigation Checkpoints
+
+- `iframe` embedding blocked by CAL-AGENT response headers or CSP.
+  Mitigation checkpoint: Task 5 Step 3 is the explicit go or no-go decision point. If the panel stays blank, shows frame-denial errors, or never fires a successful load while the URL works in the external browser, stop and switch to a `WebContentsView` fallback branch instead of polishing the `iframe` path.
+
+- Next.js dev startup is slow or flaky on first launch.
+  Mitigation checkpoint: keep the panel on `starting` with a finite timeout from `apps/electron-demo/electron/cal-agent-config.ts`; do not block renderer boot on startup completion.
+
+- Duplicate CAL-AGENT processes during repeated retries or app reloads.
+  Mitigation checkpoint: Task 1 tests lock duplicate-start suppression and Task 4 binds cleanup to `before-quit`; do not wire renderer-side spawning at any point.
+
+- Main-process changes accidentally destabilize the editor demo.
+  Mitigation checkpoint: after Task 4 and again after Task 5, run the existing Electron demo test suite and a manual edit-open-save smoke so vault browsing, outline, and backlinks still work.
+
+## Focused Validation Matrix
+
+- Automated: `pnpm --dir apps/electron-demo test -- test/cal-agent-manager.test.ts`
+- Automated: `pnpm --dir apps/electron-demo test -- test/cal-agent-preload.test.ts`
+- Automated: `pnpm --dir apps/electron-demo test -- test/cal-agent-panel.test.ts`
+- Automated: `pnpm --dir apps/electron-demo test -- test/cal-agent-main-ipc.test.ts`
+- Automated: `pnpm --dir apps/electron-demo build`
+- Manual: cold start to `ready`
+- Manual: forced failure to `error`
+- Manual: retry from `error` to `ready`
+- Manual: `Open in Browser`
+- Manual: quit app and confirm child cleanup
+- Manual: confirm editor still opens, edits, saves, and navigates vault files while CAL-AGENT is starting or failed
+
+## Fallback Branch If Embedding Is Blocked
+
+Do not start this branch unless Task 5 Step 3 proves `iframe` embedding is blocked.
+
+1. Replace renderer `iframe` embedding with a main-process-owned `WebContentsView` attached to the right side of the Electron window.
+2. Keep the same preload contract and renderer status UI so only the view-hosting layer changes.
+3. Add one focused smoke test: start the app, confirm CAL-AGENT appears in the right-side host region, and confirm hiding the panel detaches or obscures the view cleanly.
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-27-cal-agent-embedded-panel-poc.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using the `executing-plans` agent, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-27-cal-agent-embedded-panel-design.md
+++ b/docs/superpowers/specs/2026-05-27-cal-agent-embedded-panel-design.md
@@ -1,0 +1,251 @@
+# CAL-AGENT Embedded Panel Design
+
+**Date:** 2026-05-27
+
+**Scope:** `apps/electron-demo`
+
+## Context
+
+`Nexus-Editor` already has a working Electron demo with a desktop shell, a plain-DOM renderer, and multiple side panels around the editor surface. `CAL-AGENT` is a separate Node 20 monorepo with a Next.js web app that acts as a calendar-driven workbench and assistant.
+
+The immediate goal is not deep workflow integration. The goal is to embed the existing `CAL-AGENT` web UI into the Nexus Electron demo so the editor can host a right-side, always-available workbench panel. This should give the user continuous visibility into time-driven work without blocking editing workflows.
+
+The first iteration is a development-mode proof of concept. Nexus should launch the CAL-AGENT web app automatically, wait for it to become reachable, and render it inside a right-side panel. The editor and CAL-AGENT do not exchange business data in this phase.
+
+## Goals
+
+- Add a right-side persistent panel to the Electron demo for CAL-AGENT
+- Launch the CAL-AGENT web app automatically from Nexus on app startup
+- Use the existing CAL-AGENT web UI instead of rebuilding it in Nexus
+- Show clear panel states for startup, ready, and failure
+- Allow retrying launch after failure
+- Allow opening the embedded CAL-AGENT page in the system browser
+- Keep the editor usable even when CAL-AGENT is unavailable
+
+## Non-Goals
+
+- No editor-content sync into CAL-AGENT
+- No task creation, approval, or notification actions initiated from Nexus
+- No shared authentication or session bridge between the two apps
+- No packaging-grade process management in this phase
+- No rewrite of the CAL-AGENT UI into native Nexus renderer components
+- No attempt to normalize package management across the two repositories
+
+## Recommended Approach
+
+Use a host-managed embedding model:
+
+1. The Nexus Electron main process owns CAL-AGENT process lifecycle.
+2. The Nexus preload layer exposes a narrow process/status bridge.
+3. The Nexus renderer adds a right-side panel dedicated to CAL-AGENT.
+4. The panel embeds the running CAL-AGENT web app by URL.
+5. No business-level data exchange is enabled in phase 1.
+
+This keeps the two systems independent while still producing a coherent desktop experience.
+
+## Architecture
+
+The proof of concept is split into four modules.
+
+### 1. Electron main-process manager
+
+Located in `apps/electron-demo/electron/main.ts`.
+
+Responsibilities:
+
+- spawn the CAL-AGENT web app using `npm run web:dev`
+- set the working directory to `/Users/wangqiao/workspace/CAL-AGENT`
+- track child-process lifecycle and exit reasons
+- run URL health checks until the web app is reachable
+- expose IPC handlers for start, status, retry, and browser-open actions
+- kill the child process when Nexus exits
+
+The main process is the only place that may manage the child process. The renderer must not spawn or own the web server directly.
+
+### 2. Preload bridge
+
+Located in `apps/electron-demo/electron/preload.ts`.
+
+Responsibilities:
+
+- expose a minimal, desktop-safe API to renderer code
+- provide current panel/process status
+- allow the renderer to request retry/start actions
+- allow the renderer to open the target URL in the external browser
+- broadcast status changes from the main process to the renderer
+
+Suggested bridge shape:
+
+```ts
+type CalAgentPanelStatus = "idle" | "starting" | "ready" | "error";
+
+interface CalAgentStatusPayload {
+  status: CalAgentPanelStatus;
+  url: string;
+  message?: string;
+}
+
+interface CalAgentBridge {
+  start(): Promise<CalAgentStatusPayload>;
+  retry(): Promise<CalAgentStatusPayload>;
+  getStatus(): Promise<CalAgentStatusPayload>;
+  openExternal(): Promise<void>;
+  onStatusChange(cb: (payload: CalAgentStatusPayload) => void): () => void;
+}
+```
+
+### 3. Renderer panel
+
+Located near `apps/electron-demo/src/renderer/app.ts`, preferably as a dedicated panel module.
+
+Responsibilities:
+
+- render a persistent right-side panel
+- show the current connection state
+- embed the CAL-AGENT UI when ready
+- expose `Retry` and `Open in Browser` actions
+- allow the panel to be hidden without disabling the editor
+
+The panel should reuse the same layout philosophy already used by vault, outline, and backlinks side surfaces in the Electron demo.
+
+### 4. Health-check controller
+
+Implemented in the main process.
+
+Responsibilities:
+
+- poll the target URL after spawn
+- treat HTTP reachability as readiness
+- enforce a startup timeout window
+- update status to `ready` on success
+- update status to `error` on timeout or process exit
+
+For the proof of concept, a simple polling loop is sufficient.
+
+## Runtime Flow
+
+The proof-of-concept runtime flow is:
+
+1. User launches the Nexus Electron demo.
+2. The Electron main process initializes the CAL-AGENT panel controller.
+3. Nexus attempts to spawn the CAL-AGENT web app with `npm run web:dev`.
+4. The renderer shows the right-side panel in `starting` state.
+5. The main process polls the configured local URL until reachable.
+6. When reachable, the renderer switches the panel to `ready` and embeds the page.
+7. If startup fails, times out, or exits early, the panel switches to `error`.
+8. The user can click `Retry` to re-run the startup path.
+9. The user can click `Open in Browser` to open the same URL externally.
+10. When Nexus exits, it shuts down the child process it launched.
+
+## User Experience
+
+The CAL-AGENT panel should be intentionally simple.
+
+Required states:
+
+- `starting`: panel title and loading message
+- `ready`: embedded CAL-AGENT page visible
+- `error`: concise failure message plus `Retry`
+
+Required controls:
+
+- panel title, for example `Calendar Agent`
+- status indicator
+- `Retry` button
+- `Open in Browser` button
+- existing or new panel visibility toggle in the Nexus toolbar
+
+The editor must remain fully usable while the panel is starting, unavailable, or hidden.
+
+## Technical Constraints
+
+- Nexus uses `pnpm`; CAL-AGENT uses `npm`
+- Both projects currently run on Node `20.20.2`
+- CAL-AGENT `npm run gate` is not fully green today, but that does not block this proof of concept
+- The proof of concept depends only on `npm run web:dev` being launchable
+- The embedded page target for this proof of concept is the local development URL `http://127.0.0.1:3000`
+
+The process boundary is deliberate. It prevents bundling Prisma, Next.js, and CAL-AGENT workspace concerns into the Nexus renderer or Electron build pipeline.
+
+## Error Handling
+
+Error behavior should stay explicit and local to the panel.
+
+- Child-process spawn failure: panel enters `error` with a short actionable message
+- Startup timeout: panel enters `error` and offers retry
+- Early process exit: panel enters `error`
+- Embedded page unavailable after previous success: panel returns to `error`
+- Browser-open failure: keep panel state unchanged and surface a short message if practical
+
+The editor itself must not fail closed when the panel fails.
+
+## Testing Strategy
+
+The proof of concept should favor a narrow validation surface.
+
+### Manual validation
+
+Manually verify these flows:
+
+1. Cold start: Nexus launches, panel reaches `ready`
+2. Failure path: invalid command or unreachable URL leads to `error`
+3. Retry path: user can retry after failure
+4. Browser path: `Open in Browser` opens the same URL externally
+5. Exit path: closing Nexus cleans up the spawned CAL-AGENT process
+
+### Automated coverage
+
+Add focused tests only for the new Nexus-side logic:
+
+- process/status state transitions
+- timeout behavior
+- duplicate-start suppression
+- retry after failure
+
+No end-to-end automation is required in this phase.
+
+## Acceptance Criteria
+
+The proof of concept is complete when all of the following are true:
+
+1. Launching the Nexus Electron demo automatically attempts to start CAL-AGENT
+2. A persistent right-side panel exists for CAL-AGENT
+3. The panel visibly transitions through `starting`, `ready`, and `error` states as appropriate
+4. When CAL-AGENT becomes reachable, the panel embeds its existing web UI
+5. When startup fails, the user can retry from the panel
+6. The user can open the same CAL-AGENT page in the external browser
+7. Closing Nexus cleans up the CAL-AGENT child process started by Nexus
+8. CAL-AGENT failure does not break document open, edit, save, vault browsing, outline, or backlinks in the editor
+
+## Risks And Trade-offs
+
+- Embedding via `iframe` may be blocked by response headers or CSP.
+  Mitigation: treat Electron `BrowserView` or `WebContentsView` as the fallback if direct embedding is blocked.
+
+- Next.js development startup time may be slow on first run.
+  Mitigation: keep a visible `starting` state and a generous but finite timeout.
+
+- Child-process cleanup can be error-prone during development restarts.
+  Mitigation: centralize process ownership in the Electron main process and always bind cleanup to app exit.
+
+- The fixed local repository path is acceptable for the proof of concept but not portable.
+  Mitigation: keep the path in one configuration constant so a later settings-based override stays cheap.
+
+## Delivery Scope For The 2-Day POC
+
+In scope:
+
+- automatic `npm run web:dev` startup from Nexus
+- local health check and status updates
+- right-side embedded CAL-AGENT panel
+- retry action
+- external browser action
+- shutdown cleanup
+
+Out of scope:
+
+- deep editor-to-agent integration
+- shared data model or task synchronization
+- authentication/session bridging
+- packaged distribution support
+- production-grade resilience features

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "version": "0.0.4",
   "packageManager": "pnpm@9.15.4",
   "scripts": {
+    "dev": "pnpm demo",
     "build": "pnpm --filter @floatboat/nexus-core build && pnpm --filter @floatboat/nexus-react build && pnpm --filter @floatboat/nexus-vue build && pnpm --filter @floatboat/nexus-preset-gfm build && pnpm --filter @floatboat/nexus-plugin-slash build && pnpm --filter @floatboat/nexus-plugin-history build && pnpm --filter @floatboat/nexus-plugin-search build && pnpm --filter @floatboat/nexus-plugin-toolbar build && pnpm --filter @floatboat/nexus-plugin-math build && pnpm --filter @floatboat/nexus-plugin-vim build",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "test": "vitest run",
+    "demo": "pnpm dev:electron-demo",
     "dev:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo dev",
     "build:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo build",
     "publish:packages": "pnpm -r --filter \"./packages/*\" publish --access public --no-git-checks"


### PR DESCRIPTION
## Summary
- embed CAL-AGENT into the Electron demo as a right-side panel
- add one-command local startup and dynamic renderer dev URL detection
- manage CAL-AGENT child-process startup, readiness probing, and cleanup
- support panel toggle, browser fallback, and double-click maximize behavior

## Validation
- pnpm --filter @floatboat/nexus-electron-demo build
- pnpm --filter @floatboat/nexus-electron-demo test

## Notes
- this PR keeps the initial integration only
- probe-page debugging and height-investigation code are not included
- fullscreen/max-height UX is intentionally left unresolved for follow-up