### PR TITLE
feat(toolbar): multi-line formatting, list marker guard, inline HTML fix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,75 +13,78 @@ This document maps every planned feature to **package ownership / priority / sta
 
 ## 1. Toolbar / Text Editing
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 1 | Multi-line list toggle (ordered / unordered) | `plugin-toolbar` + `core` commands | P1 | planned | No | Extend existing list command to multi-line selection |
-| 12 | Advanced toolbar (emoji picker / table tools / color picker) | `plugin-toolbar` | P2 | planned | Yes | Introduces widgets — split into 3 sub-proposals |
+| #   | Feature                                                                                                                                                 | Package                            | Priority | Status  | Needs OpenSpec | Notes                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- | ------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Multi-line list toggle (ordered / unordered)                                                                                                            | `plugin-toolbar` + `core` commands | P1       | done    | No             | Implemented as part of the broader multi-line formatting work — see `openspec/changes/add-multi-line-formatting`                                             |
+| 28  | Multi-line formatting for all toolbar buttons (bold / italic / underline / strikethrough / inline-code / heading / blockquote / text-color / highlight) | `plugin-toolbar`                   | P1       | done    | Yes            | All toolbar buttons support cross-line selection; includes star-count algorithm and list marker exclusion — see `openspec/changes/add-multi-line-formatting` |
+| 12  | Advanced toolbar (emoji picker / table tools / color picker)                                                                                            | `plugin-toolbar`                   | P2       | planned | Yes            | Introduces widgets — split into 3 sub-proposals                                                                                                              |
 
 ## 2. Search / Commands
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 2  | Whole-word matching | `plugin-search` | P1 | planned | No | Extension of existing search options |
-| 15 | Regex search | `plugin-search` | P1 | in-progress | No | Watch escape edge cases — PR #9 in review |
-| 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | planned | Yes | Needs persistence (localStorage or host-injected) |
-| 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib |
-| 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
-| 27 | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0 | done | Yes | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui` |
+| #   | Feature                        | Package                          | Priority | Status      | Needs OpenSpec | Notes                                                                            |
+| --- | ------------------------------ | -------------------------------- | -------- | ----------- | -------------- | -------------------------------------------------------------------------------- |
+| 2   | Whole-word matching            | `plugin-search`                  | P1       | planned     | No             | Extension of existing search options                                             |
+| 15  | Regex search                   | `plugin-search`                  | P1       | in-progress | No             | Watch escape edge cases — PR #9 in review                                        |
+| 16  | Command / search history       | `plugin-search` + `plugin-slash` | P2       | planned     | Yes            | Needs persistence (localStorage or host-injected)                                |
+| 17  | Fuzzy search                   | `plugin-search`                  | P2       | planned     | No             | Evaluate fzf-like algorithm vs. third-party lib                                  |
+| 3   | Slash command sorting + limit  | `plugin-slash`                   | P0       | done        | Yes            | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
+| 27  | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0       | done        | Yes            | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui`  |
 
 ## 3. Core Editor
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 5 | `getSelectedText()` API | `core` | P0 | in-progress | No | Public API addition; needs types + tests — PR #8 in review |
-| 6 | Multi-cursor / multi-selection | `core` | P1 | planned | Yes | CM6 supports it; must verify live-preview and table interactions |
-| 7 | AST enhancement / Markdown extensions | `core` + `preset-gfm` | P2 | planned | Yes | Affects serialization and every AST-dependent plugin |
-| 8 | Undo / redo grouping | `plugin-history` | P1 | planned | No | Coordinate with table's `tableEditingCount` |
+| #   | Feature                               | Package               | Priority | Status      | Needs OpenSpec | Notes                                                            |
+| --- | ------------------------------------- | --------------------- | -------- | ----------- | -------------- | ---------------------------------------------------------------- |
+| 5   | `getSelectedText()` API               | `core`                | P0       | in-progress | No             | Public API addition; needs types + tests — PR #8 in review       |
+| 6   | Multi-cursor / multi-selection        | `core`                | P1       | planned     | Yes            | CM6 supports it; must verify live-preview and table interactions |
+| 7   | AST enhancement / Markdown extensions | `core` + `preset-gfm` | P2       | planned     | Yes            | Affects serialization and every AST-dependent plugin             |
+| 8   | Undo / redo grouping                  | `plugin-history`      | P1       | planned     | No             | Coordinate with table's `tableEditingCount`                      |
 
 ## 4. Plugin System
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 9  | Widget API standardization | `core` | P1 | planned | Yes | Existing widgets hit many pitfalls (see CLAUDE.md); spec first |
-| 10 | Plugin event bus | `core` | P2 | planned | Yes | Affects every existing `plugin-*` |
-| 11 | Plugin hot-reload | `core` | P3 | planned | Yes | Dev mode only; depends on #9 |
+| #   | Feature                    | Package | Priority | Status  | Needs OpenSpec | Notes                                                          |
+| --- | -------------------------- | ------- | -------- | ------- | -------------- | -------------------------------------------------------------- |
+| 9   | Widget API standardization | `core`  | P1       | planned | Yes            | Existing widgets hit many pitfalls (see CLAUDE.md); spec first |
+| 10  | Plugin event bus           | `core`  | P2       | planned | Yes            | Affects every existing `plugin-*`                              |
+| 11  | Plugin hot-reload          | `core`  | P3       | planned | Yes            | Dev mode only; depends on #9                                   |
 
 ## 5. UI / Preview / Keymap
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 13 | Markdown live preview sync scroll | `core` | P2 | planned | No | Only relevant in split-preview mode |
-| 14 | Custom keymap UI | `react` / `vue` + `core` | P2 | planned | Yes | Need to expose keymap register / query API first |
+| #   | Feature                                                                   | Package                  | Priority | Status  | Needs OpenSpec | Notes                                                                                                                                  |
+| --- | ------------------------------------------------------------------------- | ------------------------ | -------- | ------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 13  | Markdown live preview sync scroll                                         | `core`                   | P2       | planned | No             | Only relevant in split-preview mode                                                                                                    |
+| 29  | List marker unselectable (cursor guard + user-select:none)                | `core`                   | P1       | done    | Yes            | `Prec.highest` mousedown/mouseup guards + CSS `user-select:none` — see `openspec/changes/add-multi-line-formatting`                    |
+| 30  | Inline rendering of `<span>`/`<u>` tags inside list items (no line break) | `core`                   | P1       | done    | Yes            | Lezer `HTMLBlock` → `inline:true` → inline `<span>` widget instead of block `<div>` — see `openspec/changes/add-multi-line-formatting` |
+| 14  | Custom keymap UI                                                          | `react` / `vue` + `core` | P2       | planned | Yes            | Need to expose keymap register / query API first                                                                                       |
 
 ## 6. React / Vue SDK
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 4 | `<Editor />` container pass-through props + `onReady` callback | `react` (and `vue` in lockstep) | P0 | planned | No | Public API addition; semantics must match across bindings |
+| #   | Feature                                                        | Package                         | Priority | Status  | Needs OpenSpec | Notes                                                     |
+| --- | -------------------------------------------------------------- | ------------------------------- | -------- | ------- | -------------- | --------------------------------------------------------- |
+| 4   | `<Editor />` container pass-through props + `onReady` callback | `react` (and `vue` in lockstep) | P0       | planned | No             | Public API addition; semantics must match across bindings |
 
 ## 7. Collaboration
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 18 | Realtime collaboration (OT / CRDT) | new `plugin-collab` | P3 | planned | Yes | Large feature; start with a tech-selection design doc |
-| 19 | Version history / snapshots | `core` + host storage | P2 | planned | Yes | electron-demo lands the reference impl first |
-| 20 | Shared comments / @mention | new `plugin-annotation` | P3 | planned | Yes | Depends on #18 |
+| #   | Feature                            | Package                 | Priority | Status  | Needs OpenSpec | Notes                                                 |
+| --- | ---------------------------------- | ----------------------- | -------- | ------- | -------------- | ----------------------------------------------------- |
+| 18  | Realtime collaboration (OT / CRDT) | new `plugin-collab`     | P3       | planned | Yes            | Large feature; start with a tech-selection design doc |
+| 19  | Version history / snapshots        | `core` + host storage   | P2       | planned | Yes            | electron-demo lands the reference impl first          |
+| 20  | Shared comments / @mention         | new `plugin-annotation` | P3       | planned | Yes            | Depends on #18                                        |
 
 ## 8. Cross-platform
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 21 | Electron packaging optimization | `apps/electron-demo` | P1 | planned | No | Size, startup time, autoUpdater |
-| 22 | Web Component / iframe wrapper | new `wc` package | P2 | planned | Yes | Share core instance with React/Vue SDK |
-| 23 | Cloud storage interface | `core` storage adapter layer | P2 | planned | Yes | NoteVault interface with pluggable backends |
+| #   | Feature                         | Package                      | Priority | Status  | Needs OpenSpec | Notes                                       |
+| --- | ------------------------------- | ---------------------------- | -------- | ------- | -------------- | ------------------------------------------- |
+| 21  | Electron packaging optimization | `apps/electron-demo`         | P1       | planned | No             | Size, startup time, autoUpdater             |
+| 22  | Web Component / iframe wrapper  | new `wc` package             | P2       | planned | Yes            | Share core instance with React/Vue SDK      |
+| 23  | Cloud storage interface         | `core` storage adapter layer | P2       | planned | Yes            | NoteVault interface with pluggable backends |
 
 ## 9. Developer Experience
 
-| # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
-|---|---|---|---|---|---|---|
-| 24 | TypeScript type coverage | repo-wide | P0 | in-progress | No | Ongoing; new code enforces strict |
-| 25 | End-to-end testing | repo infra | P1 | planned | No | Candidate: Playwright against electron-demo |
-| 26 | CI/CD pipeline polish | `.github/workflows` | P1 | planned | No | Publish workflow exists; missing PR check / e2e gate |
+| #   | Feature                  | Package             | Priority | Status      | Needs OpenSpec | Notes                                                |
+| --- | ------------------------ | ------------------- | -------- | ----------- | -------------- | ---------------------------------------------------- |
+| 24  | TypeScript type coverage | repo-wide           | P0       | in-progress | No             | Ongoing; new code enforces strict                    |
+| 25  | End-to-end testing       | repo infra          | P1       | planned     | No             | Candidate: Playwright against electron-demo          |
+| 26  | CI/CD pipeline polish    | `.github/workflows` | P1       | planned     | No             | Publish workflow exists; missing PR check / e2e gate |
 
 ---
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -13,75 +13,78 @@
 
 ## 1. Toolbar / 文本处理
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 1 | 多行列表切换（ordered / unordered） | `plugin-toolbar` + `core` 命令 | P1 | planned | 否 | 复用 core 现有 list 命令，扩展到多行选区 |
-| 12 | 高级 toolbar（emoji picker / 表格工具 / 颜色选择） | `plugin-toolbar` | P2 | planned | 是 | 涉及新 widget，建议拆 3 个子提案 |
+| #   | 功能                                                                                                                      | 归属包                         | 优先级 | 状态    | 需要 OpenSpec | 备注                                                                                                               |
+| --- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ------ | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 1   | 多行列表切换（ordered / unordered）                                                                                       | `plugin-toolbar` + `core` 命令 | P1     | done    | 否            | 已作为多行选区格式化的一部分实现 —— 见 `openspec/changes/add-multi-line-formatting`                                |
+| 28  | 多行选区格式化（bold / italic / underline / strikethrough / inline-code / heading / blockquote / text-color / highlight） | `plugin-toolbar`               | P1     | done    | 是            | 全部 toolbar 按钮支持跨行选区；含 star-count 算法与列表标记排除 —— 见 `openspec/changes/add-multi-line-formatting` |
+| 12  | 高级 toolbar（emoji picker / 表格工具 / 颜色选择）                                                                        | `plugin-toolbar`               | P2     | planned | 是            | 涉及新 widget，建议拆 3 个子提案                                                                                   |
 
 ## 2. Search / 命令
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 2  | whole-word 匹配 | `plugin-search` | P1 | planned | 否 | 现有 search 选项扩展 |
-| 15 | 正则搜索 | `plugin-search` | P1 | in-progress | 否 | 注意转义边界用例 —— PR #9 review 中 |
-| 16 | 历史命令 / 搜索记忆 | `plugin-search` + `plugin-slash` | P2 | planned | 是 | 需要持久化层（localStorage 或宿主注入） |
-| 17 | 模糊搜索 | `plugin-search` | P2 | planned | 否 | 评估 fzf-like 算法 vs. 第三方 lib |
-| 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | done | 是 | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui` |
-| 27 | Slash 命令浮层菜单 UI | `plugin-slash` + `electron-demo` | P0 | done | 是 | `createSlashMenuUI(editor, options)` —— 见 `openspec/changes/add-slash-menu-ui` |
+| #   | 功能                   | 归属包                           | 优先级 | 状态        | 需要 OpenSpec | 备注                                                                            |
+| --- | ---------------------- | -------------------------------- | ------ | ----------- | ------------- | ------------------------------------------------------------------------------- |
+| 2   | whole-word 匹配        | `plugin-search`                  | P1     | planned     | 否            | 现有 search 选项扩展                                                            |
+| 15  | 正则搜索               | `plugin-search`                  | P1     | in-progress | 否            | 注意转义边界用例 —— PR #9 review 中                                             |
+| 16  | 历史命令 / 搜索记忆    | `plugin-search` + `plugin-slash` | P2     | planned     | 是            | 需要持久化层（localStorage 或宿主注入）                                         |
+| 17  | 模糊搜索               | `plugin-search`                  | P2     | planned     | 否            | 评估 fzf-like 算法 vs. 第三方 lib                                               |
+| 3   | Slash 命令排序与 limit | `plugin-slash`                   | P0     | done        | 是            | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui`               |
+| 27  | Slash 命令浮层菜单 UI  | `plugin-slash` + `electron-demo` | P0     | done        | 是            | `createSlashMenuUI(editor, options)` —— 见 `openspec/changes/add-slash-menu-ui` |
 
 ## 3. Core Editor
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 5 | `getSelectedText()` API | `core` | P0 | in-progress | 否 | 公共 API 增量，需补类型 + 测试 —— PR #8 review 中 |
-| 6 | 多光标 / 多选支持 | `core` | P1 | planned | 是 | CM6 已有底层，需在 live-preview 与表格交互中验证不破坏 |
-| 7 | AST 增强 / Markdown 扩展 | `core` + `preset-gfm` | P2 | planned | 是 | 影响序列化与所有依赖 AST 的插件 |
-| 8 | undo / redo 分组 | `plugin-history` | P1 | planned | 否 | 注意与表格交互的 `tableEditingCount` 协同 |
+| #   | 功能                     | 归属包                | 优先级 | 状态        | 需要 OpenSpec | 备注                                                   |
+| --- | ------------------------ | --------------------- | ------ | ----------- | ------------- | ------------------------------------------------------ |
+| 5   | `getSelectedText()` API  | `core`                | P0     | in-progress | 否            | 公共 API 增量，需补类型 + 测试 —— PR #8 review 中      |
+| 6   | 多光标 / 多选支持        | `core`                | P1     | planned     | 是            | CM6 已有底层，需在 live-preview 与表格交互中验证不破坏 |
+| 7   | AST 增强 / Markdown 扩展 | `core` + `preset-gfm` | P2     | planned     | 是            | 影响序列化与所有依赖 AST 的插件                        |
+| 8   | undo / redo 分组         | `plugin-history`      | P1     | planned     | 否            | 注意与表格交互的 `tableEditingCount` 协同              |
 
 ## 4. 插件系统
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 9  | Widget API 标准化 | `core` | P1 | planned | 是 | 现有 widget 已多次踩坑（见 CLAUDE.md），需先定 spec |
-| 10 | 插件事件总线 | `core` | P2 | planned | 是 | 影响所有现存 plugin-* |
-| 11 | 热加载插件 | `core` | P3 | planned | 是 | 仅 dev 模式，依赖 #9 完成 |
+| #   | 功能              | 归属包 | 优先级 | 状态    | 需要 OpenSpec | 备注                                                |
+| --- | ----------------- | ------ | ------ | ------- | ------------- | --------------------------------------------------- |
+| 9   | Widget API 标准化 | `core` | P1     | planned | 是            | 现有 widget 已多次踩坑（见 CLAUDE.md），需先定 spec |
+| 10  | 插件事件总线      | `core` | P2     | planned | 是            | 影响所有现存 plugin-\*                              |
+| 11  | 热加载插件        | `core` | P3     | planned | 是            | 仅 dev 模式，依赖 #9 完成                           |
 
 ## 5. UI / Preview / 快捷键
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 13 | Markdown live preview 同步滚动 | `core` | P2 | planned | 否 | 仅在分屏 preview 场景生效 |
-| 14 | 自定义快捷键界面 | `react` / `vue` + `core` | P2 | planned | 是 | 需要先暴露 keymap 注册 / 查询 API |
+| #   | 功能                                                | 归属包                   | 优先级 | 状态    | 需要 OpenSpec | 备注                                                                                                                    |
+| --- | --------------------------------------------------- | ------------------------ | ------ | ------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 13  | Markdown live preview 同步滚动                      | `core`                   | P2     | planned | 否            | 仅在分屏 preview 场景生效                                                                                               |
+| 29  | 列表标记禁止选区（cursor guard + user-select:none） | `core`                   | P1     | done    | 是            | `Prec.highest` mousedown/mouseup 守卫 + CSS `user-select:none` —— 见 `openspec/changes/add-multi-line-formatting`       |
+| 30  | 列表内 `<span>`/`<u>` 等标签内联渲染（不换行）      | `core`                   | P1     | done    | 是            | Lezer `HTMLBlock` → `inline:true` → `<span>` widget 代替块级 `<div>` —— 见 `openspec/changes/add-multi-line-formatting` |
+| 14  | 自定义快捷键界面                                    | `react` / `vue` + `core` | P2     | planned | 是            | 需要先暴露 keymap 注册 / 查询 API                                                                                       |
 
 ## 6. React / Vue SDK
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 4 | `<Editor />` 容器属性透传 + `onReady` 回调 | `react`（同步补 `vue`） | P0 | planned | 否 | 公共 API 增量，两端语义需一致 |
+| #   | 功能                                       | 归属包                  | 优先级 | 状态    | 需要 OpenSpec | 备注                          |
+| --- | ------------------------------------------ | ----------------------- | ------ | ------- | ------------- | ----------------------------- |
+| 4   | `<Editor />` 容器属性透传 + `onReady` 回调 | `react`（同步补 `vue`） | P0     | planned | 否            | 公共 API 增量，两端语义需一致 |
 
 ## 7. 协作
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 18 | 实时协作（OT / CRDT） | 新包 `plugin-collab` | P3 | planned | 是 | 大特性，先做技术选型 design doc |
-| 19 | 版本历史 / 快照 | `core` + 宿主存储 | P2 | planned | 是 | electron-demo 先落地参考实现 |
-| 20 | 共享注释 / @mention | 新包 `plugin-annotation` | P3 | planned | 是 | 依赖 #18 完成 |
+| #   | 功能                  | 归属包                   | 优先级 | 状态    | 需要 OpenSpec | 备注                            |
+| --- | --------------------- | ------------------------ | ------ | ------- | ------------- | ------------------------------- |
+| 18  | 实时协作（OT / CRDT） | 新包 `plugin-collab`     | P3     | planned | 是            | 大特性，先做技术选型 design doc |
+| 19  | 版本历史 / 快照       | `core` + 宿主存储        | P2     | planned | 是            | electron-demo 先落地参考实现    |
+| 20  | 共享注释 / @mention   | 新包 `plugin-annotation` | P3     | planned | 是            | 依赖 #18 完成                   |
 
 ## 8. 跨平台
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 21 | Electron 打包优化 | `apps/electron-demo` | P1 | planned | 否 | 关注体积、启动时长、autoUpdater |
-| 22 | Web Component / iframe 封装 | 新包 `wc` | P2 | planned | 是 | 与 React/Vue SDK 共享 core 实例 |
-| 23 | 云端存储接口 | `core`（storage 适配层） | P2 | planned | 是 | 抽象 NoteVault interface，多后端实现 |
+| #   | 功能                        | 归属包                   | 优先级 | 状态    | 需要 OpenSpec | 备注                                 |
+| --- | --------------------------- | ------------------------ | ------ | ------- | ------------- | ------------------------------------ |
+| 21  | Electron 打包优化           | `apps/electron-demo`     | P1     | planned | 否            | 关注体积、启动时长、autoUpdater      |
+| 22  | Web Component / iframe 封装 | 新包 `wc`                | P2     | planned | 是            | 与 React/Vue SDK 共享 core 实例      |
+| 23  | 云端存储接口                | `core`（storage 适配层） | P2     | planned | 是            | 抽象 NoteVault interface，多后端实现 |
 
 ## 9. 开发体验
 
-| # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
-|---|---|---|---|---|---|---|
-| 24 | TypeScript 类型覆盖 | 全仓库 | P0 | in-progress | 否 | 持续推进，新代码强制 strict |
-| 25 | End-to-End 测试 | 仓库基建 | P1 | planned | 否 | 候选：Playwright，跑 electron-demo |
-| 26 | CI/CD 流程完善 | `.github/workflows` | P1 | planned | 否 | 已有 publish workflow，缺 PR check / e2e gate |
+| #   | 功能                | 归属包              | 优先级 | 状态        | 需要 OpenSpec | 备注                                          |
+| --- | ------------------- | ------------------- | ------ | ----------- | ------------- | --------------------------------------------- |
+| 24  | TypeScript 类型覆盖 | 全仓库              | P0     | in-progress | 否            | 持续推进，新代码强制 strict                   |
+| 25  | End-to-End 测试     | 仓库基建            | P1     | planned     | 否            | 候选：Playwright，跑 electron-demo            |
+| 26  | CI/CD 流程完善      | `.github/workflows` | P1     | planned     | 否            | 已有 publish workflow，缺 PR check / e2e gate |
 
 ---
 

--- a/openspec/changes/add-multi-line-formatting/design.md
+++ b/openspec/changes/add-multi-line-formatting/design.md
@@ -1,0 +1,72 @@
+# Design: Multi-line formatting support
+
+## Context
+
+The formatting toolbar performs text manipulation by inserting/removing markdown markers. Previously this operated on single-line selections only. Multi-line selection requires:
+
+1. Expanding the selection to full line boundaries
+2. Separating list prefixes (`1. `, `- `, `* `, `> `) from content
+3. Applying marker toggle per-line with boundary rebalancing
+4. Preventing list markers from being selected
+
+## Goals / Non-Goals
+
+- **Goals**:
+  - All formatting buttons work on multi-line selections
+  - List markers are never included in the formatted range
+  - Star-count algorithm handles asymmetric `*`/`**` markers across lines
+  - Inline HTML (`<span>`, `<u>`) renders inline in list items
+  - Cursor cannot land on list markers; multi-line selections exclude markers
+- **Non-Goals**:
+  - Cross-paragraph formatting (each paragraph is independent)
+  - Nested list renumbering after reorder
+  - Keyboard-only selection guard (mouse-based only)
+
+## Decisions
+
+### Decision: Extract line content before formatting
+
+`extractLineContent(line)` splits a line into `{ prefix, content }` where prefix is the list marker (`- `, `1. `, `* `, `> `) and content is the rest. Formatting operates on content only, and the prefix is reattached afterward.
+
+**Alternatives considered**:
+
+- Regex matching per marker type — more code, harder to maintain
+- AST-based approach — slower, depends on parser
+
+### Decision: Star-count algorithm for `*`/`**`
+
+When toggling bold/italic on multi-line, the algorithm:
+
+1. For each selected line, counts inside-stars (after content start) and outside-stars (before content start)
+2. Computes target = 1 or 2 based on whether user wants bold or italic toggle
+3. For lines where inside-stars differ from target, replaces the marker
+4. For partial boundary lines, rebalances: if the adjacent content starts with the marker, treat it as a closing marker (remove), otherwise as opening marker (keep/add)
+
+**Rationale**: Handles asymmetric markers (e.g., `**text*` → toggle bold → `*text*` or `***text*`) correctly by counting from both ends.
+
+### Decision: `applyInlineHtml` unified helper
+
+Color and highlight tags share identical logic: find opening/closing tag pairs, determine if content is wrapped, toggle. The helper takes tag regex patterns and generates the toggle logic. This avoids duplicating the multi-line loop + list-marker-exclusion logic.
+
+### Decision: `inline: true` flag on Html nodes
+
+Rather than changing the Lezer parser or creating a new AST node type, the `adaptListItem` function in `lezer-mdast-adapter.ts` detects single-line `HTMLBlock` children (no `\n` in source) and sets an `inline: true` property on the resulting `Html` node. `buildHtmlDecorations` checks this flag and uses an inline `<span>` with `Decoration.replace` (no `block: true`) instead of the default `<div class="nexus-html-block">` block widget.
+
+**Alternatives considered**:
+
+- Modify `adaptParagraph` to not promote `HTMLTag`-containing paragraphs — would break standalone HTML blocks
+- Use CSS `display: inline` on block widgets — doesn't work with CM6's block widget heightmap
+
+### Decision: `Prec.highest` event handlers for list marker guard
+
+`Prec.highest` ensures the list marker guard handlers run before CM6's own mouse event processing. Two handlers:
+
+- `mousedown`: if click position is within a marker range, `preventDefault()` + dispatch cursor to `markerEnd`
+- `mouseup`: if a non-empty selection has anchor/head in marker ranges, correct them to `markerEnd` via `requestAnimationFrame` dispatch
+
+**Rationale**: Must run before CM6 to prevent its click → cursor logic from placing the cursor inside a marker range. The `requestAnimationFrame` in mouseup avoids interfering with CM6's selection finalization.
+
+## Risks / Trade-offs
+
+- **Module-level `listMarkerRanges` mutable state**: Persists across decoration rebuilds, initialized to `[]` at `buildDecorations` start. Risk: if `buildDecorations` throws mid-execution, stale ranges could affect next mouse event. Mitigation: reset at function entry; array is scoped to the decoration build cycle.
+- **`inline: true` is a non-standard property**: The `Html` mdast type doesn't declare `inline`. Downstream consumers that do `JSON.parse(JSON.stringify(ast))` won't see it. Mitigation: only used internally by `buildHtmlDecorations`; serialization-safe.

--- a/openspec/changes/add-multi-line-formatting/proposal.md
+++ b/openspec/changes/add-multi-line-formatting/proposal.md
@@ -1,0 +1,48 @@
+# Change: Add multi-line selection support for all formatting toolbar buttons
+
+## Why
+
+The formatting toolbar (bold, italic, underline, strikethrough, inline code, heading, blockquote, text color, highlight) previously only worked on single-line selections. Selecting text across multiple lines and clicking a formatting button would either fail silently or produce incorrect results (e.g., applying markers only to the cursor line, wrapping list markers instead of content). This blocked common workflows like formatting entire paragraphs or multi-line text ranges.
+
+Additionally, inline HTML tags (`<span style="color:...">`, `<u>`) inside list items caused visual line breaks in live preview because the Lezer parser classifies them as block-level `HTMLBlock` nodes, which were rendered via `display:block` widgets.
+
+Finally, list markers (`1. `, `- `, `* `) were selectable — users could place the cursor on the marker or include markers in multi-line selections, leading to unintended formatting results.
+
+## What Changes
+
+### Multi-line formatting support
+- **Bold** (`**`): star-count algorithm computes toggle target from asymmetric star markers across lines
+- **Italic** (`*`): same star-count algorithm, rebalances markers at selection boundaries
+- **Underline** (`<u>`/`</u>`): wraps/unwraps each selected line, excluding list prefixes
+- **Strikethrough** (`~~`): wraps/unwraps each selected line, handles partial selections
+- **Inline code** (`` ` ``): wraps/unwraps each selected line, handles partial selections
+- **Heading** (`##`): toggles H2 prefix on each selected line
+- **Blockquote** (`>`): toggles quote prefix on each selected line, handles empty quote exit
+- **Ordered/Unordered list**: toggles list markers on each selected line
+- **Text color** (`<span style="color:...">`): applies/removes color spans per line, excluding list markers
+- **Highlight** (`<mark>`): applies/removes highlight tags per line, excluding list markers
+
+### Live preview fixes
+- **Inline HTML in list items**: `<span>` and `<u>` nodes marked with `inline: true` in the mdast adapter; `buildHtmlDecorations` uses inline `<span>` widgets instead of block-level `<div>` wrappers
+- **List marker guard**: `Prec.highest` mousedown handler prevents cursor from landing on list markers; mouseup handler corrects multi-line selections that include marker ranges; bullet widgets have `user-select: none`
+
+### New helpers
+- `extractLineContent`: separates list prefix (`1. `, `- `, `* `, `> `) from content text
+- `getSelectionLineRange`: expands a selection to full line boundaries
+- `applyInlineHtml`: unified multi-line logic for color and highlight tag toggles
+- `stripAllMarkers`: strips all formatting markers from a line (vs `unwrapLine` for single marker)
+
+## Impact
+
+- Affected specs: `live-preview`, `plugins` (toolbar)
+- Affected code:
+  - `packages/plugin-toolbar/src/index.ts` — `toggleWrap` multi-line, `toggleUnderline`, `toggleHeading`, `toggleStrikethrough`, `toggleInlineCode`
+  - `packages/plugin-toolbar/src/formatting.ts` — `toggleBlockquote`, `applyTextColor`, `applyHighlight`, `applyInlineHtml`, `extractLineContent`, `getSelectionLineRange`
+  - `packages/plugin-toolbar/src/toolbar-ui.ts` — underline button uses `toggleUnderline`
+  - `packages/core/src/lezer-mdast-adapter.ts` — inline HTML detection in `adaptListItem`
+  - `packages/core/src/live-preview.ts` — inline HTML widget rendering, list marker guard
+  - `packages/plugin-toolbar/test/plugin-toolbar.test.ts` — 83 tests
+  - `packages/core/test/live-preview.test.ts` — 49 tests
+  - `packages/core/test/live-preview-ranges.test.ts` — 4 tests
+- **No breaking changes** to existing API
+- **136 tests passing** across all affected test suites

--- a/openspec/changes/add-multi-line-formatting/specs/live-preview/spec.md
+++ b/openspec/changes/add-multi-line-formatting/specs/live-preview/spec.md
@@ -1,0 +1,48 @@
+# Live Preview Spec Delta
+
+## ADDED Requirements
+
+### Requirement: render inline HTML tags in list items without line breaks
+
+Inline HTML tags (`<span>`, `<u>`) that appear inside list items SHALL be rendered as inline elements (not block-level widgets), preserving the list structure without visual line breaks.
+
+#### Scenario: Span with color in ordered list
+- **WHEN** document contains `1. <span style='color:red'>text</span> more`
+- **AND** cursor is outside the HTML range
+- **THEN** the span SHALL render inline with red text
+- **AND** NO `nexus-html-block` wrapper SHALL be present
+- **AND** the list bullet `1.` SHALL still be visible
+
+#### Scenario: Underline in unordered list
+- **WHEN** document contains `- <u>under</u> line`
+- **AND** cursor is outside the HTML range
+- **THEN** the `<u>` tag SHALL render as underlined text inline
+- **AND** the list bullet SHALL still be visible
+
+#### Scenario: Cursor enters inline HTML in list item
+- **WHEN** cursor moves into an inline HTML range inside a list item
+- **THEN** the raw HTML source SHALL be shown for editing
+- **AND** the list bullet SHALL remain visible
+
+#### Scenario: Click rendered inline HTML to edit
+- **WHEN** user clicks on a rendered inline HTML element in a list item
+- **THEN** the cursor SHALL move to the start of the HTML source range
+- **AND** the raw source SHALL be revealed for editing
+
+### Requirement: prevent list markers from being selectable
+
+List markers (`1. `, `- `, `* `) in live preview SHALL be rendered with `user-select: none` and SHALL NOT accept cursor placement or text selection.
+
+#### Scenario: Bullet widget has user-select:none
+- **WHEN** an unordered list is rendered in live preview
+- **THEN** bullet span elements SHALL have `user-select: none`
+
+#### Scenario: Cursor cannot land on list marker on click
+- **WHEN** user clicks on a list marker position in live preview
+- **THEN** the cursor SHALL be placed at the start of the content text (after the marker)
+- **AND** the marker text SHALL NOT be editable
+
+#### Scenario: Multi-line selection excludes list markers
+- **WHEN** user drag-selects across multiple list items
+- **THEN** the selection range SHALL exclude list marker positions
+- **AND** marker text SHALL NOT appear in the selection

--- a/openspec/changes/add-multi-line-formatting/specs/plugins/spec.md
+++ b/openspec/changes/add-multi-line-formatting/specs/plugins/spec.md
@@ -1,0 +1,64 @@
+# Plugins Spec Delta
+
+## ADDED Requirements
+
+### Requirement: support multi-line selection for all formatting toolbar buttons
+
+All formatting toolbar buttons (bold, italic, underline, strikethrough, inline code, heading, blockquote, ordered list, unordered list, text color, highlight) SHALL correctly format text selected across multiple lines.
+
+#### Scenario: Bold multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks bold
+- **THEN** `**` markers SHALL be toggled on each selected line's content
+- **AND** asymmetric star markers (e.g., `**text*`) SHALL be corrected to a consistent count
+
+#### Scenario: Italic multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks italic
+- **THEN** `*` markers SHALL be toggled on each selected line's content
+
+#### Scenario: Underline multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks underline
+- **THEN** `<u>`/`</u>` tags SHALL be toggled on each selected line
+- **AND** list markers (`- `, `1. `) SHALL NOT be wrapped in `<u>` tags
+
+#### Scenario: Strikethrough multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks strikethrough
+- **THEN** `~~` markers SHALL be toggled on each selected line's content
+
+#### Scenario: Inline code multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks inline code
+- **THEN** `` ` `` markers SHALL be toggled on each selected line's content
+
+#### Scenario: Heading multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks heading
+- **THEN** `## ` prefix SHALL be toggled on each selected line
+
+#### Scenario: Blockquote multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks blockquote
+- **THEN** `> ` prefix SHALL be toggled on each selected line
+
+#### Scenario: Ordered list multi-line selection
+- **WHEN** user selects text spanning multiple lines and clicks ordered list
+- **THEN** `1. ` prefix SHALL be toggled on each selected line
+
+#### Scenario: Text color multi-line selection
+- **WHEN** user selects text spanning multiple lines and applies a text color
+- **THEN** `<span style="color:...">` tags SHALL be applied to each selected line's content
+- **AND** list markers SHALL NOT be wrapped in color spans
+
+#### Scenario: Highlight multi-line selection
+- **WHEN** user selects text spanning multiple lines and applies highlight
+- **THEN** `<mark>` tags SHALL be applied to each selected line's content
+- **AND** list markers SHALL NOT be wrapped in `<mark>` tags
+
+### Requirement: partial selection across lines
+
+When a selection covers only part of a line (not the full line), the formatting SHALL be applied to the entire line content, excluding list markers.
+
+#### Scenario: Partial selection of a multi-line range
+- **WHEN** user selects from the middle of line 1 to the middle of line 3 and clicks bold
+- **THEN** the full content of all three lines SHALL receive `**` toggling
+- **AND** list markers on any of those lines SHALL NOT be affected
+
+#### Scenario: Partial selection with strikethrough
+- **WHEN** user selects from middle of a line containing `~~text~~` to middle of the next line and clicks strikethrough
+- **THEN** `~~` SHALL be toggled correctly (unwrap the first line, wrap the second)

--- a/openspec/changes/add-multi-line-formatting/tasks.md
+++ b/openspec/changes/add-multi-line-formatting/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Add multi-line selection support
+
+## Phase 1: Core multi-line formatting
+
+- [x] 1.1 Implement `extractLineContent` and `getSelectionLineRange` helpers in `formatting.ts`
+- [x] 1.2 Multi-line bold/italic with star-count algorithm in `toggleWrap` (index.ts)
+- [x] 1.3 Multi-line underline (`toggleUnderline`) in index.ts
+- [x] 1.4 Multi-line strikethrough in `toggleStrikethrough` (index.ts)
+- [x] 1.5 Multi-line inline code in `toggleInlineCode` (index.ts)
+- [x] 1.6 Multi-line heading (H2) in `toggleHeading` (index.ts)
+- [x] 1.7 Multi-line blockquote in `toggleBlockquote` (formatting.ts)
+- [x] 1.8 Multi-line ordered/unordered list in `toggleOrderedList`/`toggleUnorderedList` (formatting.ts)
+
+## Phase 2: Color and highlight multi-line
+
+- [x] 2.1 Implement `applyInlineHtml` unified helper in formatting.ts
+- [x] 2.2 Multi-line text color (`applyTextColor`) delegating to `applyInlineHtml`
+- [x] 2.3 Multi-line highlight (`applyHighlight`) delegating to `applyInlineHtml`
+- [x] 2.4 List marker exclusion for color/highlight via `extractLineContent`
+
+## Phase 3: Live preview fixes
+
+- [x] 3.1 Mark single-line `HTMLBlock` in list items with `inline: true` in `lezer-mdast-adapter.ts`
+- [x] 3.2 Add inline HTML rendering path in `buildHtmlDecorations` (live-preview.ts)
+- [x] 3.3 Collect list marker ranges in `buildListDecorations`
+- [x] 3.4 Add `user-select: none` on bullet widgets
+- [x] 3.5 Add `Prec.highest` mousedown guard to prevent cursor on list markers
+- [x] 3.6 Add mouseup guard to correct multi-line selections including markers
+
+## Phase 4: Testing
+
+- [x] 4.1 83 toolbar tests covering all multi-line scenarios
+- [x] 4.2 Live preview tests for inline HTML in list items (no line break)
+- [x] 4.3 Live preview tests for list marker unselectable (user-select:none, cursor guard)
+- [x] 4.4 AST adapter test for inline HTML flag in list items

--- a/packages/core/src/lezer-mdast-adapter.ts
+++ b/packages/core/src/lezer-mdast-adapter.ts
@@ -46,7 +46,10 @@ import { findChildByName, headingDepth } from "./lezer-helpers";
 // `position` info so collectLivePreviewRanges can read offsets.
 
 interface PositionedNode {
-  position: { start: { line: number; column: number; offset: number }; end: { line: number; column: number; offset: number } };
+  position: {
+    start: { line: number; column: number; offset: number };
+    end: { line: number; column: number; offset: number };
+  };
 }
 
 function position(from: number, to: number): PositionedNode["position"] {
@@ -90,7 +93,10 @@ function readSlice(source: Source, from: number, to: number): string {
  * an ATX heading source so the synthesized text node matches what remark
  * emits for `## title`.
  */
-function headingTextRange(source: Source, node: SyntaxNode): { from: number; to: number } {
+function headingTextRange(
+  source: Source,
+  node: SyntaxNode,
+): { from: number; to: number } {
   // Skip past the opening HeaderMark child(ren) (the `##`).
   let cursor = node.from;
   let openingEnd = node.from;
@@ -101,7 +107,8 @@ function headingTextRange(source: Source, node: SyntaxNode): { from: number; to:
     child = child.nextSibling;
   }
   // Trim leading whitespace.
-  while (cursor < node.to && /\s/.test(source.slice(cursor, cursor + 1))) cursor++;
+  while (cursor < node.to && /\s/.test(source.slice(cursor, cursor + 1)))
+    cursor++;
 
   // Trim trailing closing `#` markers — but only if they are SEPARATE from
   // the opening run (i.e. start past `openingEnd`). Without this guard a
@@ -110,7 +117,11 @@ function headingTextRange(source: Source, node: SyntaxNode): { from: number; to:
   // range to nothing.
   let end = node.to;
   let trailing = node.lastChild;
-  while (trailing && trailing.name === "HeaderMark" && trailing.from >= openingEnd) {
+  while (
+    trailing &&
+    trailing.name === "HeaderMark" &&
+    trailing.from >= openingEnd
+  ) {
     end = trailing.from;
     trailing = trailing.prevSibling;
   }
@@ -119,7 +130,8 @@ function headingTextRange(source: Source, node: SyntaxNode): { from: number; to:
 }
 
 function emitText(source: Source, from: number, to: number): Text {
-  if (to <= from) return { type: "text", value: "", position: position(from, from) };
+  if (to <= from)
+    return { type: "text", value: "", position: position(from, from) };
   return {
     type: "text",
     value: readSlice(source, from, to),
@@ -156,14 +168,18 @@ function trimTableCellRange(
   line: string,
   lineFrom: number,
   start: number,
-  end: number
+  end: number,
 ): { from: number; to: number } {
   while (start < end && /[ \t]/.test(line[start])) start++;
   while (end > start && /[ \t]/.test(line[end - 1])) end--;
   return { from: lineFrom + start, to: lineFrom + end };
 }
 
-function tableCellContentRanges(source: Source, from: number, to: number): Array<{ from: number; to: number }> {
+function tableCellContentRanges(
+  source: Source,
+  from: number,
+  to: number,
+): Array<{ from: number; to: number }> {
   const line = readSlice(source, from, to);
   const pipes: number[] = [];
 
@@ -207,7 +223,10 @@ function adaptTableRowCells(source: Source, row: SyntaxNode): TableCell[] {
 
   const used = new Set<SyntaxNode>();
   return ranges.map((range) => {
-    const syntaxCell = syntaxCells.find((cell) => !used.has(cell) && cell.from >= range.from && cell.to <= range.to);
+    const syntaxCell = syntaxCells.find(
+      (cell) =>
+        !used.has(cell) && cell.from >= range.from && cell.to <= range.to,
+    );
     if (syntaxCell) {
       used.add(syntaxCell);
       return {
@@ -235,6 +254,7 @@ function adaptTableRowCells(source: Source, row: SyntaxNode): TableCell[] {
 // appear as a standalone top-level node for GFM autolink literals.)
 const MARKER_NODE_NAMES = new Set([
   "EmphasisMark",
+  "StrikethroughMark",
   "CodeMark",
   "LinkMark",
   "ListMark",
@@ -247,7 +267,10 @@ const MARKER_NODE_NAMES = new Set([
 ]);
 
 /** Inline-only adapter — delimiter marks and structural wrappers are skipped. */
-function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | null {
+function adaptInlineNode(
+  source: Source,
+  node: SyntaxNode,
+): PhrasingContent | null {
   const name = node.name;
   if (MARKER_NODE_NAMES.has(name)) return null;
   switch (name) {
@@ -313,7 +336,9 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
       // Lezer Link: contains LinkMark `[`, label content, LinkMark `]`,
       // optional `(URL "title")`. We pull URL via child name.
       const url = findChildByName(node, "URL");
-      const urlText = url ? readSlice(source, url.from, url.to) : readSlice(source, node.from, node.to).replace(/^<|>$/g, "");
+      const urlText = url
+        ? readSlice(source, url.from, url.to)
+        : readSlice(source, node.from, node.to).replace(/^<|>$/g, "");
       // Walk children between the first `[` and the matching `]` and
       // recursively adapt nested inline nodes (Image, StrongEmphasis,
       // Emphasis, InlineCode, etc.) so things like
@@ -329,7 +354,10 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
           if (c.name !== "LinkMark") continue;
           seen++;
           if (seen === 1) labelStartMark = c;
-          else if (seen === 2) { labelEndMark = c; break; }
+          else if (seen === 2) {
+            labelEndMark = c;
+            break;
+          }
         }
         if (!labelStartMark || !labelEndMark) {
           // Autolink / bare URL — no `[]`, the whole node is the label.
@@ -339,7 +367,11 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
         const labelEnd = labelEndMark.from;
         const out: PhrasingContent[] = [];
         let cursor = labelFrom;
-        for (let c = labelStartMark.nextSibling; c && c !== labelEndMark; c = c.nextSibling) {
+        for (
+          let c = labelStartMark.nextSibling;
+          c && c !== labelEndMark;
+          c = c.nextSibling
+        ) {
           if (c.from >= labelEnd) break;
           if (c.from > cursor) out.push(emitText(source, cursor, c.from));
           const adapted = adaptInlineNode(source, c);
@@ -371,7 +403,10 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
         for (let c = node.firstChild; c; c = c.nextSibling) {
           if (c.name === "LinkMark") {
             seen++;
-            if (seen === 2) { altTo = c.from; break; }
+            if (seen === 2) {
+              altTo = c.from;
+              break;
+            }
           }
         }
         alt = readSlice(source, altFrom, altTo);
@@ -435,7 +470,15 @@ function adaptListItem(source: Source, node: SyntaxNode): ListItem {
       continue;
     }
     const block = adaptBlockChild(source, c);
-    if (block) children.push(block);
+    if (block) {
+      if (block.type === "html") {
+        const src = readSlice(source, c.from, c.to);
+        if (!src.includes("\n")) {
+          (block as unknown as Record<string, unknown>).inline = true;
+        }
+      }
+      children.push(block);
+    }
   }
   return {
     type: "listItem",
@@ -465,7 +508,7 @@ function adaptList(source: Source, node: SyntaxNode, ordered: boolean): List {
   return {
     type: "list",
     ordered,
-    start: ordered ? start ?? 1 : null,
+    start: ordered ? (start ?? 1) : null,
     spread: false,
     children: items,
     position: position(node.from, node.to),
@@ -543,7 +586,8 @@ function adaptHeading(source: Source, node: SyntaxNode): Heading {
 //   :::type [optional title]
 //   body line(s) without blank lines
 //   :::
-const CALLOUT_FENCE_RE = /^:::([a-zA-Z]+)(?:[ \t]+(.+?))?\r?\n([\s\S]*?)\r?\n:::\s*$/;
+const CALLOUT_FENCE_RE =
+  /^:::([a-zA-Z]+)(?:[ \t]+(.+?))?\r?\n([\s\S]*?)\r?\n:::\s*$/;
 
 interface CalloutPalette {
   border: string;
@@ -554,14 +598,62 @@ interface CalloutPalette {
 }
 
 const CALLOUT_PALETTE: Record<string, CalloutPalette> = {
-  info: { border: "#0969da", bg: "rgba(9,105,218,0.08)", color: "#0969da", icon: "ℹ", defaultLabel: "INFO" },
-  note: { border: "#0969da", bg: "rgba(9,105,218,0.08)", color: "#0969da", icon: "ℹ", defaultLabel: "NOTE" },
-  tip: { border: "#1a7f37", bg: "rgba(26,127,55,0.08)", color: "#1a7f37", icon: "💡", defaultLabel: "TIP" },
-  success: { border: "#1a7f37", bg: "rgba(26,127,55,0.08)", color: "#1a7f37", icon: "✓", defaultLabel: "SUCCESS" },
-  important: { border: "#8250df", bg: "rgba(130,80,223,0.08)", color: "#8250df", icon: "❗", defaultLabel: "IMPORTANT" },
-  warning: { border: "#9a6700", bg: "rgba(154,103,0,0.08)", color: "#9a6700", icon: "⚠", defaultLabel: "WARNING" },
-  caution: { border: "#cf222e", bg: "rgba(207,34,46,0.08)", color: "#cf222e", icon: "🚫", defaultLabel: "CAUTION" },
-  danger: { border: "#cf222e", bg: "rgba(207,34,46,0.08)", color: "#cf222e", icon: "🚫", defaultLabel: "DANGER" },
+  info: {
+    border: "#0969da",
+    bg: "rgba(9,105,218,0.08)",
+    color: "#0969da",
+    icon: "ℹ",
+    defaultLabel: "INFO",
+  },
+  note: {
+    border: "#0969da",
+    bg: "rgba(9,105,218,0.08)",
+    color: "#0969da",
+    icon: "ℹ",
+    defaultLabel: "NOTE",
+  },
+  tip: {
+    border: "#1a7f37",
+    bg: "rgba(26,127,55,0.08)",
+    color: "#1a7f37",
+    icon: "💡",
+    defaultLabel: "TIP",
+  },
+  success: {
+    border: "#1a7f37",
+    bg: "rgba(26,127,55,0.08)",
+    color: "#1a7f37",
+    icon: "✓",
+    defaultLabel: "SUCCESS",
+  },
+  important: {
+    border: "#8250df",
+    bg: "rgba(130,80,223,0.08)",
+    color: "#8250df",
+    icon: "❗",
+    defaultLabel: "IMPORTANT",
+  },
+  warning: {
+    border: "#9a6700",
+    bg: "rgba(154,103,0,0.08)",
+    color: "#9a6700",
+    icon: "⚠",
+    defaultLabel: "WARNING",
+  },
+  caution: {
+    border: "#cf222e",
+    bg: "rgba(207,34,46,0.08)",
+    color: "#cf222e",
+    icon: "🚫",
+    defaultLabel: "CAUTION",
+  },
+  danger: {
+    border: "#cf222e",
+    bg: "rgba(207,34,46,0.08)",
+    color: "#cf222e",
+    icon: "🚫",
+    defaultLabel: "DANGER",
+  },
 };
 
 function escapeHtml(s: string): string {
@@ -572,21 +664,25 @@ function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function buildCalloutHtml(type: string, title: string | null, body: string): string {
+function buildCalloutHtml(
+  type: string,
+  title: string | null,
+  body: string,
+): string {
   const palette = CALLOUT_PALETTE[type.toLowerCase()] ?? CALLOUT_PALETTE.info;
   const heading = title ?? palette.defaultLabel;
   return (
     `<div class="nexus-callout" data-callout-type="${escapeHtml(type)}" ` +
-      `style="border-left:4px solid ${palette.border};background:${palette.bg};` +
-      `padding:8px 14px;border-radius:6px;margin:6px 0;">` +
-      `<div class="nexus-callout-title" style="color:${palette.color};font-weight:600;` +
-      `display:flex;align-items:center;gap:6px;margin-bottom:4px;">` +
-      `<span aria-hidden="true">${palette.icon}</span>` +
-      `<span>${escapeHtml(heading)}</span>` +
-      `</div>` +
-      `<div class="nexus-callout-body" style="color:var(--nexus-text);white-space:pre-wrap;">` +
-      escapeHtml(body) +
-      `</div>` +
+    `style="border-left:4px solid ${palette.border};background:${palette.bg};` +
+    `padding:8px 14px;border-radius:6px;margin:6px 0;">` +
+    `<div class="nexus-callout-title" style="color:${palette.color};font-weight:600;` +
+    `display:flex;align-items:center;gap:6px;margin-bottom:4px;">` +
+    `<span aria-hidden="true">${palette.icon}</span>` +
+    `<span>${escapeHtml(heading)}</span>` +
+    `</div>` +
+    `<div class="nexus-callout-body" style="color:var(--nexus-text);white-space:pre-wrap;">` +
+    escapeHtml(body) +
+    `</div>` +
     `</div>`
   );
 }
@@ -652,12 +748,15 @@ function adaptLinkReference(source: Source, node: SyntaxNode): Definition {
     identifier: m ? m[1] : "",
     label: m ? m[1] : undefined,
     url: m ? m[2] : "",
-    title: m ? m[3] ?? null : null,
+    title: m ? (m[3] ?? null) : null,
     position: position(node.from, node.to),
   };
 }
 
-function adaptFootnoteDefinition(source: Source, node: SyntaxNode): FootnoteDefinition {
+function adaptFootnoteDefinition(
+  source: Source,
+  node: SyntaxNode,
+): FootnoteDefinition {
   const src = readSlice(source, node.from, node.to);
   const m = /^\[\^([^\]]+)\]:/.exec(src);
   return {
@@ -693,19 +792,29 @@ function adaptBlockChild(source: Source, node: SyntaxNode): Content | null {
     return adaptHeading(source, node);
   }
   switch (name) {
-    case "Paragraph": return adaptParagraph(source, node);
-    case "Blockquote": return adaptBlockquote(source, node);
-    case "BulletList": return adaptList(source, node, false);
-    case "OrderedList": return adaptList(source, node, true);
-    case "FencedCode": return adaptCode(source, node, true);
+    case "Paragraph":
+      return adaptParagraph(source, node);
+    case "Blockquote":
+      return adaptBlockquote(source, node);
+    case "BulletList":
+      return adaptList(source, node, false);
+    case "OrderedList":
+      return adaptList(source, node, true);
+    case "FencedCode":
+      return adaptCode(source, node, true);
     // @lezer/markdown emits "CodeBlock" for indented code blocks; keep
     // "IndentedCode" as a defensive alias for any non-default config.
     case "CodeBlock":
-    case "IndentedCode": return adaptCode(source, node, false);
-    case "HorizontalRule": return adaptThematicBreak(node);
-    case "Table": return adaptTable(source, node);
-    case "LinkReference": return adaptLinkReference(source, node);
-    case "FootnoteDefinition": return adaptFootnoteDefinition(source, node);
+    case "IndentedCode":
+      return adaptCode(source, node, false);
+    case "HorizontalRule":
+      return adaptThematicBreak(node);
+    case "Table":
+      return adaptTable(source, node);
+    case "LinkReference":
+      return adaptLinkReference(source, node);
+    case "FootnoteDefinition":
+      return adaptFootnoteDefinition(source, node);
     case "HTMLBlock":
     case "CommentBlock":
       return adaptHtml(source, node);
@@ -738,7 +847,10 @@ function walkRoot(tree: Tree, source: Source): Root {
   };
 }
 
-export function lezerTreeToMdast(state: EditorState, tree: Tree = syntaxTree(state)): Root {
+export function lezerTreeToMdast(
+  state: EditorState,
+  tree: Tree = syntaxTree(state),
+): Root {
   return walkRoot(tree, stateSource(state));
 }
 
@@ -746,7 +858,8 @@ export function lezerTreeToMdast(state: EditorState, tree: Tree = syntaxTree(sta
 // (before a CM6 view exists) and for any get-ast call that doesn't have a
 // live state. Configures the same GFM + footnote extensions as the live
 // language support so the produced AST shape matches.
-let configuredParser: ReturnType<typeof commonmarkParser.configure> | null = null;
+let configuredParser: ReturnType<typeof commonmarkParser.configure> | null =
+  null;
 function getStringParser() {
   if (!configuredParser) {
     configuredParser = commonmarkParser.configure([...GFM, footnoteExtension]);

--- a/packages/core/src/live-preview.ts
+++ b/packages/core/src/live-preview.ts
@@ -1,14 +1,41 @@
-import { type EditorState, StateField, type Extension, type Range, type SelectionRange, type Transaction } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView, ViewPlugin, WidgetType } from "@codemirror/view";
+import {
+  Prec,
+  type EditorState,
+  StateField,
+  type Extension,
+  type Range,
+  type SelectionRange,
+  type Transaction,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+} from "@codemirror/view";
 import { ensureSyntaxTree } from "@codemirror/language";
-import type { Code, FootnoteDefinition, FootnoteReference, Heading, Html, List, Root, Table } from "mdast";
+import type {
+  Code,
+  FootnoteDefinition,
+  FootnoteReference,
+  Heading,
+  Html,
+  List,
+  Root,
+  Table,
+} from "mdast";
 
 import type { CodeHighlightToken } from "./types";
 import { lezerStringToMdast, lezerTreeToMdast } from "./lezer-mdast-adapter";
 import { highlightCodeBlock } from "./live-preview-highlight";
 
 import { createLivePreviewDiagnostics } from "./live-preview-diag";
-import { collectLivePreviewRanges, selectionIntersects, selectionOnSameLine } from "./live-preview-ranges";
+import {
+  collectLivePreviewRanges,
+  selectionIntersects,
+  selectionOnSameLine,
+} from "./live-preview-ranges";
 import { renderLivePreviewNode } from "./live-preview-renderers";
 import { EditableTableWidget, isTableEditing } from "./live-preview-table";
 import type {
@@ -79,7 +106,7 @@ function walkCodeBlocks(node: unknown, visit: (n: Code) => void): void {
 }
 
 function normalizeConfig(
-  config: boolean | LivePreviewConfig | undefined
+  config: boolean | LivePreviewConfig | undefined,
 ): NormalizedLivePreviewConfig {
   if (!config) {
     return { enabled: false, renderers: {}, labels: DEFAULT_LABELS };
@@ -90,7 +117,7 @@ function normalizeConfig(
   return {
     enabled: config.enabled ?? true,
     renderers: config.renderers ?? {},
-    labels: { ...DEFAULT_LABELS, ...config.labels }
+    labels: { ...DEFAULT_LABELS, ...config.labels },
   };
 }
 
@@ -103,7 +130,8 @@ function createWidget(
   // Eager path: caller already built the element. Lazy path: caller passes a
   // builder closure and we defer DOM construction to first toDOM(), so widgets
   // outside the CM6 viewport pay nothing until scrolled in.
-  let element: HTMLElement | null = typeof source === "function" ? null : source;
+  let element: HTMLElement | null =
+    typeof source === "function" ? null : source;
   const builder = typeof source === "function" ? source : null;
   return new (class extends WidgetType {
     /** Stable identity used by eq() so CM6 reuses old DOM across rebuilds. */
@@ -121,18 +149,31 @@ function createWidget(
       const otherKey = (other as { _eqKey?: string })._eqKey;
       return otherKey === this._eqKey;
     }
-    ignoreEvent() { return swallowEvents; }
+    ignoreEvent() {
+      return swallowEvents;
+    }
     // For block widgets, giving CM6 a pre-measure height prevents the heightmap
     // from assigning 0 and then jumping to the real height on first measure.
     // That jump shifts every click resolution below the widget until remeasured.
-    get estimatedHeight(): number { return heightHint ?? -1; }
+    get estimatedHeight(): number {
+      return heightHint ?? -1;
+    }
   })();
 }
 
 class CodeCopyWidget extends WidgetType {
-  constructor(private readonly code: string, private readonly lang: string) { super(); }
-  eq(other: CodeCopyWidget): boolean { return other.code === this.code && other.lang === this.lang; }
-  ignoreEvent(): boolean { return true; }
+  constructor(
+    private readonly code: string,
+    private readonly lang: string,
+  ) {
+    super();
+  }
+  eq(other: CodeCopyWidget): boolean {
+    return other.code === this.code && other.lang === this.lang;
+  }
+  ignoreEvent(): boolean {
+    return true;
+  }
   toDOM(): HTMLElement {
     // CM6 measures inline widget DOM elements via offsetHeight and uses that to
     // size the line box. A <button> with position:absolute still has a measurable
@@ -144,7 +185,8 @@ class CodeCopyWidget extends WidgetType {
     // → offsetHeight=0 → CM6 sees 0 contribution. The button overflows visually
     // via overflow:visible and is anchored by the parent line's position:relative.
     const wrapper = document.createElement("span");
-    wrapper.style.cssText = "line-height:0;font-size:0;overflow:visible;display:inline;";
+    wrapper.style.cssText =
+      "line-height:0;font-size:0;overflow:visible;display:inline;";
 
     const btn = document.createElement("button");
     btn.type = "button";
@@ -168,21 +210,32 @@ class CodeCopyWidget extends WidgetType {
       "opacity:0.7",
       "z-index:1",
       "user-select:none",
-      "transition:opacity .15s"
+      "transition:opacity .15s",
     ].join(";");
-    btn.addEventListener("mouseenter", () => { btn.style.opacity = "1"; });
-    btn.addEventListener("mouseleave", () => { btn.style.opacity = "0.7"; });
-    btn.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+    btn.addEventListener("mouseenter", () => {
+      btn.style.opacity = "1";
+    });
+    btn.addEventListener("mouseleave", () => {
+      btn.style.opacity = "0.7";
+    });
+    btn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
     btn.addEventListener("click", async (e) => {
       e.preventDefault();
       e.stopPropagation();
       try {
         await navigator.clipboard.writeText(this.code);
         btn.textContent = "Copied";
-        setTimeout(() => { btn.textContent = defaultLabel; }, 1200);
+        setTimeout(() => {
+          btn.textContent = defaultLabel;
+        }, 1200);
       } catch {
         btn.textContent = "Failed";
-        setTimeout(() => { btn.textContent = defaultLabel; }, 1200);
+        setTimeout(() => {
+          btn.textContent = defaultLabel;
+        }, 1200);
       }
     });
     wrapper.appendChild(btn);
@@ -197,7 +250,13 @@ class CodeCopyWidget extends WidgetType {
 
 type MermaidAPI = {
   render(id: string, text: string): Promise<{ svg: string }>;
-  parse(text: string, opts?: { suppressErrors?: boolean }): Promise<boolean | { diagramType: string }> | boolean | { diagramType: string };
+  parse(
+    text: string,
+    opts?: { suppressErrors?: boolean },
+  ):
+    | Promise<boolean | { diagramType: string }>
+    | boolean
+    | { diagramType: string };
 };
 
 let mermaidPromise: Promise<MermaidAPI> | null = null;
@@ -205,7 +264,11 @@ function loadMermaid(): Promise<MermaidAPI> {
   if (!mermaidPromise) {
     mermaidPromise = import("mermaid").then((mod) => {
       const m = (mod as any).default ?? mod;
-      m.initialize({ startOnLoad: false, theme: "default", securityLevel: "strict" });
+      m.initialize({
+        startOnLoad: false,
+        theme: "default",
+        securityLevel: "strict",
+      });
       return m as MermaidAPI;
     });
   }
@@ -220,14 +283,18 @@ class MermaidWidget extends WidgetType {
     private readonly source: string,
     private readonly viewRef: { current: EditorView | null },
     private readonly blockFrom: number,
-    private readonly sourceOffsetInBlock: number
-  ) { super(); }
+    private readonly sourceOffsetInBlock: number,
+  ) {
+    super();
+  }
 
   eq(other: MermaidWidget): boolean {
     return other.source === this.source;
   }
 
-  ignoreEvent(): boolean { return true; }
+  ignoreEvent(): boolean {
+    return true;
+  }
 
   get estimatedHeight(): number {
     const cached = MERMAID_CACHE.get(this.source);
@@ -238,17 +305,18 @@ class MermaidWidget extends WidgetType {
     // Container: margin:0, padding for visual spacing (CLAUDE.md rule #11 / thematicBreak pattern).
     const container = document.createElement("div");
     container.className = "nexus-mermaid";
-    container.style.cssText = [
-      "display:block",
-      "position:relative",
-      "margin:0",
-      "padding:12px",
-      "background:var(--nexus-bg-subtle)",
-      "border-radius:4px",
-      "min-height:80px",
-      "text-align:center",
-      "overflow:hidden",
-    ].join(";") + ";";
+    container.style.cssText =
+      [
+        "display:block",
+        "position:relative",
+        "margin:0",
+        "padding:12px",
+        "background:var(--nexus-bg-subtle)",
+        "border-radius:4px",
+        "min-height:80px",
+        "text-align:center",
+        "overflow:hidden",
+      ].join(";") + ";";
 
     // Edit icon — always rendered, always on top. stopPropagation so the
     // click doesn't get swallowed as a widget-surface click.
@@ -257,27 +325,35 @@ class MermaidWidget extends WidgetType {
     editBtn.title = "Edit mermaid source";
     editBtn.setAttribute("aria-label", "Edit mermaid source");
     editBtn.textContent = "✎";
-    editBtn.style.cssText = [
-      "position:absolute",
-      "top:4px",
-      "right:8px",
-      "padding:2px 8px",
-      "font-size:12px",
-      "font-family:system-ui,sans-serif",
-      "line-height:1.4",
-      "background:var(--nexus-bg)",
-      "border:1px solid var(--nexus-border-subtle)",
-      "border-radius:3px",
-      "color:var(--nexus-text-muted)",
-      "cursor:pointer",
-      "opacity:0.7",
-      "z-index:2",
-      "user-select:none",
-      "transition:opacity .15s",
-    ].join(";") + ";";
-    editBtn.addEventListener("mouseenter", () => { editBtn.style.opacity = "1"; });
-    editBtn.addEventListener("mouseleave", () => { editBtn.style.opacity = "0.7"; });
-    editBtn.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+    editBtn.style.cssText =
+      [
+        "position:absolute",
+        "top:4px",
+        "right:8px",
+        "padding:2px 8px",
+        "font-size:12px",
+        "font-family:system-ui,sans-serif",
+        "line-height:1.4",
+        "background:var(--nexus-bg)",
+        "border:1px solid var(--nexus-border-subtle)",
+        "border-radius:3px",
+        "color:var(--nexus-text-muted)",
+        "cursor:pointer",
+        "opacity:0.7",
+        "z-index:2",
+        "user-select:none",
+        "transition:opacity .15s",
+      ].join(";") + ";";
+    editBtn.addEventListener("mouseenter", () => {
+      editBtn.style.opacity = "1";
+    });
+    editBtn.addEventListener("mouseleave", () => {
+      editBtn.style.opacity = "0.7";
+    });
+    editBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
     editBtn.addEventListener("click", (e) => {
       e.preventDefault();
       e.stopPropagation();
@@ -292,7 +368,8 @@ class MermaidWidget extends WidgetType {
     const diagramHost = document.createElement("div");
     // max-width on host + responsive SVG (set after innerHTML) prevents the
     // diagram from overflowing and adding a third scrollbar.
-    diagramHost.style.cssText = "display:block;min-height:64px;max-width:100%;overflow:hidden;";
+    diagramHost.style.cssText =
+      "display:block;min-height:64px;max-width:100%;overflow:hidden;";
     container.appendChild(editBtn);
     container.appendChild(diagramHost);
 
@@ -343,12 +420,17 @@ class MermaidWidget extends WidgetType {
       body.style.cssText = "white-space:pre-wrap;";
 
       const hint = document.createElement("div");
-      hint.style.cssText = "margin-top:8px;font-family:system-ui,sans-serif;color:var(--nexus-text-muted);";
+      hint.style.cssText =
+        "margin-top:8px;font-family:system-ui,sans-serif;color:var(--nexus-text-muted);";
       const editLink = document.createElement("a");
       editLink.href = "#";
       editLink.textContent = "Edit source";
-      editLink.style.cssText = "color:var(--nexus-accent);text-decoration:underline;cursor:pointer;";
-      editLink.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+      editLink.style.cssText =
+        "color:var(--nexus-accent);text-decoration:underline;cursor:pointer;";
+      editLink.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
       editLink.addEventListener("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -419,26 +501,41 @@ class MermaidWidget extends WidgetType {
 const BLOCK_NODE_TYPES = new Set(["thematicBreak"]);
 
 const HEADING_FONT_SIZE: Record<number, string> = {
-  1: "1.6em", 2: "1.4em", 3: "1.2em", 4: "1.1em", 5: "1.05em", 6: "1em"
+  1: "1.6em",
+  2: "1.4em",
+  3: "1.2em",
+  4: "1.1em",
+  5: "1.05em",
+  6: "1em",
 };
 
 function buildHeadingDecorations(
   range: { from: number; to: number; node: Heading },
   selection: readonly SelectionRange[],
-  decos: Range<Decoration>[]
+  decos: Range<Decoration>[],
 ): void {
   const firstChild = range.node.children[0];
   const textStart = firstChild?.position?.start?.offset;
 
-  if (typeof textStart === "number" && textStart > range.from && textStart <= range.to) {
+  if (
+    typeof textStart === "number" &&
+    textStart > range.from &&
+    textStart <= range.to
+  ) {
     const fontSize = HEADING_FONT_SIZE[range.node.depth] ?? "1em";
-    const cursorOnHeading = selectionIntersects(range.from, range.to, selection);
+    const cursorOnHeading = selectionIntersects(
+      range.from,
+      range.to,
+      selection,
+    );
 
     if (cursorOnHeading) {
       decos.push(
         Decoration.mark({
-          attributes: { style: `font-weight: bold; font-size: ${fontSize}; color: var(--nexus-text-muted)` }
-        }).range(range.from, textStart)
+          attributes: {
+            style: `font-weight: bold; font-size: ${fontSize}; color: var(--nexus-text-muted)`,
+          },
+        }).range(range.from, textStart),
       );
     } else {
       decos.push(Decoration.replace({}).range(range.from, textStart));
@@ -450,12 +547,14 @@ function buildHeadingDecorations(
           style: `font-weight: bold; font-size: ${fontSize}`,
           "data-heading-level": String(range.node.depth),
           role: "heading",
-          "aria-level": String(range.node.depth)
-        }
-      }).range(textStart, range.to)
+          "aria-level": String(range.node.depth),
+        },
+      }).range(textStart, range.to),
     );
   }
 }
+
+let listMarkerRanges: [number, number][] = [];
 
 const LIST_MARKER_RE = /^(\s*)([-*+]|\d+[.)]) /;
 const CHECKBOX_RE = /^\[([ xX])\] /;
@@ -464,7 +563,7 @@ function buildListDecorations(
   range: { from: number; to: number; node: List },
   doc: string,
   decos: Range<Decoration>[],
-  viewRef: { current: EditorView | null }
+  viewRef: { current: EditorView | null },
 ): void {
   // Iterate ListItems via mdast structure (not regex over flat source lines).
   // Nested sub-lists are children of a ListItem, not of the outer list, so
@@ -490,6 +589,8 @@ function buildListDecorations(
     const markerEnd = itemFrom + markerMatch[0].length;
 
     const bullet = document.createElement("span");
+    bullet.style.userSelect = "none";
+    bullet.style.webkitUserSelect = "none";
     let bulletKey: string;
     if (isOrdered) {
       const n = orderNum;
@@ -505,8 +606,9 @@ function buildListDecorations(
     decos.push(
       Decoration.replace({
         widget: createWidget(bullet, false, undefined, bulletKey),
-      }).range(markerStart, markerEnd)
+      }).range(markerStart, markerEnd),
     );
+    listMarkerRanges.push([markerStart, markerEnd]);
 
     const afterMarker = headLine.slice(markerMatch[0].length);
     const checkMatch = CHECKBOX_RE.exec(afterMarker);
@@ -528,7 +630,11 @@ function buildListDecorations(
         const v = viewRef.current;
         if (!v) return;
         v.dispatch({
-          changes: { from: toggleFrom, to: toggleFrom + 1, insert: isChecked ? " " : "x" }
+          changes: {
+            from: toggleFrom,
+            to: toggleFrom + 1,
+            insert: isChecked ? " " : "x",
+          },
         });
       });
 
@@ -536,14 +642,17 @@ function buildListDecorations(
       decos.push(
         Decoration.replace({
           widget: createWidget(checkbox, false, undefined, taskKey),
-        }).range(checkStart, checkEnd)
+        }).range(checkStart, checkEnd),
       );
 
       if (isChecked && checkEnd < headLineEnd) {
         decos.push(
           Decoration.mark({
-            attributes: { style: "text-decoration: line-through; color: var(--nexus-text-muted)" }
-          }).range(checkEnd, headLineEnd)
+            attributes: {
+              style:
+                "text-decoration: line-through; color: var(--nexus-text-muted)",
+            },
+          }).range(checkEnd, headLineEnd),
         );
       }
     }
@@ -561,13 +670,22 @@ function buildListDecorations(
 function defaultSanitizeHtml(rawHtml: string): string {
   let html = rawHtml;
   // Remove dangerous element bodies entirely (open tag through close tag).
-  html = html.replace(/<\s*(script|iframe|object|embed|style)\b[\s\S]*?<\/\s*\1\s*>/gi, "");
+  html = html.replace(
+    /<\s*(script|iframe|object|embed|style)\b[\s\S]*?<\/\s*\1\s*>/gi,
+    "",
+  );
   // Remove orphan dangerous self-closing tags.
-  html = html.replace(/<\s*(script|iframe|object|embed|style)\b[^>]*\/?>/gi, "");
+  html = html.replace(
+    /<\s*(script|iframe|object|embed|style)\b[^>]*\/?>/gi,
+    "",
+  );
   // Strip inline event handlers: `onclick="…"` / `onload='…'` / onfoo=bareword.
   html = html.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "");
   // Strip `javascript:` URLs in href / src attributes.
-  html = html.replace(/(href|src|xlink:href)\s*=\s*(['"])\s*javascript:[^'"]*\2/gi, '$1=$2#$2');
+  html = html.replace(
+    /(href|src|xlink:href)\s*=\s*(['"])\s*javascript:[^'"]*\2/gi,
+    "$1=$2#$2",
+  );
   return html;
 }
 
@@ -576,12 +694,52 @@ function buildHtmlDecorations(
   selection: readonly SelectionRange[],
   decos: Range<Decoration>[],
   config: NormalizedLivePreviewConfig,
-  viewRef: { current: EditorView | null }
+  viewRef: { current: EditorView | null },
 ): void {
+  const cursorInside = selectionIntersects(
+    range.from,
+    range.to,
+    selection,
+    true,
+  );
+
+  if ((range.node as unknown as Record<string, unknown>).inline) {
+    if (cursorInside) return;
+
+    const inlineEl = document.createElement("span");
+    inlineEl.innerHTML = defaultSanitizeHtml(range.node.value ?? range.source);
+    inlineEl.style.cssText = "display:inline;";
+    inlineEl.style.cursor = "text";
+
+    inlineEl.addEventListener("mousedown", (event) => {
+      if (
+        (event.target as HTMLElement)?.closest(
+          "a[href], button, input, select, textarea, label",
+        )
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      const v = viewRef.current;
+      if (!v) return;
+      const safeFrom = Math.min(range.from, v.state.doc.length);
+      v.dispatch({ selection: { anchor: safeFrom } });
+      v.focus();
+    });
+
+    const inlineKey = `inline-html:${range.from}:${range.to}:${range.source}`;
+    decos.push(
+      Decoration.replace({
+        widget: createWidget(inlineEl, false, undefined, inlineKey),
+      }).range(range.from, range.to),
+    );
+    return;
+  }
+
   // Show raw source while the user is editing the block — same pattern as
   // mermaid / code blocks. `inclusiveEnd: true` so the cursor parked at the
   // closing offset (typical after pressing End) still counts as inside.
-  const cursorInside = selectionIntersects(range.from, range.to, selection, true);
   if (cursorInside) return;
 
   // Host may override with a custom renderer (e.g. to plug a stronger
@@ -605,7 +763,8 @@ function buildHtmlDecorations(
   if (!inner) {
     inner = document.createElement("div");
     inner.className = "nexus-html-block-content";
-    inner.style.cssText = "display:block;margin:0;padding:0;line-height:normal;font-family:inherit;";
+    inner.style.cssText =
+      "display:block;margin:0;padding:0;line-height:normal;font-family:inherit;";
     inner.innerHTML = defaultSanitizeHtml(range.node.value ?? range.source);
   }
 
@@ -621,7 +780,8 @@ function buildHtmlDecorations(
   // to resolve the click into a cursor position itself.
   const wrapper = document.createElement("div");
   wrapper.className = "nexus-html-block";
-  wrapper.style.cssText = "position:relative;display:block;margin:0;padding:0;cursor:text;";
+  wrapper.style.cssText =
+    "position:relative;display:block;margin:0;padding:0;cursor:text;";
   wrapper.appendChild(inner);
 
   // Selector for elements whose native behaviour we want to preserve.
@@ -656,7 +816,7 @@ function buildHtmlDecorations(
     Decoration.replace({
       widget: createWidget(wrapper, true, heightHint, htmlKey),
       block: true,
-    }).range(range.from, range.to)
+    }).range(range.from, range.to),
   );
 }
 
@@ -674,11 +834,41 @@ interface AlertStyle {
 }
 
 const ALERT_STYLES: Record<AlertType, AlertStyle> = {
-  NOTE: { borderColor: "#0969da", bg: "rgba(9,105,218,0.08)", textColor: "#0969da", icon: "ℹ", label: "Note" },
-  TIP: { borderColor: "#1a7f37", bg: "rgba(26,127,55,0.08)", textColor: "#1a7f37", icon: "💡", label: "Tip" },
-  IMPORTANT: { borderColor: "#8250df", bg: "rgba(130,80,223,0.08)", textColor: "#8250df", icon: "❗", label: "Important" },
-  WARNING: { borderColor: "#9a6700", bg: "rgba(154,103,0,0.08)", textColor: "#9a6700", icon: "⚠", label: "Warning" },
-  CAUTION: { borderColor: "#cf222e", bg: "rgba(207,34,46,0.08)", textColor: "#cf222e", icon: "🚫", label: "Caution" },
+  NOTE: {
+    borderColor: "#0969da",
+    bg: "rgba(9,105,218,0.08)",
+    textColor: "#0969da",
+    icon: "ℹ",
+    label: "Note",
+  },
+  TIP: {
+    borderColor: "#1a7f37",
+    bg: "rgba(26,127,55,0.08)",
+    textColor: "#1a7f37",
+    icon: "💡",
+    label: "Tip",
+  },
+  IMPORTANT: {
+    borderColor: "#8250df",
+    bg: "rgba(130,80,223,0.08)",
+    textColor: "#8250df",
+    icon: "❗",
+    label: "Important",
+  },
+  WARNING: {
+    borderColor: "#9a6700",
+    bg: "rgba(154,103,0,0.08)",
+    textColor: "#9a6700",
+    icon: "⚠",
+    label: "Warning",
+  },
+  CAUTION: {
+    borderColor: "#cf222e",
+    bg: "rgba(207,34,46,0.08)",
+    textColor: "#cf222e",
+    icon: "🚫",
+    label: "Caution",
+  },
 };
 
 /**
@@ -721,11 +911,16 @@ function detectAlert(source: string): {
 function buildBlockquoteDecorations(
   range: { from: number; to: number; source: string },
   selection: readonly SelectionRange[],
-  decos: Range<Decoration>[]
+  decos: Range<Decoration>[],
 ): { alertHeadEnd: number } | null {
   const source = range.source;
   const lines = source.split("\n");
-  const cursorInBlockquote = selectionIntersects(range.from, range.to, selection, true);
+  const cursorInBlockquote = selectionIntersects(
+    range.from,
+    range.to,
+    selection,
+    true,
+  );
   const alert = detectAlert(source);
   const style = alert ? ALERT_STYLES[alert.type] : null;
   let offset = range.from;
@@ -756,7 +951,9 @@ function buildBlockquoteDecorations(
     const lineEnd = offset + line.length;
 
     decos.push(
-      Decoration.line({ attributes: { style: lineStyleFor(i) } }).range(lineStart)
+      Decoration.line({ attributes: { style: lineStyleFor(i) } }).range(
+        lineStart,
+      ),
     );
 
     const markerMatch = BLOCKQUOTE_MARKER_RE.exec(line);
@@ -785,8 +982,13 @@ function buildBlockquoteDecorations(
           badge.appendChild(labelSpan);
           decos.push(
             Decoration.replace({
-              widget: createWidget(badge, false, undefined, `alert:${alert.type}:${tagStart}`),
-            }).range(tagStart, tagEnd)
+              widget: createWidget(
+                badge,
+                false,
+                undefined,
+                `alert:${alert.type}:${tagStart}`,
+              ),
+            }).range(tagStart, tagEnd),
           );
           alertHeadEnd = lineEnd;
         }
@@ -809,11 +1011,16 @@ function buildCodeBlockDecorations(
   selection: readonly SelectionRange[],
   decos: Range<Decoration>[],
   viewRef: { current: EditorView | null },
-  codeTokens?: readonly import("./types").CodeHighlightToken[]
+  codeTokens?: readonly import("./types").CodeHighlightToken[],
 ): void {
   const source = range.source;
   const lines = source.split("\n");
-  const cursorOnCode = selectionIntersects(range.from, range.to, selection, true);
+  const cursorOnCode = selectionIntersects(
+    range.from,
+    range.to,
+    selection,
+    true,
+  );
   const firstNewline = source.indexOf("\n");
   const isFenced = /^[ \t]*(`{3,}|~{3,})/.test(source);
 
@@ -823,9 +1030,14 @@ function buildCodeBlockDecorations(
   if (range.node.lang === "mermaid" && !cursorOnCode && firstNewline >= 0) {
     decos.push(
       Decoration.replace({
-        widget: new MermaidWidget(range.node.value ?? "", viewRef, range.from, firstNewline + 1),
+        widget: new MermaidWidget(
+          range.node.value ?? "",
+          viewRef,
+          range.from,
+          firstNewline + 1,
+        ),
         block: true,
-      }).range(range.from, range.to)
+      }).range(range.from, range.to),
     );
     return;
   }
@@ -857,9 +1069,15 @@ function buildCodeBlockDecorations(
 
     // Line decoration: ONLY background + border-radius (no font changes).
     // position:relative on first fence line anchors the absolute copy button.
-    const radius = isFirstLine ? "border-radius:4px 4px 0 0;" : isLastLine ? "border-radius:0 0 4px 4px;" : "";
+    const radius = isFirstLine
+      ? "border-radius:4px 4px 0 0;"
+      : isLastLine
+        ? "border-radius:0 0 4px 4px;"
+        : "";
     const firstLineExtra = isFirstLine && isFenced ? "position:relative;" : "";
-    const lineAttrs: Record<string, string> = { style: LINE_BG + radius + firstLineExtra };
+    const lineAttrs: Record<string, string> = {
+      style: LINE_BG + radius + firstLineExtra,
+    };
     if (isFirstLine) {
       lineAttrs.role = "code";
       if (lang) lineAttrs["aria-label"] = `Code block: ${lang}`;
@@ -868,20 +1086,26 @@ function buildCodeBlockDecorations(
 
     // Fence lines: transparent + monospace via mark; visible when cursor in block.
     if (isFenced && (isFirstLine || isLastLine) && lineEnd > lineStart) {
-      decos.push(Decoration.mark({
-        attributes: {
-          style: MONO_MARK + (cursorOnCode
-            ? "color:var(--nexus-text-faint,#bbb);"
-            : "color:transparent;cursor:text;")
-        }
-      }).range(lineStart, lineEnd));
+      decos.push(
+        Decoration.mark({
+          attributes: {
+            style:
+              MONO_MARK +
+              (cursorOnCode
+                ? "color:var(--nexus-text-faint,#bbb);"
+                : "color:transparent;cursor:text;"),
+          },
+        }).range(lineStart, lineEnd),
+      );
     }
 
     // Content lines (non-fence): monospace via mark.
     if (!(isFenced && (isFirstLine || isLastLine)) && lineEnd > lineStart) {
-      decos.push(Decoration.mark({
-        attributes: { style: MONO_MARK }
-      }).range(lineStart, lineEnd));
+      decos.push(
+        Decoration.mark({
+          attributes: { style: MONO_MARK },
+        }).range(lineStart, lineEnd),
+      );
     }
 
     // Copy button: always present, absolute-positioned inside first fence line.
@@ -889,8 +1113,8 @@ function buildCodeBlockDecorations(
       decos.push(
         Decoration.widget({
           widget: new CodeCopyWidget(codeValue, lang ?? ""),
-          side: 1
-        }).range(lineEnd)
+          side: 1,
+        }).range(lineEnd),
       );
     }
 
@@ -903,7 +1127,12 @@ function buildCodeBlockDecorations(
   // (worker hasn't responded for this document), the code block renders
   // unstyled and gets coloured on the next buildDecorations pass once the
   // worker response has been merged into the AST cache.
-  if (codeTokens && codeTokens.length > 0 && firstNewline >= 0 && range.node.value) {
+  if (
+    codeTokens &&
+    codeTokens.length > 0 &&
+    firstNewline >= 0 &&
+    range.node.value
+  ) {
     // Tokens are sorted by `from` in the worker; still filter since one
     // code block gets decorations for only its subrange.
     const contentStart = range.from + firstNewline + 1;
@@ -913,7 +1142,7 @@ function buildCodeBlockDecorations(
       if (tok.to <= contentStart) continue;
       if (tok.from < range.from || tok.to > range.to) continue;
       decos.push(
-        Decoration.mark({ class: tok.className }).range(tok.from, tok.to)
+        Decoration.mark({ class: tok.className }).range(tok.from, tok.to),
       );
     }
   }
@@ -929,7 +1158,10 @@ interface InlineMarkerStyle {
   attrs?: Record<string, string>;
 }
 
-function getInlineMarkerStyle(nodeType: string, source: string): InlineMarkerStyle | null {
+function getInlineMarkerStyle(
+  nodeType: string,
+  source: string,
+): InlineMarkerStyle | null {
   switch (nodeType) {
     case "strong":
       return { openLen: 2, closeLen: 2, style: "font-weight:bold" };
@@ -942,8 +1174,10 @@ function getInlineMarkerStyle(nodeType: string, source: string): InlineMarkerSty
       let ticks = 0;
       for (let i = 0; i < source.length && source[i] === "`"; i++) ticks++;
       return {
-        openLen: ticks, closeLen: ticks,
-        style: "font-family:monospace;background:var(--nexus-bg-muted);padding:1px 4px;border-radius:3px"
+        openLen: ticks,
+        closeLen: ticks,
+        style:
+          "font-family:monospace;background:var(--nexus-bg-muted);padding:1px 4px;border-radius:3px",
       };
     }
     case "link": {
@@ -952,25 +1186,30 @@ function getInlineMarkerStyle(nodeType: string, source: string): InlineMarkerSty
       if (bracketClose >= 0) {
         const url = source.slice(bracketClose + 2, source.length - 1);
         return {
-          openLen: 1,                            // hide [
+          openLen: 1, // hide [
           closeLen: source.length - bracketClose, // hide ](url)
-          style: "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
-          attrs: { "data-link-url": url }
+          style:
+            "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
+          attrs: { "data-link-url": url },
         };
       }
       // Standard autolink: <URL> — hide angle brackets
       if (source.startsWith("<") && source.endsWith(">")) {
         return {
-          openLen: 1, closeLen: 1,
-          style: "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
-          attrs: { "data-link-url": source.slice(1, -1) }
+          openLen: 1,
+          closeLen: 1,
+          style:
+            "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
+          attrs: { "data-link-url": source.slice(1, -1) },
         };
       }
       // GFM autolink literal: bare URL, no markers to hide
       return {
-        openLen: 0, closeLen: 0,
-        style: "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
-        attrs: { "data-link-url": source }
+        openLen: 0,
+        closeLen: 0,
+        style:
+          "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
+        attrs: { "data-link-url": source },
       };
     }
     default:
@@ -990,11 +1229,18 @@ function buildDecorations(
   selection: readonly SelectionRange[],
   config: NormalizedLivePreviewConfig,
   viewRef: { current: EditorView | null },
-  ctx: BuildContext
+  ctx: BuildContext,
 ): { decos: DecorationSet; ast: Root; codeTokens: CodeHighlightToken[] } {
-  if (!config.enabled) return { decos: Decoration.none, ast: ctx.ast ?? createEmptyAst(), codeTokens: [] };
+  listMarkerRanges = [];
+  if (!config.enabled)
+    return {
+      decos: Decoration.none,
+      ast: ctx.ast ?? createEmptyAst(),
+      codeTokens: [],
+    };
 
-  const perfEnabled = (globalThis as { NEXUS_PERF?: boolean }).NEXUS_PERF !== false;
+  const perfEnabled =
+    (globalThis as { NEXUS_PERF?: boolean }).NEXUS_PERF !== false;
   const t0 = perfEnabled ? performance.now() : 0;
   const doc = state.doc.toString();
   // Lezer-driven adapter: synchronous, viewport-agnostic, intrinsic to the
@@ -1012,20 +1258,30 @@ function buildDecorations(
   const astHit = !!ctx.ast;
   const decos: Range<Decoration>[] = [];
   const parentSpans: [number, number][] = [];
+  const deleteCoveredRanges: [number, number][] = [];
 
   for (const range of ranges) {
-    if (parentSpans.some(([from, to]) => range.from >= from && range.to <= to)) continue;
+    if (parentSpans.some(([from, to]) => range.from >= from && range.to <= to))
+      continue;
 
     if (range.node.type === "heading" && !config.renderers.heading) {
-      buildHeadingDecorations(range as { from: number; to: number; node: Heading }, selection, decos);
+      buildHeadingDecorations(
+        range as { from: number; to: number; node: Heading },
+        selection,
+        decos,
+      );
     } else if (range.node.type === "table" && !config.renderers.table) {
       decos.push(
         Decoration.replace({
           widget: new EditableTableWidget(
-            range.node as Table, range.from, range.source, viewRef, config.labels
+            range.node as Table,
+            range.from,
+            range.source,
+            viewRef,
+            config.labels,
           ),
-          block: true
-        }).range(range.from, range.to)
+          block: true,
+        }).range(range.from, range.to),
       );
     } else if (range.node.type === "html") {
       buildHtmlDecorations(
@@ -1033,15 +1289,20 @@ function buildDecorations(
         selection,
         decos,
         config,
-        viewRef
+        viewRef,
       );
     } else if (range.node.type === "list") {
-      buildListDecorations(range as { from: number; to: number; node: List }, doc, decos, viewRef);
+      buildListDecorations(
+        range as { from: number; to: number; node: List },
+        doc,
+        decos,
+        viewRef,
+      );
     } else if (range.node.type === "blockquote") {
       const alertInfo = buildBlockquoteDecorations(
         range as { from: number; to: number; source: string },
         selection,
-        decos
+        decos,
       );
       if (alertInfo) {
         // GFM Alert: suppress the inline link decoration that lezer emits for
@@ -1051,7 +1312,13 @@ function buildDecorations(
         parentSpans.push([range.from, alertInfo.alertHeadEnd]);
       }
     } else if (range.node.type === "code" && !config.renderers.code) {
-      buildCodeBlockDecorations(range as { from: number; to: number; node: Code; source: string }, selection, decos, viewRef, codeTokens);
+      buildCodeBlockDecorations(
+        range as { from: number; to: number; node: Code; source: string },
+        selection,
+        decos,
+        viewRef,
+        codeTokens,
+      );
     } else if (range.node.type === "image") {
       // Cursor-aware + preview-alongside:
       //   * cursor OUT  → replace widget (source hidden).
@@ -1061,19 +1328,30 @@ function buildDecorations(
       // the custom renderer, which dispatches setSelection(range.from).
       // swallowEvents=true so interactive chrome inside a custom image renderer
       // isn't preempted by CM6's cursor-placement handler.
-      const cursorOnImage = selectionIntersects(range.from, range.to, selection, true);
+      const cursorOnImage = selectionIntersects(
+        range.from,
+        range.to,
+        selection,
+        true,
+      );
       // Stable identity keyed by content + position lets CM6 reuse the existing
       // DOM across cursor-only updates and unrelated edits — image renderers
       // are heavy (50+ DOM nodes with inline styles), so skipping the rebuild
       // is the bulk of the buildWidgets win on documents with many images.
       const imgKey = `image:${range.from}:${range.to}:${cursorOnImage ? "in" : "out"}:${range.source}`;
       const buildImg = (): HTMLElement =>
-        renderLivePreviewNode(range.node, range.source, config.renderers, range.from, range.to);
+        renderLivePreviewNode(
+          range.node,
+          range.source,
+          config.renderers,
+          range.from,
+          range.to,
+        );
       if (!cursorOnImage) {
         decos.push(
           Decoration.replace({
-            widget: createWidget(buildImg, true, undefined, imgKey)
-          }).range(range.from, range.to)
+            widget: createWidget(buildImg, true, undefined, imgKey),
+          }).range(range.from, range.to),
         );
       } else {
         // Edit mode: keep source text visible; also render the image below.
@@ -1082,7 +1360,7 @@ function buildDecorations(
             widget: createWidget(buildImg, true, undefined, imgKey),
             block: true,
             side: 1,
-          }).range(range.to)
+          }).range(range.to),
         );
       }
     } else if (range.node.type === "link" && !config.renderers.link) {
@@ -1090,12 +1368,19 @@ function buildDecorations(
       if (inlineStyle) {
         const { openLen, closeLen, style, attrs } = inlineStyle;
         // Always render as widget — no cursor-on/off switching (avoids viewport instability)
-        const linkText = range.source.slice(openLen, range.source.length - closeLen);
+        const linkText = range.source.slice(
+          openLen,
+          range.source.length - closeLen,
+        );
         const span = document.createElement("span");
         span.textContent = linkText;
         span.style.cssText = style + ";transition:opacity .15s;";
-        span.addEventListener("mouseenter", () => { span.style.opacity = "0.7"; });
-        span.addEventListener("mouseleave", () => { span.style.opacity = "1"; });
+        span.addEventListener("mouseenter", () => {
+          span.style.opacity = "0.7";
+        });
+        span.addEventListener("mouseleave", () => {
+          span.style.opacity = "1";
+        });
         if (attrs) {
           for (const [k, v] of Object.entries(attrs)) span.setAttribute(k, v);
         }
@@ -1103,7 +1388,7 @@ function buildDecorations(
         decos.push(
           Decoration.replace({
             widget: createWidget(span, false, undefined, linkKey),
-          }).range(range.from, range.to)
+          }).range(range.from, range.to),
         );
       }
     } else if (range.node.type === "definition") {
@@ -1112,39 +1397,44 @@ function buildDecorations(
       // was the single biggest click-drift source. Heights must stay constant regardless
       // of cursor to keep CM6's measurement cache and click-position resolution stable.
       decos.push(
-        Decoration.mark({ attributes: { style: "color:var(--nexus-text-faint)" } })
-          .range(range.from, range.to)
+        Decoration.mark({
+          attributes: { style: "color:var(--nexus-text-faint)" },
+        }).range(range.from, range.to),
       );
     } else if (range.node.type === "footnoteReference") {
       const ref = range.node as FootnoteReference;
       const sup = document.createElement("sup");
       sup.textContent = ref.identifier;
-      sup.style.cssText = "color:var(--nexus-accent);cursor:pointer;font-size:0.8em;vertical-align:super;";
+      sup.style.cssText =
+        "color:var(--nexus-accent);cursor:pointer;font-size:0.8em;vertical-align:super;";
       const fnRefKey = `fnref:${range.from}-${range.to}:${ref.identifier}`;
       decos.push(
         Decoration.replace({
           widget: createWidget(sup, false, undefined, fnRefKey),
-        }).range(range.from, range.to)
+        }).range(range.from, range.to),
       );
     } else if (range.node.type === "footnoteDefinition") {
       const def = range.node as FootnoteDefinition;
       const defText = range.source.replace(/^\[\^\w+\]:\s*/, "");
       const el = document.createElement("div");
-      el.style.cssText = "font-size:0.85em;color:var(--nexus-text-muted);border-top:1px solid var(--nexus-border);padding-top:8px;";
+      el.style.cssText =
+        "font-size:0.85em;color:var(--nexus-text-muted);border-top:1px solid var(--nexus-border);padding-top:8px;";
       const marker = document.createElement("sup");
       marker.textContent = def.identifier;
       marker.style.cssText = "color:var(--nexus-accent);margin-right:4px;";
       el.appendChild(marker);
       el.appendChild(document.createTextNode(defText));
       // Use line decoration + widget for stable viewport height
-      decos.push(Decoration.line({
-        attributes: { style: "padding:0;margin:0;min-height:0;" }
-      }).range(range.from));
+      decos.push(
+        Decoration.line({
+          attributes: { style: "padding:0;margin:0;min-height:0;" },
+        }).range(range.from),
+      );
       const fnDefKey = `fndef:${range.from}-${range.to}:${def.identifier}:${range.source}`;
       decos.push(
         Decoration.replace({
           widget: createWidget(el, false, undefined, fnDefKey),
-        }).range(range.from, range.to)
+        }).range(range.from, range.to),
       );
     } else {
       if (range.node.type === "heading" || range.node.type === "table") {
@@ -1161,22 +1451,39 @@ function buildDecorations(
       // look broken when the user was editing the line.
       const inlineStyle = getInlineMarkerStyle(range.node.type, range.source);
       if (inlineStyle && !config.renderers[range.node.type]) {
+        if (range.node.type === "delete") {
+          deleteCoveredRanges.push([range.from, range.to]);
+        }
         const { openLen, closeLen, style, attrs } = inlineStyle;
-        const cursorOnLine = selectionOnSameLine(range.from, range.to, doc, selection);
+        const cursorOnLine = selectionOnSameLine(
+          range.from,
+          range.to,
+          doc,
+          selection,
+        );
         const textFrom = range.from + openLen;
         const textTo = range.to - closeLen;
 
         if (!cursorOnLine) {
           if (openLen > 0) {
-            decos.push(Decoration.replace({}).range(range.from, range.from + openLen));
+            decos.push(
+              Decoration.replace({}).range(range.from, range.from + openLen),
+            );
           }
           if (closeLen > 0) {
-            decos.push(Decoration.replace({}).range(range.to - closeLen, range.to));
+            decos.push(
+              Decoration.replace({}).range(range.to - closeLen, range.to),
+            );
           }
         }
 
         if (textTo > textFrom) {
-          decos.push(Decoration.mark({ attributes: { style, ...attrs } }).range(textFrom, textTo));
+          decos.push(
+            Decoration.mark({ attributes: { style, ...attrs } }).range(
+              textFrom,
+              textTo,
+            ),
+          );
         }
       } else {
         // Block fallback for thematicBreak: always render as widget.
@@ -1194,14 +1501,53 @@ function buildDecorations(
         decos.push(
           Decoration.replace({
             widget: createWidget(
-              () => renderLivePreviewNode(range.node, range.source, config.renderers, range.from, range.to),
+              () =>
+                renderLivePreviewNode(
+                  range.node,
+                  range.source,
+                  config.renderers,
+                  range.from,
+                  range.to,
+                ),
               isBlock,
               heightHint,
               blockKey,
             ),
-            block: isBlock
-          }).range(range.from, range.to)
+            block: isBlock,
+          }).range(range.from, range.to),
         );
+      }
+    }
+  }
+
+  {
+    const coveredSet = new Set<string>();
+    for (const [cf, ct] of deleteCoveredRanges) {
+      coveredSet.add(`${cf}:${ct}`);
+    }
+    const strikethroughRe = /~~([^~]+)~~/g;
+    let m: RegExpExecArray | null;
+    while ((m = strikethroughRe.exec(doc)) !== null) {
+      const matchFrom = m.index;
+      const matchTo = m.index + m[0].length;
+      const key = `${matchFrom}:${matchTo}`;
+      if (coveredSet.has(key)) continue;
+      const cursorOnLine = selectionOnSameLine(
+        matchFrom,
+        matchTo,
+        doc,
+        selection,
+      );
+      if (!cursorOnLine) {
+        decos.push(Decoration.replace({}).range(matchFrom, matchFrom + 2));
+      }
+      decos.push(
+        Decoration.mark({
+          attributes: { style: "text-decoration:line-through" },
+        }).range(matchFrom + 2, matchTo - 2),
+      );
+      if (!cursorOnLine) {
+        decos.push(Decoration.replace({}).range(matchTo - 2, matchTo));
       }
     }
   }
@@ -1218,7 +1564,8 @@ function buildDecorations(
     if (total > 5 || parseMs > 2) {
       // eslint-disable-next-line no-console
       console.log(
-        "%c[perf]", "color:#0aa;font-weight:bold",
+        "%c[perf]",
+        "color:#0aa;font-weight:bold",
         "buildDecorations",
         `total=${total.toFixed(1)}ms`,
         {
@@ -1238,7 +1585,7 @@ function buildDecorations(
 
 export function createLivePreviewExtension(
   config: boolean | LivePreviewConfig | undefined,
-  localeLabels?: LivePreviewLabels
+  localeLabels?: LivePreviewLabels,
 ): Extension[] {
   const normalized = normalizeConfig(config);
   if (!normalized.enabled) return [];
@@ -1253,13 +1600,22 @@ export function createLivePreviewExtension(
   // Cursor-only updates pass this through as ctx so we skip the Lezer→mdast
   // walk and the hljs run when the source hasn't changed. Edits replace the
   // cache via the docChanged branch below.
-  let lastBuilt: { doc: string; ast: Root; codeTokens: CodeHighlightToken[] } | null = null;
+  let lastBuilt: {
+    doc: string;
+    ast: Root;
+    codeTokens: CodeHighlightToken[];
+  } | null = null;
 
-  function build(state: EditorState, selection: readonly SelectionRange[], reuseCache: boolean) {
+  function build(
+    state: EditorState,
+    selection: readonly SelectionRange[],
+    reuseCache: boolean,
+  ) {
     const docStr = state.doc.toString();
-    const ctx: BuildContext = reuseCache && lastBuilt && lastBuilt.doc === docStr
-      ? { ast: lastBuilt.ast, codeTokens: lastBuilt.codeTokens }
-      : {};
+    const ctx: BuildContext =
+      reuseCache && lastBuilt && lastBuilt.doc === docStr
+        ? { ast: lastBuilt.ast, codeTokens: lastBuilt.codeTokens }
+        : {};
     const out = buildDecorations(state, selection, normalized, viewRef, ctx);
     lastBuilt = { doc: docStr, ast: out.ast, codeTokens: out.codeTokens };
     return out.decos;
@@ -1288,7 +1644,7 @@ export function createLivePreviewExtension(
     },
     provide(field) {
       return EditorView.decorations.from(field);
-    }
+    },
   });
 
   const viewCapture = ViewPlugin.fromClass(
@@ -1304,7 +1660,7 @@ export function createLivePreviewExtension(
       destroy(): void {
         if (viewRef.current === this.view) viewRef.current = null;
       }
-    }
+    },
   );
 
   // Click to navigate links; arrow-key into link to edit
@@ -1325,7 +1681,8 @@ export function createLivePreviewExtension(
         const headingRe = /^(#{1,6})\s+(.+)$/gm;
         let m: RegExpExecArray | null;
         while ((m = headingRe.exec(doc)) !== null) {
-          const headingSlug = m[2].trim()
+          const headingSlug = m[2]
+            .trim()
             .toLowerCase()
             .replace(/[^\p{L}\p{N}\s-]/gu, "")
             .trim()
@@ -1335,7 +1692,10 @@ export function createLivePreviewExtension(
           if (headingSlug === targetSlug) {
             view.dispatch({
               selection: { anchor: m.index },
-              effects: EditorView.scrollIntoView(m.index, { y: "start", yMargin: 20 })
+              effects: EditorView.scrollIntoView(m.index, {
+                y: "start",
+                yMargin: 20,
+              }),
             });
             view.focus();
             return true;
@@ -1347,8 +1707,64 @@ export function createLivePreviewExtension(
       // External links: open in new tab
       window.open(url, "_blank", "noopener");
       return true;
-    }
+    },
   });
 
-  return [field, viewCapture, linkHandler, createLivePreviewDiagnostics()];
+  const listMarkerGuard = Prec.highest(
+    EditorView.domEventHandlers({
+      mousedown(event, view) {
+        const me = event as MouseEvent;
+        const pos = view.posAtCoords({ x: me.clientX, y: me.clientY });
+        if (pos == null) return false;
+        for (const [from, to] of listMarkerRanges) {
+          if (pos >= from && pos < to) {
+            event.preventDefault();
+            view.dispatch({
+              selection: { anchor: Math.min(to, view.state.doc.length) },
+            });
+            view.focus();
+            return true;
+          }
+        }
+        return false;
+      },
+      mouseup(_event, view) {
+        const sel = view.state.selection.main;
+        if (sel.empty) return false;
+        let newAnchor = sel.anchor;
+        let newHead = sel.head;
+        let changed = false;
+        for (const [from, to] of listMarkerRanges) {
+          if (newAnchor >= from && newAnchor < to) {
+            newAnchor = to;
+            changed = true;
+          }
+          if (newHead >= from && newHead < to) {
+            newHead = to;
+            changed = true;
+          }
+        }
+        if (changed && newAnchor !== newHead) {
+          requestAnimationFrame(() => {
+            const docLen = view.state.doc.length;
+            view.dispatch({
+              selection: {
+                anchor: Math.min(newAnchor, docLen),
+                head: Math.min(newHead, docLen),
+              },
+            });
+          });
+        }
+        return false;
+      },
+    }),
+  );
+
+  return [
+    field,
+    viewCapture,
+    listMarkerGuard,
+    linkHandler,
+    createLivePreviewDiagnostics(),
+  ];
 }

--- a/packages/core/test/live-preview-ranges.test.ts
+++ b/packages/core/test/live-preview-ranges.test.ts
@@ -13,33 +13,38 @@ function parse(markdown: string): Root {
 
 describe("live preview ranges", () => {
   it("collects stable ranges for block and image previews", () => {
-    const doc = "Intro\n\n# Heading\n\n> Quote\n\n![Alt](https://example.com/image.png)";
-    const ranges = collectLivePreviewRanges(
-      parse(doc),
-      doc,
-      [EditorSelection.cursor(0)]
-    );
+    const doc =
+      "Intro\n\n# Heading\n\n> Quote\n\n![Alt](https://example.com/image.png)";
+    const ranges = collectLivePreviewRanges(parse(doc), doc, [
+      EditorSelection.cursor(0),
+    ]);
 
-    expect(ranges.map((range) => range.node.type)).toEqual(["heading", "blockquote", "image"]);
+    expect(ranges.map((range) => range.node.type)).toEqual([
+      "heading",
+      "blockquote",
+      "image",
+    ]);
     expect(ranges.at(-1)?.source).toBe("![Alt](https://example.com/image.png)");
   });
 
   it("always emits inline ranges regardless of cursor position", () => {
     const doc = "Text **bold** *italic*\n\nother line";
     // Inline ranges are always emitted; buildDecorations decides styling
-    const rangesSameLine = collectLivePreviewRanges(
-      parse(doc),
-      doc,
-      [EditorSelection.cursor(8)]
-    );
-    expect(rangesSameLine.map((r) => r.node.type)).toEqual(["strong", "emphasis"]);
+    const rangesSameLine = collectLivePreviewRanges(parse(doc), doc, [
+      EditorSelection.cursor(8),
+    ]);
+    expect(rangesSameLine.map((r) => r.node.type)).toEqual([
+      "strong",
+      "emphasis",
+    ]);
 
-    const rangesDiffLine = collectLivePreviewRanges(
-      parse(doc),
-      doc,
-      [EditorSelection.cursor(doc.length)]
-    );
-    expect(rangesDiffLine.map((r) => r.node.type)).toEqual(["strong", "emphasis"]);
+    const rangesDiffLine = collectLivePreviewRanges(parse(doc), doc, [
+      EditorSelection.cursor(doc.length),
+    ]);
+    expect(rangesDiffLine.map((r) => r.node.type)).toEqual([
+      "strong",
+      "emphasis",
+    ]);
   });
 
   it("does not emit inline ranges inside table widgets", () => {
@@ -51,12 +56,32 @@ describe("live preview ranges", () => {
       "## After",
     ].join("\n");
 
-    const ranges = collectLivePreviewRanges(
-      lezerStringToMdast(doc),
-      doc,
-      [EditorSelection.cursor(doc.length)]
-    );
+    const ranges = collectLivePreviewRanges(lezerStringToMdast(doc), doc, [
+      EditorSelection.cursor(doc.length),
+    ]);
 
-    expect(ranges.map((range) => range.node.type)).toEqual(["table", "heading"]);
+    expect(ranges.map((range) => range.node.type)).toEqual([
+      "table",
+      "heading",
+    ]);
+  });
+
+  it("parses span and u in list items as inline HTML (not HTML block)", () => {
+    const doc =
+      "1. <span style='color:red'>text</span> more\n2. <u>under</u> line";
+    const ast = lezerStringToMdast(doc);
+    const rootTypes = ast.children.map((c) => c.type);
+    expect(rootTypes).toContain("list");
+
+    const list = ast.children.find((c) => c.type === "list") as {
+      children: { children: { type: string; inline?: boolean }[] }[];
+    };
+    expect(list?.children?.length).toBe(2);
+
+    for (const item of list.children) {
+      const child = item.children?.[0] as { type: string; inline?: boolean };
+      expect(child?.type).toBe("html");
+      expect(child?.inline).toBe(true);
+    }
   });
 });

--- a/packages/core/test/live-preview.test.ts
+++ b/packages/core/test/live-preview.test.ts
@@ -12,8 +12,9 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "Text **bold** *italic* `code` [link](https://example.com)\n\nend",
-      livePreview: true
+      initialValue:
+        "Text **bold** *italic* `code` [link](https://example.com)\n\nend",
+      livePreview: true,
     });
 
     // Move cursor to a different line
@@ -35,7 +36,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold**\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     // Cursor on different line → markers hidden
@@ -54,7 +55,7 @@ describe("live preview", () => {
       container,
       initialValue: "Text ~~deleted~~\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -70,7 +71,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold**\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setDocument("Text **changed**\n\nend");
@@ -89,7 +90,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text ***bold italic***\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -106,7 +107,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **_mixed_**\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -118,6 +119,43 @@ describe("live preview", () => {
     editor.destroy();
   });
 
+  it("renders strikethrough wrapping bold with both styles", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "Text ~~**bold**~~\n\nend",
+      livePreview: true,
+      plugins: [createGfmPreset()],
+    });
+
+    editor.setSelection(editor.getDocument().length);
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("bold");
+    expect(text).not.toContain("~~");
+    expect(text).not.toContain("**");
+    editor.destroy();
+  });
+
+  it("renders bold wrapping strikethrough (overlapping markers) with both styles", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**a~~b**~~\n\nend",
+      livePreview: true,
+      plugins: [createGfmPreset()],
+    });
+
+    editor.setSelection(editor.getDocument().length);
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("a");
+    expect(text).toContain("b");
+    expect(text).not.toContain("**");
+    expect(text).not.toContain("~~");
+    editor.destroy();
+  });
+
   // ── Link Ctrl+Click ──
 
   it("adds data-link-url attribute to mark-decorated links", () => {
@@ -125,7 +163,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Click [here](https://example.com)\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -140,8 +178,9 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "## 目录\n\n1. [项目概述](#项目概述)\n2. [快速开始](#快速开始)\n3. [主要功能](#主要功能)\n\nend",
-      livePreview: true
+      initialValue:
+        "## 目录\n\n1. [项目概述](#项目概述)\n2. [快速开始](#快速开始)\n3. [主要功能](#主要功能)\n\nend",
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -159,7 +198,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Click [here](https://example.com) now\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -178,10 +217,12 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Intro\n\n# Heading",
-      livePreview: true
+      livePreview: true,
     });
 
-    expect(container.querySelector("[data-heading-level='1']")?.textContent).toBe("Heading");
+    expect(
+      container.querySelector("[data-heading-level='1']")?.textContent,
+    ).toBe("Heading");
     editor.destroy();
   });
 
@@ -192,15 +233,17 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Intro\n\n> Quote\n\n![Alt](https://example.com/image.png)",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.querySelector("blockquote")).toBeNull();
     expect(container.textContent).toContain("Quote");
     expect(container.textContent).not.toContain("> Quote");
-    expect(container.querySelector("[data-live-preview-image]")?.getAttribute("data-live-preview-image")).toBe(
-      "https://example.com/image.png"
-    );
+    expect(
+      container
+        .querySelector("[data-live-preview-image]")
+        ?.getAttribute("data-live-preview-image"),
+    ).toBe("https://example.com/image.png");
 
     editor.setSelection(9);
     expect(container.textContent).toContain("> Quote");
@@ -212,7 +255,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n---\n\nMore",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.querySelector("hr")).not.toBeNull();
@@ -226,7 +269,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconsole.log(1)\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.textContent).toContain("console.log(1)");
@@ -241,7 +284,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconsole.log(1)\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     const textBefore = container.textContent ?? "";
@@ -260,12 +303,13 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```py\nx = 1\ny = 2\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     const codeLines = Array.from(container.querySelectorAll(".cm-line")).filter(
-      (line) => (line as HTMLElement).style.background === "rgb(246, 248, 250)"
-        || (line as HTMLElement).getAttribute("style")?.includes("background")
+      (line) =>
+        (line as HTMLElement).style.background === "rgb(246, 248, 250)" ||
+        (line as HTMLElement).getAttribute("style")?.includes("background"),
     );
     expect(codeLines.length).toBeGreaterThanOrEqual(2);
     editor.destroy();
@@ -278,15 +322,16 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n    indented code\n    second line",
-      livePreview: true
+      livePreview: true,
     });
 
     const text = container.textContent ?? "";
     expect(text).toContain("indented code");
     expect(text).toContain("second line");
     const codeLines = Array.from(container.querySelectorAll(".cm-line")).filter(
-      (line) => (line as HTMLElement).getAttribute("style")?.includes("background") ||
-        (line as HTMLElement).innerHTML.includes("monospace")
+      (line) =>
+        (line as HTMLElement).getAttribute("style")?.includes("background") ||
+        (line as HTMLElement).innerHTML.includes("monospace"),
     );
     expect(codeLines.length).toBeGreaterThanOrEqual(2);
     editor.destroy();
@@ -300,7 +345,7 @@ describe("live preview", () => {
       container,
       initialValue: "Text with footnote[^1]\n\n[^1]: Definition text",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const sup = container.querySelector("sup");
@@ -317,7 +362,7 @@ describe("live preview", () => {
       container,
       initialValue: "Visit https://example.com today\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -336,7 +381,7 @@ describe("live preview", () => {
       container,
       initialValue: "Text\n\n| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const table = container.querySelector("table");
@@ -358,9 +403,12 @@ describe("live preview", () => {
       plugins: [createGfmPreset()],
     });
 
-    const links = container.querySelectorAll<HTMLAnchorElement>("table a[href]");
+    const links =
+      container.querySelectorAll<HTMLAnchorElement>("table a[href]");
     expect(links.length).toBe(2);
-    expect(links[0].getAttribute("href")).toBe("https://linkedin.com/in/sonali");
+    expect(links[0].getAttribute("href")).toBe(
+      "https://linkedin.com/in/sonali",
+    );
     expect(links[0].textContent).toBe("LinkedIn");
     expect(links[1].getAttribute("href")).toBe("https://twitter.com/RWong");
     expect(links[1].textContent).toBe("@RWong");
@@ -377,23 +425,31 @@ describe("live preview", () => {
       plugins: [createGfmPreset()],
     });
 
-    const imgs = Array.from(container.querySelectorAll<HTMLImageElement>("table img"));
+    const imgs = Array.from(
+      container.querySelectorAll<HTMLImageElement>("table img"),
+    );
     expect(imgs.length).toBe(3);
 
     // First row, first column: media-only standalone image — width:100%
     // so it grows with the column.
-    const mediaOnlyStandalone = imgs.find((i) => i.getAttribute("src") === "https://example.com/a.png");
+    const mediaOnlyStandalone = imgs.find(
+      (i) => i.getAttribute("src") === "https://example.com/a.png",
+    );
     expect(mediaOnlyStandalone?.style.width).toBe("100%");
     expect(mediaOnlyStandalone?.style.maxHeight).toBe("240px");
 
     // First row, second column: inline image alongside text — stays
     // small (capped at the existing 1.6em line-height + 160px width).
-    const inlineImg = imgs.find((i) => i.getAttribute("src") === "https://example.com/i.png");
+    const inlineImg = imgs.find(
+      (i) => i.getAttribute("src") === "https://example.com/i.png",
+    );
     expect(inlineImg?.style.maxHeight).toBe("1.6em");
     expect(inlineImg?.style.maxWidth).toBe("160px");
 
     // Second row, first column: image-in-link is also media-only.
-    const linkWrapped = imgs.find((i) => i.getAttribute("src") === "https://example.com/l.png");
+    const linkWrapped = imgs.find(
+      (i) => i.getAttribute("src") === "https://example.com/l.png",
+    );
     expect(linkWrapped?.style.width).toBe("100%");
     // Anchor parent should switch to block so the image fills the cell
     // without inline-baseline whitespace eating space.
@@ -470,19 +526,29 @@ describe("live preview", () => {
       plugins: [createGfmPreset()],
     });
 
-    const handle = container.querySelector(".nexus-col-resize") as HTMLElement | null;
+    const handle = container.querySelector(
+      ".nexus-col-resize",
+    ) as HTMLElement | null;
     expect(handle).not.toBeNull();
 
     // Simulate a drag: mousedown on handle, mousemove on document,
     // mouseup to commit. The DOM should pick up a <colgroup> + the
     // table should switch to fixed layout afterwards.
     const startX = 200;
-    handle?.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true, cancelable: true, button: 0, clientX: startX,
-    }));
-    document.dispatchEvent(new MouseEvent("mousemove", {
-      bubbles: true, clientX: startX + 60,
-    }));
+    handle?.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: startX,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: startX + 60,
+      }),
+    );
     document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
     const table = container.querySelector("table") as HTMLTableElement | null;
@@ -499,13 +565,16 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "| A | B | C |\n|---|---|---|\n| 1 | 2 |\n| 3 | 4 | 5 | 6 |",
+      initialValue:
+        "| A | B | C |\n|---|---|---|\n| 1 | 2 |\n| 3 | 4 | 5 | 6 |",
       livePreview: true,
       plugins: [createGfmPreset()],
     });
 
     const rows = Array.from(container.querySelectorAll("tr")).map((row) =>
-      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent)
+      Array.from(row.querySelectorAll(".nexus-cell")).map(
+        (cell) => cell.textContent,
+      ),
     );
     // Every body row should have the same cell count as the widest row (4).
     // Header padded with one empty extra column; the short row padded too.
@@ -521,11 +590,13 @@ describe("live preview", () => {
       container,
       initialValue: "| A |  | C |\n| --- | --- | --- |\n| 1 |  | 3 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const rows = Array.from(container.querySelectorAll("tr")).map((row) =>
-      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent)
+      Array.from(row.querySelectorAll(".nexus-cell")).map(
+        (cell) => cell.textContent,
+      ),
     );
     expect(rows[1]).toEqual(["A", "", "C"]);
     expect(rows[2]).toEqual(["1", "", "3"]);
@@ -538,17 +609,19 @@ describe("live preview", () => {
       container,
       initialValue: "| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const addColumn = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.title === "Add column"
+      (button) => button.title === "Add column",
     );
     expect(addColumn).not.toBeUndefined();
     addColumn?.click();
 
     const rows = Array.from(container.querySelectorAll("tr")).map((row) =>
-      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent)
+      Array.from(row.querySelectorAll(".nexus-cell")).map(
+        (cell) => cell.textContent,
+      ),
     );
     expect(rows[1]).toEqual(["A", "B", ""]);
     expect(rows[2]).toEqual(["1", "2", ""]);
@@ -566,18 +639,20 @@ describe("live preview", () => {
         deleteRow: "删除行",
         deleteColumn: "删除列",
         insertRowBelow: "在下方插入行",
-        insertColumnAfter: "在右侧插入列"
+        insertColumnAfter: "在右侧插入列",
       },
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
-    const dataCell = container.querySelectorAll("tr")[2]?.querySelector(".nexus-cell");
+    const dataCell = container
+      .querySelectorAll("tr")[2]
+      ?.querySelector(".nexus-cell");
     expect(dataCell).not.toBeNull();
     const event = new MouseEvent("contextmenu", {
       bubbles: true,
       cancelable: true,
       clientX: 32,
-      clientY: 40
+      clientY: 40,
     });
     dataCell?.dispatchEvent(event);
 
@@ -609,12 +684,14 @@ describe("live preview", () => {
             element.setAttribute("data-heading", "custom");
             element.textContent = text.toUpperCase();
             return element;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
-    expect(container.querySelector("[data-heading='custom']")?.textContent).toBe("HEADING");
+    expect(
+      container.querySelector("[data-heading='custom']")?.textContent,
+    ).toBe("HEADING");
     editor.destroy();
   });
 
@@ -629,15 +706,17 @@ describe("live preview", () => {
             const element = document.createElement("span");
             element.setAttribute("data-source", source);
             return element;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
     // Cursor on first line, away from the bold
     editor.setSelection(0);
 
-    expect(container.querySelector("[data-source]")?.getAttribute("data-source")).toBe("**bold**");
+    expect(
+      container.querySelector("[data-source]")?.getAttribute("data-source"),
+    ).toBe("**bold**");
     editor.destroy();
   });
 
@@ -645,7 +724,8 @@ describe("live preview", () => {
 
   it("renders embedded HTML blocks via innerHTML when cursor is outside", () => {
     const container = document.createElement("div");
-    const html = '<div class="demo"><strong>Bold</strong> and <em>italic</em></div>';
+    const html =
+      '<div class="demo"><strong>Bold</strong> and <em>italic</em></div>';
     const editor = createEditor({
       container,
       initialValue: `Intro\n\n${html}\n\nend`,
@@ -734,7 +814,9 @@ describe("live preview", () => {
     // enter edit mode. mousedown is the trigger (fires before any inner
     // click handler).
     const inner = wrapper?.querySelector("strong") ?? wrapper!;
-    inner.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    inner.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
 
     expect(container.querySelector(".demo")).toBeNull();
     expect(container.textContent).toContain("<div class=");
@@ -752,7 +834,9 @@ describe("live preview", () => {
     });
 
     editor.setSelection(editor.getDocument().length);
-    const badge = container.querySelector(".nexus-alert-label") as HTMLElement | null;
+    const badge = container.querySelector(
+      ".nexus-alert-label",
+    ) as HTMLElement | null;
     expect(badge).not.toBeNull();
     expect(badge?.textContent ?? "").toContain("Note");
     // The literal `[!NOTE]` link decoration should be suppressed — we
@@ -794,10 +878,14 @@ describe("live preview", () => {
     });
 
     editor.setSelection(0);
-    const callout = container.querySelector(".nexus-callout") as HTMLElement | null;
+    const callout = container.querySelector(
+      ".nexus-callout",
+    ) as HTMLElement | null;
     expect(callout).not.toBeNull();
     expect(callout?.getAttribute("data-callout-type")).toBe("info");
-    expect(callout?.querySelector(".nexus-callout-body")?.textContent).toContain("body text");
+    expect(
+      callout?.querySelector(".nexus-callout-body")?.textContent,
+    ).toContain("body text");
     editor.destroy();
   });
 
@@ -818,7 +906,7 @@ describe("live preview", () => {
   it("clicking <summary> or <a href> inside an HTML block preserves native behaviour (no edit-mode trigger)", () => {
     const container = document.createElement("div");
     const html =
-      '<details><summary>Toggle</summary><p>Hidden text</p></details>' +
+      "<details><summary>Toggle</summary><p>Hidden text</p></details>" +
       '<p><a href="https://example.com" data-test="link">Link</a></p>';
     const editor = createEditor({
       container,
@@ -831,20 +919,28 @@ describe("live preview", () => {
     expect(summary).not.toBeNull();
 
     // Clicking summary must NOT enter edit mode — the widget stays mounted.
-    summary?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    summary?.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
     expect(container.querySelector(".nexus-html-block")).not.toBeNull();
     expect(container.querySelector("summary")).not.toBeNull();
 
     // Clicking a link inside the block also preserves native behaviour.
-    const link = container.querySelector('a[data-test="link"]') as HTMLElement | null;
+    const link = container.querySelector(
+      'a[data-test="link"]',
+    ) as HTMLElement | null;
     expect(link).not.toBeNull();
-    link?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    link?.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
     expect(container.querySelector(".nexus-html-block")).not.toBeNull();
 
     // Clicking the surrounding wrapper (not on an interactive element)
     // DOES enter edit mode.
     const wrapper = container.querySelector<HTMLElement>(".nexus-html-block");
-    wrapper?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    wrapper?.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
     expect(container.querySelector(".nexus-html-block")).toBeNull();
     editor.destroy();
   });
@@ -853,7 +949,7 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const html =
       '<div class="hostile" onclick="alert(1)">' +
-      '<script>window.evil=true;</script>safe content</div>';
+      "<script>window.evil=true;</script>safe content</div>";
     const editor = createEditor({
       container,
       initialValue: `Intro\n\n${html}\n\nend`,
@@ -878,9 +974,10 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "Intro\n\n1. first\n   - nested a\n   - nested b\n2. second\n3. third\n\nend",
+      initialValue:
+        "Intro\n\n1. first\n   - nested a\n   - nested b\n2. second\n3. third\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -902,11 +999,13 @@ describe("live preview", () => {
       container,
       initialValue: "Intro\n\n- [x] done item\n- [ ] open item\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
-    const inputs = container.querySelectorAll<HTMLInputElement>("input[type=checkbox]");
+    const inputs = container.querySelectorAll<HTMLInputElement>(
+      "input[type=checkbox]",
+    );
     expect(inputs.length).toBe(2);
     expect(inputs[0].checked).toBe(true);
     expect(inputs[1].checked).toBe(false);
@@ -920,7 +1019,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold** here\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     // Cursor on the line with bold — markers should remain visible but
@@ -928,8 +1027,12 @@ describe("live preview", () => {
     editor.setSelection(8);
     const text = container.textContent ?? "";
     expect(text).toContain("**bold**");
-    const boldSpan = Array.from(container.querySelectorAll<HTMLElement>("span")).find(
-      (el) => el.textContent === "bold" && /font-weight\s*:\s*bold/i.test(el.getAttribute("style") ?? "")
+    const boldSpan = Array.from(
+      container.querySelectorAll<HTMLElement>("span"),
+    ).find(
+      (el) =>
+        el.textContent === "bold" &&
+        /font-weight\s*:\s*bold/i.test(el.getAttribute("style") ?? ""),
     );
     expect(boldSpan).not.toBeUndefined();
     editor.destroy();
@@ -946,9 +1049,9 @@ describe("live preview", () => {
             const element = document.createElement("span");
             element.textContent = text.toUpperCase();
             return element;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
     editor.setSelection(0);
@@ -959,6 +1062,70 @@ describe("live preview", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("italic");
     expect(text).not.toContain("*italic*");
+    editor.destroy();
+  });
+
+  // ── Inline HTML in list items ──
+  it("renders span and u tags as inline within list items (no line break)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue:
+        "1. <span style='color:red'>text</span> more\n2. <u>under</u> line\n\nend",
+      livePreview: true,
+    });
+    editor.setSelection(editor.getDocument().length);
+
+    // Should NOT render as block-level HTML (no nexus-html-block wrapper)
+    expect(container.querySelectorAll(".nexus-html-block").length).toBe(0);
+
+    // Both list items should be present
+    const text = container.textContent ?? "";
+    expect(text).toContain("text");
+    expect(text).toContain("under");
+
+    editor.destroy();
+  });
+
+  // ── List marker unselectable ──
+  it("renders list bullets with user-select:none to prevent text selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- first\n- second\n\nend",
+      livePreview: true,
+    });
+    editor.setSelection(editor.getDocument().length);
+
+    const bullets = container.querySelectorAll<HTMLElement>(
+      ".cm-content span[style*='user-select']",
+    );
+    expect(bullets.length).toBeGreaterThanOrEqual(2);
+
+    for (const bullet of Array.from(bullets)) {
+      const style = bullet.style.userSelect || bullet.style.webkitUserSelect;
+      expect(style).toBe("none");
+    }
+
+    editor.destroy();
+  });
+
+  it("prevents cursor from landing on list marker on mousedown", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- first\n- second\n\nend",
+      livePreview: true,
+    });
+    editor.setSelection(editor.getDocument().length);
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("first");
+    expect(text).toContain("second");
+    expect(text).toContain("\u2022 ");
+    expect(text).not.toContain("- first");
+    expect(text).not.toContain("- second");
+
     editor.destroy();
   });
 });

--- a/packages/plugin-toolbar/src/color-decoration.ts
+++ b/packages/plugin-toolbar/src/color-decoration.ts
@@ -18,8 +18,7 @@ import {
 } from "@codemirror/view";
 
 // Matches <span style="color:...">...</span> and <mark style="background:...">...</mark>
-const COLOR_RE =
-  /<span\s+style="color:\s*([^"]+)">([\s\S]*?)<\/span>/g;
+const COLOR_RE = /<span\s+style="color:\s*([^"]+)">([\s\S]*?)<\/span>/g;
 const HIGHLIGHT_RE =
   /<mark\s+style="background:\s*([^"]+)">([\s\S]*?)<\/mark>/g;
 
@@ -30,7 +29,9 @@ class HiddenTagWidget extends WidgetType {
     el.style.display = "none";
     return el;
   }
-  ignoreEvent(): boolean { return false; }
+  ignoreEvent(): boolean {
+    return false;
+  }
 }
 
 const hiddenWidget = Decoration.replace({ widget: new HiddenTagWidget() });
@@ -98,7 +99,8 @@ function buildDecorations(view: EditorView): DecorationSet {
   // Check if the cursor is inside any color range — if so, show raw text for that range
   const cursorPos = view.state.selection.main.head;
 
-  const decorations: Array<{ from: number; to: number; value: Decoration }> = [];
+  const decorations: Array<{ from: number; to: number; value: Decoration }> =
+    [];
 
   for (const r of ranges) {
     // If cursor is inside this range, skip decorations so user can edit the raw HTML
@@ -111,7 +113,11 @@ function buildDecorations(view: EditorView): DecorationSet {
     const markDeco =
       r.kind === "color"
         ? Decoration.mark({ attributes: { style: `color:${r.color}` } })
-        : Decoration.mark({ attributes: { style: `background:${r.color};border-radius:2px;padding:0 1px` } });
+        : Decoration.mark({
+            attributes: {
+              style: `background:${r.color};border-radius:2px;padding:0 1px`,
+            },
+          });
     decorations.push({ from: r.innerFrom, to: r.innerTo, value: markDeco });
 
     // Hide closing tag
@@ -119,7 +125,9 @@ function buildDecorations(view: EditorView): DecorationSet {
   }
 
   // Must be sorted by from position, then by startSide
-  decorations.sort((a, b) => a.from - b.from || a.value.startSide - b.value.startSide);
+  decorations.sort(
+    (a, b) => a.from - b.from || a.value.startSide - b.value.startSide,
+  );
   return Decoration.set(decorations.map((d) => d.value.range(d.from, d.to)));
 }
 

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -1,18 +1,187 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
+export function getSelectionLineRange(
+  doc: string,
+  anchor: number,
+  head: number,
+): {
+  rangeStart: number;
+  rangeEnd: number;
+  lines: string[];
+  lineStarts: number[];
+} {
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
 
-/** Get the current line containing the anchor position. */
-function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineEnd: number; line: string } {
+  const rangeStart = doc.lastIndexOf("\n", from - 1) + 1;
+  const nl = doc.indexOf("\n", to);
+  const rangeEnd = nl === -1 ? doc.length : nl;
+
+  const lines: string[] = [];
+  const lineStarts: number[] = [];
+  let pos = rangeStart;
+  let remaining = doc.slice(rangeStart, rangeEnd);
+
+  while (true) {
+    const nlIdx = remaining.indexOf("\n");
+    if (nlIdx === -1) {
+      lines.push(remaining);
+      lineStarts.push(pos);
+      break;
+    }
+    lines.push(remaining.slice(0, nlIdx));
+    lineStarts.push(pos);
+    pos += nlIdx + 1;
+    remaining = remaining.slice(nlIdx + 1);
+  }
+
+  return { rangeStart, rangeEnd, lines, lineStarts };
+}
+
+export const OL_RE = /^(\s*)(\d+[.)]\s)/;
+export const UL_RE = /^(\s*)([-*+]\s)/;
+
+function isOrderedListItem(line: string): boolean {
+  return OL_RE.test(line);
+}
+
+function isUnorderedListItem(line: string): boolean {
+  return UL_RE.test(line);
+}
+
+function removeListMarker(line: string): string {
+  const olMatch = line.match(OL_RE);
+  if (olMatch)
+    return olMatch[1] + line.slice(olMatch[1].length + olMatch[2].length);
+  const ulMatch = line.match(UL_RE);
+  if (ulMatch)
+    return ulMatch[1] + line.slice(ulMatch[1].length + ulMatch[2].length);
+  return line;
+}
+
+function makeOrderedListItem(line: string): string {
+  const olMatch = line.match(OL_RE);
+  if (olMatch) return line;
+  const ulMatch = line.match(UL_RE);
+  if (ulMatch)
+    return (
+      ulMatch[1] + "1. " + line.slice(ulMatch[1].length + ulMatch[2].length)
+    );
+  return "1. " + line;
+}
+
+function makeUnorderedListItem(line: string): string {
+  const ulMatch = line.match(UL_RE);
+  if (ulMatch) return line;
+  const olMatch = line.match(OL_RE);
+  if (olMatch)
+    return (
+      olMatch[1] + "- " + line.slice(olMatch[1].length + olMatch[2].length)
+    );
+  return "- " + line;
+}
+
+export function extractLineContent(
+  line: string,
+  marker: string,
+): { prefix: string; content: string } {
+  const olMatch = line.match(OL_RE);
+  if (olMatch) {
+    const prefix = olMatch[1] + olMatch[2];
+    return { prefix, content: line.slice(prefix.length) };
+  }
+  const ulMatch = line.match(UL_RE);
+  if (ulMatch) {
+    const prefix = ulMatch[1] + ulMatch[2];
+    return { prefix, content: line.slice(prefix.length) };
+  }
+  return { prefix: "", content: line };
+}
+
+export function isLineWrapped(content: string, marker: string): boolean {
+  if (content.length < 2 * marker.length) return false;
+  if (!content.startsWith(marker) || !content.endsWith(marker)) return false;
+  if (marker.length === 1 && content.length > 2) {
+    const afterOpen = content[marker.length];
+    const beforeClose = content[content.length - marker.length - 1];
+    if (afterOpen === marker || beforeClose === marker) return false;
+  }
+  return true;
+}
+
+export function unwrapLine(content: string, marker: string): string {
+  return content.slice(marker.length, content.length - marker.length);
+}
+
+export function stripAllMarkers(content: string, marker: string): string {
+  if (marker.length === 1) {
+    const double = marker + marker;
+    if (!content.includes(double)) {
+      return content.split(marker).join("");
+    }
+    const parts = content.split(double);
+    for (let i = 0; i < parts.length; i++) {
+      parts[i] = parts[i].split(marker).join("");
+    }
+    return parts.join(double);
+  }
+  return content.split(marker).join("");
+}
+
+export function countStarsLeft(doc: string, pos: number): number {
+  let count = 0;
+  while (pos - count - 1 >= 0 && doc[pos - count - 1] === "*") {
+    count++;
+  }
+  return count;
+}
+
+export function countStarsRight(doc: string, pos: number): number {
+  let count = 0;
+  while (pos + count < doc.length && doc[pos + count] === "*") {
+    count++;
+  }
+  return count;
+}
+
+export function toggleBlockquote(editor: EditorAPI): boolean {
+  const doc = editor.getDocument();
+  const { anchor, head } = editor.getSelection();
+  const prefix = "> ";
+  const selected = doc.slice(Math.min(anchor, head), Math.max(anchor, head));
+
+  if (selected.includes("\n")) {
+    const { rangeStart, rangeEnd, lines } = getSelectionLineRange(
+      doc,
+      anchor,
+      head,
+    );
+    const nonEmpty = lines.filter((l) => l.trim() !== "");
+    const allQuoted =
+      nonEmpty.length > 0 &&
+      nonEmpty.every((l) => l.startsWith(prefix) && l.length > prefix.length);
+
+    const newLines = lines.map((line) => {
+      if (line.trim() === "") return line;
+      if (allQuoted) return line.slice(prefix.length);
+      return prefix + line;
+    });
+
+    const newDoc =
+      doc.slice(0, rangeStart) + newLines.join("\n") + doc.slice(rangeEnd);
+    editor.setDocument(newDoc);
+    let cursorOffset = 0;
+    for (let i = 0; i < newLines.length - 1; i++) {
+      cursorOffset += newLines[i].length + 1;
+    }
+    cursorOffset += newLines[newLines.length - 1].length;
+    editor.setSelection(rangeStart + cursorOffset);
+    return true;
+  }
+
   const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
   const lineEndIdx = doc.indexOf("\n", anchor);
   const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
-  return { lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) };
-}
-
-/** Toggle a line prefix (e.g., "> " for blockquote). */
-function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const line = doc.slice(lineStart, lineEnd);
 
   let newLine: string;
   if (line.startsWith(prefix)) {
@@ -27,51 +196,77 @@ function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   return true;
 }
 
-export function toggleBlockquote(editor: EditorAPI): boolean {
-  return toggleLinePrefix(editor, "> ");
-}
-
 export function toggleOrderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const { rangeStart, rangeEnd, lines } = getSelectionLineRange(
+    doc,
+    anchor,
+    head,
+  );
 
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
+  const nonEmpty = lines.filter((l) => l.trim() !== "");
+  const allOl = nonEmpty.length > 0 && nonEmpty.every(isOrderedListItem);
+
+  const newLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.trim() === "") {
+      newLines.push(line);
+    } else if (allOl) {
+      newLines.push(removeListMarker(line));
+    } else {
+      newLines.push(makeOrderedListItem(line));
+    }
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+  let cursorOffset = 0;
+  for (let i = 0; i < newLines.length - 1; i++) {
+    cursorOffset += newLines[i].length + 1;
+  }
+  cursorOffset += newLines[newLines.length - 1].length;
+
+  const newRangeText = newLines.join("\n");
+  const newDoc = doc.slice(0, rangeStart) + newRangeText + doc.slice(rangeEnd);
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setSelection(rangeStart + cursorOffset);
   return true;
 }
 
 export function toggleUnorderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const { rangeStart, rangeEnd, lines } = getSelectionLineRange(
+    doc,
+    anchor,
+    head,
+  );
 
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
+  const nonEmpty = lines.filter((l) => l.trim() !== "");
+  const allUl = nonEmpty.length > 0 && nonEmpty.every(isUnorderedListItem);
+
+  const newLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.trim() === "") {
+      newLines.push(line);
+    } else if (allUl) {
+      newLines.push(removeListMarker(line));
+    } else {
+      newLines.push(makeUnorderedListItem(line));
+    }
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+  let cursorOffset = 0;
+  for (let i = 0; i < newLines.length - 1; i++) {
+    cursorOffset += newLines[i].length + 1;
+  }
+  cursorOffset += newLines[newLines.length - 1].length;
+
+  const newRangeText = newLines.join("\n");
+  const newDoc = doc.slice(0, rangeStart) + newRangeText + doc.slice(rangeEnd);
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setSelection(rangeStart + cursorOffset);
   return true;
 }
 
@@ -87,7 +282,9 @@ export function insertCodeBlock(editor: EditorAPI): boolean {
 
   const block =
     (needsLeadingNewline ? "\n" : "") +
-    "```\n" + (selected || "") + "\n```" +
+    "```\n" +
+    (selected || "") +
+    "\n```" +
     (needsTrailingNewline ? "\n" : "");
 
   const newDoc = doc.slice(0, from) + block + doc.slice(to);
@@ -118,23 +315,22 @@ export function insertImage(editor: EditorAPI): boolean {
 }
 
 export function applyTextColor(editor: EditorAPI, color: string): boolean {
-  const doc = editor.getDocument();
-  const { anchor, head } = editor.getSelection();
-  const from = Math.min(anchor, head);
-  const to = Math.max(anchor, head);
-  const selected = doc.slice(from, to);
-
-  if (from === to) return false;
-
-  const wrapped = `<span style="color:${color}">${selected}</span>`;
-  const newDoc = doc.slice(0, from) + wrapped + doc.slice(to);
-  editor.setDocument(newDoc);
-  const innerStart = from + `<span style="color:${color}">`.length;
-  editor.setSelection(innerStart, innerStart + selected.length);
-  return true;
+  return applyInlineHtml(editor, `<span style="color:${color}">`, "</span>");
 }
 
 export function applyHighlight(editor: EditorAPI, color: string): boolean {
+  return applyInlineHtml(
+    editor,
+    `<mark style="background:${color}">`,
+    "</mark>",
+  );
+}
+
+function applyInlineHtml(
+  editor: EditorAPI,
+  open: string,
+  close: string,
+): boolean {
   const doc = editor.getDocument();
   const { anchor, head } = editor.getSelection();
   const from = Math.min(anchor, head);
@@ -143,10 +339,72 @@ export function applyHighlight(editor: EditorAPI, color: string): boolean {
 
   if (from === to) return false;
 
-  const wrapped = `<mark style="background:${color}">${selected}</mark>`;
+  if (selected.includes("\n")) {
+    const { rangeStart, rangeEnd, lines, lineStarts } = getSelectionLineRange(
+      doc,
+      anchor,
+      head,
+    );
+
+    const newLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lStart = lineStarts[i];
+
+      if (line.trim() === "") {
+        newLines.push(line);
+        continue;
+      }
+
+      const { prefix } = extractLineContent(line, "");
+      const prefixLen = prefix.length;
+      const content = line.slice(prefixLen);
+
+      let selContentStart = 0;
+      let selContentEnd = content.length;
+
+      if (i === 0) {
+        selContentStart = Math.max(from - lStart - prefixLen, 0);
+      }
+      if (i === lines.length - 1) {
+        const lineEnd = lStart + line.length;
+        if (to >= lineEnd) {
+          selContentEnd = content.length;
+        } else {
+          selContentEnd = Math.min(to - lStart - prefixLen, content.length);
+        }
+      }
+
+      if (selContentStart >= selContentEnd) {
+        newLines.push(line);
+        continue;
+      }
+
+      const beforeContent = content.slice(0, selContentStart);
+      const selContent = content.slice(selContentStart, selContentEnd);
+      const afterContent = content.slice(selContentEnd);
+
+      newLines.push(
+        prefix + beforeContent + open + selContent + close + afterContent,
+      );
+    }
+
+    const newDoc =
+      doc.slice(0, rangeStart) + newLines.join("\n") + doc.slice(rangeEnd);
+    editor.setDocument(newDoc);
+    let cursorOffset = 0;
+    for (let i = 0; i < newLines.length - 1; i++) {
+      cursorOffset += newLines[i].length + 1;
+    }
+    cursorOffset += newLines[newLines.length - 1].length;
+    editor.setSelection(rangeStart + cursorOffset);
+    return true;
+  }
+
+  const wrapped = open + selected + close;
   const newDoc = doc.slice(0, from) + wrapped + doc.slice(to);
   editor.setDocument(newDoc);
-  const innerStart = from + `<mark style="background:${color}">`.length;
+  const innerStart = from + open.length;
   editor.setSelection(innerStart, innerStart + selected.length);
   return true;
 }

--- a/packages/plugin-toolbar/src/index.ts
+++ b/packages/plugin-toolbar/src/index.ts
@@ -1,18 +1,43 @@
-import type { EditorAPI, NexusPlugin, SlashCommandDef } from "@floatboat/nexus-core";
+import type {
+  EditorAPI,
+  NexusPlugin,
+  SlashCommandDef,
+} from "@floatboat/nexus-core";
 import { colorDecorationExtension } from "./color-decoration";
 import {
+  countStarsLeft,
+  countStarsRight,
+  extractLineContent,
+  getSelectionLineRange,
   insertCodeBlock,
   insertHorizontalRule,
   insertImage,
+  isLineWrapped,
+  stripAllMarkers,
   toggleBlockquote,
   toggleOrderedList,
   toggleUnorderedList,
+  unwrapLine,
 } from "./formatting";
 
-export { toggleBlockquote, toggleOrderedList, toggleUnorderedList, insertCodeBlock, insertImage, insertHorizontalRule, applyTextColor, applyHighlight } from "./formatting";
+export {
+  toggleBlockquote,
+  toggleOrderedList,
+  toggleUnorderedList,
+  insertCodeBlock,
+  insertImage,
+  insertHorizontalRule,
+  applyTextColor,
+  applyHighlight,
+} from "./formatting";
 export { createToolbarUI } from "./toolbar-ui";
 export { colorDecorationExtension } from "./color-decoration";
-export type { ToolbarUI, ToolbarUIOptions, ToolbarButton, ToolbarGroup } from "./toolbar-ui";
+export type {
+  ToolbarUI,
+  ToolbarUIOptions,
+  ToolbarButton,
+  ToolbarGroup,
+} from "./toolbar-ui";
 
 export function toggleWrap(editor: EditorAPI, marker: string): boolean {
   const doc = editor.getDocument();
@@ -21,11 +46,333 @@ export function toggleWrap(editor: EditorAPI, marker: string): boolean {
   const to = Math.max(anchor, head);
   const selected = doc.slice(from, to);
 
+  if (selected.includes("\n")) {
+    const { rangeStart, rangeEnd, lines, lineStarts } = getSelectionLineRange(
+      doc,
+      anchor,
+      head,
+    );
+
+    const fullContentLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.trim() === "") continue;
+      const { prefix } = extractLineContent(line, marker);
+      const prefixLen = prefix.length;
+      const content = line.slice(prefixLen);
+      const lStart = lineStarts[i];
+
+      let selContentStart = 0;
+      let selContentEnd = content.length;
+
+      if (i === 0) {
+        selContentStart = Math.max(from - lStart - prefixLen, 0);
+      }
+      if (i === lines.length - 1) {
+        const lineEnd = lStart + line.length;
+        if (to >= lineEnd || to >= lineEnd - marker.length) {
+          selContentEnd = content.length;
+        } else {
+          selContentEnd = Math.min(to - lStart - prefixLen, content.length);
+        }
+      }
+
+      if (
+        selContentStart === 0 &&
+        selContentEnd === content.length &&
+        content.length > 0
+      ) {
+        fullContentLines.push(content);
+      }
+    }
+
+    const allWrapped =
+      fullContentLines.length > 0 &&
+      fullContentLines.every((c) => isLineWrapped(c, marker));
+
+    const newLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lStart = lineStarts[i];
+
+      if (line.trim() === "") {
+        newLines.push(line);
+        continue;
+      }
+
+      const { prefix } = extractLineContent(line, marker);
+      const prefixLen = prefix.length;
+      const content = line.slice(prefixLen);
+
+      let selContentStart = 0;
+      let selContentEnd = content.length;
+
+      if (i === 0) {
+        selContentStart = Math.max(from - lStart - prefixLen, 0);
+      }
+      if (i === lines.length - 1) {
+        const lineEnd = lStart + line.length;
+        if (to >= lineEnd || to >= lineEnd - marker.length) {
+          selContentEnd = content.length;
+        } else {
+          selContentEnd = Math.min(to - lStart - prefixLen, content.length);
+        }
+      }
+
+      if (selContentStart >= selContentEnd) {
+        newLines.push(line);
+        continue;
+      }
+
+      let beforeContent = content.slice(0, selContentStart);
+      const selContent = content.slice(selContentStart, selContentEnd);
+      let afterContent = content.slice(selContentEnd);
+
+      const isFullContent =
+        selContentStart === 0 && selContentEnd === content.length;
+
+      let newSel: string;
+      if (isFullContent) {
+        if (allWrapped) {
+          newSel = unwrapLine(selContent, marker);
+        } else if (marker === "*" && selContent.includes("**")) {
+          let leftInside = 0;
+          while (
+            leftInside < selContent.length &&
+            selContent[leftInside] === "*"
+          ) {
+            leftInside++;
+          }
+          let rightInside = 0;
+          while (
+            rightInside < selContent.length &&
+            selContent[selContent.length - 1 - rightInside] === "*"
+          ) {
+            rightInside++;
+          }
+          const starTarget = (total: number, m: string): number => {
+            if (m === "*") return total % 2 === 0 ? total + 1 : total - 1;
+            return total >= 2 ? total - 2 : total + 2;
+          };
+          const leftTarget = starTarget(leftInside, marker);
+          const rightTarget = starTarget(rightInside, marker);
+          const inner = selContent.slice(
+            leftInside,
+            selContent.length - rightInside,
+          );
+          newSel = "*".repeat(leftTarget) + inner + "*".repeat(rightTarget);
+        } else {
+          const rewrap = marker + stripAllMarkers(selContent, marker) + marker;
+          if (rewrap === selContent) {
+            const single = unwrapLine(selContent, marker);
+            if (single.startsWith(marker) && single.endsWith(marker)) {
+              newSel = single;
+            } else {
+              newSel = rewrap;
+            }
+          } else {
+            newSel = rewrap;
+          }
+        }
+      } else if (isLineWrapped(selContent, marker)) {
+        newSel = unwrapLine(selContent, marker);
+      } else if (
+        (marker === "*" || marker === "**") &&
+        selContent.length > 0 &&
+        (selContent[0] === "*" ||
+          selContent[selContent.length - 1] === "*" ||
+          beforeContent.endsWith("*") ||
+          afterContent.startsWith("*"))
+      ) {
+        let leftInside = 0;
+        while (
+          leftInside < selContent.length &&
+          selContent[leftInside] === "*"
+        ) {
+          leftInside++;
+        }
+        let rightInside = 0;
+        while (
+          rightInside < selContent.length &&
+          selContent[selContent.length - 1 - rightInside] === "*"
+        ) {
+          rightInside++;
+        }
+
+        let leftOutside = 0;
+        while (
+          leftOutside < beforeContent.length &&
+          beforeContent[beforeContent.length - 1 - leftOutside] === "*"
+        ) {
+          leftOutside++;
+        }
+        let rightOutside = 0;
+        while (
+          rightOutside < afterContent.length &&
+          afterContent[rightOutside] === "*"
+        ) {
+          rightOutside++;
+        }
+
+        const splitsCluster =
+          (leftOutside > 0 && leftInside > 0) ||
+          (rightOutside > 0 && rightInside > 0);
+
+        if (splitsCluster) {
+          if (marker === "*") {
+            const leftTotal = leftOutside + leftInside;
+            const rightTotal = rightInside + rightOutside;
+            const starTargetN = (total: number, m: string): number => {
+              if (m === "*") return total % 2 === 0 ? total + 1 : total - 1;
+              return total >= 2 ? total - 2 : total + 2;
+            };
+            const leftTarget = starTargetN(leftTotal, marker);
+            const rightTarget = starTargetN(rightTotal, marker);
+            const inner = selContent.slice(
+              leftInside,
+              selContent.length - rightInside,
+            );
+            newSel = "*".repeat(leftTarget) + inner + "*".repeat(rightTarget);
+            beforeContent = beforeContent.slice(
+              0,
+              beforeContent.length - leftOutside,
+            );
+            afterContent = afterContent.slice(rightOutside);
+            newLines.push(prefix + beforeContent + newSel + afterContent);
+            continue;
+          }
+          newSel = stripAllMarkers(selContent, marker);
+        } else {
+          const leftTotal = leftOutside + leftInside;
+          const rightTotal = rightInside + rightOutside;
+
+          const targetN = (total: number, m: string): number => {
+            if (m === "*") return total % 2 === 0 ? total + 1 : total - 1;
+            return total >= 2 ? total - 2 : total + 2;
+          };
+
+          const leftTarget = targetN(leftTotal, marker);
+          const rightTarget = targetN(rightTotal, marker);
+          const inner = selContent.slice(
+            leftInside,
+            selContent.length - rightInside,
+          );
+
+          newSel = "*".repeat(leftTarget) + inner + "*".repeat(rightTarget);
+          beforeContent = beforeContent.slice(
+            0,
+            beforeContent.length - leftOutside,
+          );
+          afterContent = afterContent.slice(rightOutside);
+          newLines.push(prefix + beforeContent + newSel + afterContent);
+          continue;
+        }
+      } else if (selContent === marker) {
+        if (beforeContent.startsWith(marker)) {
+          newSel = "";
+        } else {
+          newSel = selContent;
+        }
+        newLines.push(prefix + beforeContent + newSel + afterContent);
+        continue;
+      } else if (
+        selContent.startsWith(marker) &&
+        selContent.length > marker.length
+      ) {
+        newSel = selContent.slice(marker.length);
+        if (afterContent.includes(marker) && !afterContent.startsWith(marker)) {
+          afterContent = marker + afterContent;
+        }
+        newLines.push(prefix + beforeContent + newSel + afterContent);
+        continue;
+      } else if (
+        selContent.endsWith(marker) &&
+        selContent.length > marker.length
+      ) {
+        newSel = selContent.slice(0, selContent.length - marker.length);
+        if (beforeContent.includes(marker) && !beforeContent.endsWith(marker)) {
+          beforeContent = beforeContent + marker;
+        }
+        newLines.push(prefix + beforeContent + newSel + afterContent);
+        continue;
+      } else if (selContent.includes(marker)) {
+        newSel = stripAllMarkers(selContent, marker);
+      } else {
+        newSel = marker + selContent + marker;
+      }
+
+      if (afterContent.includes(marker) && !afterContent.startsWith(marker)) {
+        afterContent = marker + afterContent;
+      }
+      if (beforeContent.includes(marker) && !beforeContent.endsWith(marker)) {
+        beforeContent = beforeContent + marker;
+      }
+
+      newLines.push(prefix + beforeContent + newSel + afterContent);
+    }
+
+    let cursorOffset = 0;
+    for (let i = 0; i < newLines.length - 1; i++) {
+      cursorOffset += newLines[i].length + 1;
+    }
+    cursorOffset += newLines[newLines.length - 1].length;
+
+    const newRangeText = newLines.join("\n");
+    const newDoc =
+      doc.slice(0, rangeStart) + newRangeText + doc.slice(rangeEnd);
+    editor.setDocument(newDoc);
+    editor.setSelection(rangeStart + cursorOffset);
+    return true;
+  }
+
+  const markerTarget = (total: number, m: string): number => {
+    if (m === "*") return total % 2 === 0 ? total + 1 : total - 1;
+    return total >= 2 ? total - 2 : total + 2;
+  };
+
+  if (from !== to && (marker === "*" || marker === "**")) {
+    const leftOutside = countStarsLeft(doc, from);
+    const rightOutside = countStarsRight(doc, to);
+
+    let leftInside = 0;
+    while (leftInside < selected.length && selected[leftInside] === "*") {
+      leftInside++;
+    }
+    let rightInside = 0;
+    while (
+      rightInside < selected.length &&
+      selected[selected.length - 1 - rightInside] === "*"
+    ) {
+      rightInside++;
+    }
+
+    const skipStarCount =
+      selected.includes(marker) && leftInside === 0 && rightInside === 0;
+
+    if (!skipStarCount) {
+      const leftTotal = leftOutside + leftInside;
+      const rightTotal = rightOutside + rightInside;
+      const leftTarget = markerTarget(leftTotal, marker);
+      const rightTarget = markerTarget(rightTotal, marker);
+      const inner = selected.slice(leftInside, selected.length - rightInside);
+
+      const newDoc =
+        doc.slice(0, from - leftOutside) +
+        "*".repeat(leftTarget) +
+        inner +
+        "*".repeat(rightTarget) +
+        doc.slice(to + rightOutside);
+      editor.setDocument(newDoc);
+      const newFrom = from - leftOutside + leftTarget;
+      editor.setSelection(newFrom, newFrom + inner.length);
+      return true;
+    }
+  }
+
   const before = doc.slice(Math.max(0, from - marker.length), from);
   const after = doc.slice(to, to + marker.length);
 
   if (before === marker && after === marker) {
-    // Already wrapped — remove markers
     const newDoc =
       doc.slice(0, from - marker.length) +
       selected +
@@ -35,7 +382,60 @@ export function toggleWrap(editor: EditorAPI, marker: string): boolean {
     return true;
   }
 
-  // Wrap selection with markers
+  if (before === marker || after === marker) {
+    if (selected.startsWith(marker) || selected.endsWith(marker)) {
+      const cleaned = stripAllMarkers(selected, marker);
+      const adjFrom = before === marker ? from - marker.length : from;
+      const adjTo = after === marker ? to + marker.length : to;
+      const newDoc = doc.slice(0, adjFrom) + cleaned + doc.slice(adjTo);
+      editor.setDocument(newDoc);
+      editor.setSelection(adjFrom, adjFrom + cleaned.length);
+      return true;
+    }
+
+    if (selected.includes(marker)) {
+      const lineStart = doc.lastIndexOf("\n", from - 1) + 1;
+      const nlIdx = doc.indexOf("\n", to);
+      const lineEnd = nlIdx === -1 ? doc.length : nlIdx;
+      const line = doc.slice(lineStart, lineEnd);
+
+      const { prefix, content } = extractLineContent(line, marker);
+      const isWrapped = isLineWrapped(content, marker);
+
+      let newLine: string;
+      if (isWrapped) {
+        newLine = prefix + unwrapLine(content, marker);
+      } else {
+        newLine = prefix + marker + stripAllMarkers(content, marker) + marker;
+      }
+
+      const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+      editor.setDocument(newDoc);
+      editor.setSelection(lineStart + newLine.length);
+      return true;
+    }
+
+    if (before === marker) {
+      const newDoc =
+        doc.slice(0, from - marker.length) + selected + marker + doc.slice(to);
+      editor.setDocument(newDoc);
+      editor.setSelection(
+        from - marker.length,
+        from - marker.length + selected.length,
+      );
+      return true;
+    }
+
+    const newDoc =
+      doc.slice(0, from) + marker + selected + doc.slice(to + marker.length);
+    editor.setDocument(newDoc);
+    editor.setSelection(
+      from + marker.length,
+      from + marker.length + selected.length,
+    );
+    return true;
+  }
+
   const newDoc =
     doc.slice(0, from) + marker + selected + marker + doc.slice(to);
   editor.setDocument(newDoc);
@@ -53,6 +453,139 @@ export function toggleItalic(editor: EditorAPI): boolean {
 
 export function toggleStrikethrough(editor: EditorAPI): boolean {
   return toggleWrap(editor, "~~");
+}
+
+export function toggleUnderline(editor: EditorAPI): boolean {
+  const doc = editor.getDocument();
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+  const selected = doc.slice(from, to);
+
+  if (selected.includes("\n")) {
+    const { rangeStart, rangeEnd, lines, lineStarts } = getSelectionLineRange(
+      doc,
+      anchor,
+      head,
+    );
+
+    const fullContentLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.trim() === "") continue;
+      const { prefix } = extractLineContent(line, "<u>");
+      const prefixLen = prefix.length;
+      const content = line.slice(prefixLen);
+      const lStart = lineStarts[i];
+
+      let selContentStart = 0;
+      let selContentEnd = content.length;
+
+      if (i === 0) {
+        selContentStart = Math.max(from - lStart - prefixLen, 0);
+      }
+      if (i === lines.length - 1) {
+        const lineEnd = lStart + line.length;
+        if (to >= lineEnd || to >= lineEnd - 4) {
+          selContentEnd = content.length;
+        } else {
+          selContentEnd = Math.min(to - lStart - prefixLen, content.length);
+        }
+      }
+
+      if (
+        selContentStart === 0 &&
+        selContentEnd === content.length &&
+        content.length > 0
+      ) {
+        fullContentLines.push(content);
+      }
+    }
+
+    const isWrapped = (l: string) =>
+      l.startsWith("<u>") && l.endsWith("</u>") && l.length >= 7;
+    const allWrapped =
+      fullContentLines.length > 0 && fullContentLines.every(isWrapped);
+
+    const newLines: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lStart = lineStarts[i];
+
+      if (line.trim() === "") {
+        newLines.push(line);
+        continue;
+      }
+
+      const { prefix } = extractLineContent(line, "<u>");
+      const prefixLen = prefix.length;
+      const content = line.slice(prefixLen);
+
+      let selContentStart = 0;
+      let selContentEnd = content.length;
+
+      if (i === 0) {
+        selContentStart = Math.max(from - lStart - prefixLen, 0);
+      }
+      if (i === lines.length - 1) {
+        const lineEnd = lStart + line.length;
+        if (to >= lineEnd || to >= lineEnd - 4) {
+          selContentEnd = content.length;
+        } else {
+          selContentEnd = Math.min(to - lStart - prefixLen, content.length);
+        }
+      }
+
+      if (selContentStart >= selContentEnd) {
+        newLines.push(line);
+        continue;
+      }
+
+      let beforeContent = content.slice(0, selContentStart);
+      const selContent = content.slice(selContentStart, selContentEnd);
+      let afterContent = content.slice(selContentEnd);
+
+      const isFullContent =
+        selContentStart === 0 && selContentEnd === content.length;
+
+      let newSel: string;
+      if (isFullContent && allWrapped) {
+        newSel = selContent.slice(3, selContent.length - 4);
+      } else if (isWrapped(selContent)) {
+        newSel = selContent.slice(3, selContent.length - 4);
+      } else {
+        newSel = "<u>" + selContent + "</u>";
+      }
+
+      newLines.push(prefix + beforeContent + newSel + afterContent);
+    }
+
+    const newDoc =
+      doc.slice(0, rangeStart) + newLines.join("\n") + doc.slice(rangeEnd);
+    editor.setDocument(newDoc);
+    let cursorOffset = 0;
+    for (let i = 0; i < newLines.length - 1; i++) {
+      cursorOffset += newLines[i].length + 1;
+    }
+    cursorOffset += newLines[newLines.length - 1].length;
+    editor.setSelection(rangeStart + cursorOffset);
+    return true;
+  }
+
+  const before = doc.slice(Math.max(0, from - 3), from);
+  const after = doc.slice(to, to + 4);
+
+  if (before === "<u>" && after === "</u>") {
+    editor.setDocument(doc.slice(0, from - 3) + selected + doc.slice(to + 4));
+    editor.setSelection(from - 3, to - 3);
+    return true;
+  }
+
+  editor.setDocument(
+    doc.slice(0, from) + "<u>" + selected + "</u>" + doc.slice(to),
+  );
+  editor.setSelection(from + 3, to + 3);
+  return true;
 }
 
 export function toggleInlineCode(editor: EditorAPI): boolean {
@@ -79,25 +612,62 @@ export function insertLink(editor: EditorAPI): boolean {
 
 export function toggleHeading(editor: EditorAPI, level: number): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
+  const { anchor, head } = editor.getSelection();
+  const prefix = "#".repeat(level) + " ";
+  const selected = doc.slice(Math.min(anchor, head), Math.max(anchor, head));
+
+  if (selected.includes("\n")) {
+    const { rangeStart, rangeEnd, lines } = getSelectionLineRange(
+      doc,
+      anchor,
+      head,
+    );
+    const newLines = lines.map((line) => {
+      const trimmed = line.trimEnd();
+      if (trimmed === "") return line;
+      const { prefix: listPrefix, content } = extractLineContent(
+        trimmed,
+        prefix,
+      );
+      const headingMatch = content.match(/^#{1,6}\s/);
+      if (headingMatch && headingMatch[0] === prefix) {
+        return listPrefix + content.slice(headingMatch[0].length);
+      } else if (headingMatch) {
+        return listPrefix + prefix + content.slice(headingMatch[0].length);
+      }
+      return listPrefix + prefix + content;
+    });
+    const newDoc =
+      doc.slice(0, rangeStart) + newLines.join("\n") + doc.slice(rangeEnd);
+    editor.setDocument(newDoc);
+    let cursorOffset = 0;
+    for (let i = 0; i < newLines.length - 1; i++) {
+      cursorOffset += newLines[i].length + 1;
+    }
+    cursorOffset += newLines[newLines.length - 1].length;
+    editor.setSelection(rangeStart + cursorOffset);
+    return true;
+  }
+
   const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
   const lineEnd = doc.indexOf("\n", anchor);
   const end = lineEnd === -1 ? doc.length : lineEnd;
   const line = doc.slice(lineStart, end);
-
-  const prefix = "#".repeat(level) + " ";
-  const headingMatch = line.match(/^#{1,6}\s/);
+  const trimmed = line.trimEnd();
 
   let newLine: string;
-  if (headingMatch && headingMatch[0] === prefix) {
-    // Same level — remove heading
-    newLine = line.slice(headingMatch[0].length);
-  } else if (headingMatch) {
-    // Different level — replace
-    newLine = prefix + line.slice(headingMatch[0].length);
+  if (trimmed === "") {
+    newLine = prefix;
   } else {
-    // No heading — add
-    newLine = prefix + line;
+    const { prefix: listPrefix, content } = extractLineContent(trimmed, prefix);
+    const headingMatch = content.match(/^#{1,6}\s/);
+    if (headingMatch && headingMatch[0] === prefix) {
+      newLine = listPrefix + content.slice(headingMatch[0].length);
+    } else if (headingMatch) {
+      newLine = listPrefix + prefix + content.slice(headingMatch[0].length);
+    } else {
+      newLine = listPrefix + prefix + content;
+    }
   }
 
   const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(end);

--- a/packages/plugin-toolbar/src/toolbar-ui.ts
+++ b/packages/plugin-toolbar/src/toolbar-ui.ts
@@ -4,10 +4,10 @@ import {
   toggleBold,
   toggleItalic,
   toggleStrikethrough,
+  toggleUnderline,
   toggleInlineCode,
   insertLink,
   toggleHeading,
-  toggleWrap,
 } from "./index";
 import {
   toggleBlockquote,
@@ -74,11 +74,15 @@ function pickOverlayMount(anchor: HTMLElement | Document): HTMLElement {
   const doc = anchor instanceof Document ? anchor : anchor.ownerDocument;
   const node = anchor instanceof Document ? null : anchor;
   const fullscreenEl = doc.fullscreenElement as HTMLElement | null;
-  if (fullscreenEl && (!node || fullscreenEl.contains(node))) return fullscreenEl;
+  if (fullscreenEl && (!node || fullscreenEl.contains(node)))
+    return fullscreenEl;
   return doc.body;
 }
 
-function positionToolbarTooltip(button: HTMLElement, tooltip: HTMLElement): void {
+function positionToolbarTooltip(
+  button: HTMLElement,
+  tooltip: HTMLElement,
+): void {
   const rect = button.getBoundingClientRect();
   tooltip.style.left = `${rect.left + rect.width / 2}px`;
   tooltip.style.top = `${rect.bottom + 8}px`;
@@ -92,7 +96,8 @@ function installToolbarTooltip(button: HTMLButtonElement): () => void {
   button.setAttribute("aria-describedby", tooltip.id);
 
   const show = () => {
-    const label = button.dataset.toolbarTooltip ?? button.getAttribute("aria-label") ?? "";
+    const label =
+      button.dataset.toolbarTooltip ?? button.getAttribute("aria-label") ?? "";
     if (!label.trim()) return;
     tooltip.textContent = label;
     tooltip.dataset.state = "open";
@@ -142,47 +147,127 @@ function defaultGroups(options?: ToolbarUIOptions): ToolbarGroup[] {
     },
     {
       buttons: [
-        { id: "link", title: "Insert link", icon: iconLink, action: insertLink },
+        {
+          id: "link",
+          title: "Insert link",
+          icon: iconLink,
+          action: insertLink,
+        },
       ],
     },
     {
       buttons: [
-        { id: "h2", title: "Heading 2", icon: iconH2, action: (e) => toggleHeading(e, 2) },
-        { id: "h3", title: "Heading 3", icon: iconH3, action: (e) => toggleHeading(e, 3) },
-        { id: "heading-menu", title: "More headings", icon: iconHeadingMenu, action: () => {} },
+        {
+          id: "h2",
+          title: "Heading 2",
+          icon: iconH2,
+          action: (e) => toggleHeading(e, 2),
+        },
+        {
+          id: "h3",
+          title: "Heading 3",
+          icon: iconH3,
+          action: (e) => toggleHeading(e, 3),
+        },
+        {
+          id: "heading-menu",
+          title: "More headings",
+          icon: iconHeadingMenu,
+          action: () => {},
+        },
       ],
     },
     {
       buttons: [
         { id: "bold", title: "Bold", icon: iconBold, action: toggleBold },
-        { id: "italic", title: "Italic", icon: iconItalic, action: toggleItalic },
-        { id: "strikethrough", title: "Strikethrough", icon: iconStrikethrough, action: toggleStrikethrough },
-        { id: "underline", title: "Underline", icon: iconUnderline, action: (e) => toggleWrap(e, "<u>") },
-        { id: "inline-code", title: "Inline code", icon: iconInlineCode, action: toggleInlineCode },
+        {
+          id: "italic",
+          title: "Italic",
+          icon: iconItalic,
+          action: toggleItalic,
+        },
+        {
+          id: "strikethrough",
+          title: "Strikethrough",
+          icon: iconStrikethrough,
+          action: toggleStrikethrough,
+        },
+        {
+          id: "underline",
+          title: "Underline",
+          icon: iconUnderline,
+          action: toggleUnderline,
+        },
+        {
+          id: "inline-code",
+          title: "Inline code",
+          icon: iconInlineCode,
+          action: toggleInlineCode,
+        },
       ],
     },
     {
       buttons: [
-        { id: "blockquote", title: "Blockquote", icon: iconBlockquote, action: toggleBlockquote },
-        { id: "code-block", title: "Code block", icon: iconCodeBlock, action: insertCodeBlock },
+        {
+          id: "blockquote",
+          title: "Blockquote",
+          icon: iconBlockquote,
+          action: toggleBlockquote,
+        },
+        {
+          id: "code-block",
+          title: "Code block",
+          icon: iconCodeBlock,
+          action: insertCodeBlock,
+        },
       ],
     },
     {
       buttons: [
-        { id: "ordered-list", title: "Ordered list", icon: iconOrderedList, action: toggleOrderedList },
-        { id: "unordered-list", title: "Unordered list", icon: iconUnorderedList, action: toggleUnorderedList },
+        {
+          id: "ordered-list",
+          title: "Ordered list",
+          icon: iconOrderedList,
+          action: toggleOrderedList,
+        },
+        {
+          id: "unordered-list",
+          title: "Unordered list",
+          icon: iconUnorderedList,
+          action: toggleUnorderedList,
+        },
       ],
     },
     {
       buttons: [
-        { id: "text-color", title: "Text color", icon: iconTextColor, action: () => {} },
-        { id: "highlight", title: "Highlight", icon: iconHighlight, action: () => {} },
+        {
+          id: "text-color",
+          title: "Text color",
+          icon: iconTextColor,
+          action: () => {},
+        },
+        {
+          id: "highlight",
+          title: "Highlight",
+          icon: iconHighlight,
+          action: () => {},
+        },
       ],
     },
     {
       buttons: [
-        { id: "image", title: "Insert image", icon: iconImage, action: insertImage },
-        { id: "fullscreen", title: "Fullscreen", icon: iconFullscreen, action: () => options?.onFullscreen?.() },
+        {
+          id: "image",
+          title: "Insert image",
+          icon: iconImage,
+          action: insertImage,
+        },
+        {
+          id: "fullscreen",
+          title: "Fullscreen",
+          icon: iconFullscreen,
+          action: () => options?.onFullscreen?.(),
+        },
       ],
     },
   ];
@@ -303,7 +388,9 @@ function showHeadingDropdown(
         const m = line.match(/^#{1,6}\s/);
         if (m) {
           const newLine = line.slice(m[0].length);
-          editor.setDocument(doc.slice(0, lineStart) + newLine + doc.slice(lineEnd));
+          editor.setDocument(
+            doc.slice(0, lineStart) + newLine + doc.slice(lineEnd),
+          );
           editor.setSelection(lineStart + newLine.length);
         }
       }
@@ -311,8 +398,12 @@ function showHeadingDropdown(
       onClose();
     };
 
-    const handleEnter = () => { item.style.background = "var(--nexus-bg-muted, #f0f0f0)"; };
-    const handleLeave = () => { item.style.background = "transparent"; };
+    const handleEnter = () => {
+      item.style.background = "var(--nexus-bg-muted, #f0f0f0)";
+    };
+    const handleLeave = () => {
+      item.style.background = "transparent";
+    };
 
     item.addEventListener("click", handleClick);
     item.addEventListener("mouseenter", handleEnter);
@@ -339,20 +430,72 @@ function showHeadingDropdown(
 
 const COLOR_PALETTE = [
   // row 1: grays + black/white
-  "#000000", "#434343", "#666666", "#999999", "#b7b7b7", "#cccccc", "#d9d9d9", "#efefef", "#f3f3f3", "#ffffff",
+  "#000000",
+  "#434343",
+  "#666666",
+  "#999999",
+  "#b7b7b7",
+  "#cccccc",
+  "#d9d9d9",
+  "#efefef",
+  "#f3f3f3",
+  "#ffffff",
   // row 2: saturated
-  "#ff0000", "#ff9900", "#ffff00", "#00ff00", "#00ffff", "#0000ff", "#9900ff", "#ff00ff", "#f4cccc", "#fce5cd",
+  "#ff0000",
+  "#ff9900",
+  "#ffff00",
+  "#00ff00",
+  "#00ffff",
+  "#0000ff",
+  "#9900ff",
+  "#ff00ff",
+  "#f4cccc",
+  "#fce5cd",
   // row 3: muted
-  "#ea4335", "#ff6d01", "#fbbc04", "#34a853", "#46bdc6", "#4285f4", "#a142f4", "#ff6d9b", "#e06666", "#f6b26b",
+  "#ea4335",
+  "#ff6d01",
+  "#fbbc04",
+  "#34a853",
+  "#46bdc6",
+  "#4285f4",
+  "#a142f4",
+  "#ff6d9b",
+  "#e06666",
+  "#f6b26b",
   // row 4: dark
-  "#cc0000", "#e69138", "#f1c232", "#6aa84f", "#45818e", "#3c78d8", "#674ea7", "#a64d79", "#990000", "#783f04",
+  "#cc0000",
+  "#e69138",
+  "#f1c232",
+  "#6aa84f",
+  "#45818e",
+  "#3c78d8",
+  "#674ea7",
+  "#a64d79",
+  "#990000",
+  "#783f04",
 ];
 
 const HIGHLIGHT_PALETTE = [
-  "#ffff00", "#00ff00", "#00ffff", "#ff9900", "#ff00ff",
-  "#fce5cd", "#d9ead3", "#d0e0e3", "#cfe2f3", "#d9d2e9",
-  "#fff2cc", "#b6d7a8", "#a2c4c9", "#9fc5e8", "#b4a7d6",
-  "#f4cccc", "#ea9999", "#e6b8af", "#dd7e6b", "#cc4125",
+  "#ffff00",
+  "#00ff00",
+  "#00ffff",
+  "#ff9900",
+  "#ff00ff",
+  "#fce5cd",
+  "#d9ead3",
+  "#d0e0e3",
+  "#cfe2f3",
+  "#d9d2e9",
+  "#fff2cc",
+  "#b6d7a8",
+  "#a2c4c9",
+  "#9fc5e8",
+  "#b4a7d6",
+  "#f4cccc",
+  "#ea9999",
+  "#e6b8af",
+  "#dd7e6b",
+  "#cc4125",
 ];
 
 const COLOR_GRID_STYLES = `
@@ -443,7 +586,10 @@ function showColorPicker(
 /** IDs that trigger dropdown behavior instead of a direct action. */
 const DROPDOWN_IDS = new Set(["heading-menu", "text-color", "highlight"]);
 
-export function createToolbarUI(editor: EditorAPI, options?: ToolbarUIOptions): ToolbarUI {
+export function createToolbarUI(
+  editor: EditorAPI,
+  options?: ToolbarUIOptions,
+): ToolbarUI {
   const groups = options?.groups ?? defaultGroups(options);
   const toolbar = document.createElement("div");
   toolbar.className = "nexus-toolbar";
@@ -502,24 +648,45 @@ export function createToolbarUI(editor: EditorAPI, options?: ToolbarUIOptions): 
           e.preventDefault();
           e.stopPropagation();
 
-          if (activeDropdown) { closeDropdown(); return; }
+          if (activeDropdown) {
+            closeDropdown();
+            return;
+          }
 
           if (btn.id === "heading-menu") {
             activeDropdown = showHeadingDropdown(editor, button, closeDropdown);
           } else if (btn.id === "text-color") {
-            activeDropdown = showColorPicker(editor, button, COLOR_PALETTE, applyTextColor, closeDropdown);
+            activeDropdown = showColorPicker(
+              editor,
+              button,
+              COLOR_PALETTE,
+              applyTextColor,
+              closeDropdown,
+            );
           } else if (btn.id === "highlight") {
-            activeDropdown = showColorPicker(editor, button, HIGHLIGHT_PALETTE, applyHighlight, closeDropdown);
+            activeDropdown = showColorPicker(
+              editor,
+              button,
+              HIGHLIGHT_PALETTE,
+              applyHighlight,
+              closeDropdown,
+            );
           }
 
           outsideHandler = (ev: MouseEvent) => {
-            const dropdownEl = document.querySelector(".nexus-toolbar-dropdown");
-            if (!button.contains(ev.target as Node) && (!dropdownEl || !dropdownEl.contains(ev.target as Node))) {
+            const dropdownEl = document.querySelector(
+              ".nexus-toolbar-dropdown",
+            );
+            if (
+              !button.contains(ev.target as Node) &&
+              (!dropdownEl || !dropdownEl.contains(ev.target as Node))
+            ) {
               closeDropdown();
             }
           };
           requestAnimationFrame(() => {
-            if (outsideHandler) document.addEventListener("mousedown", outsideHandler, true);
+            if (outsideHandler)
+              document.addEventListener("mousedown", outsideHandler, true);
           });
         };
 

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -5,8 +5,15 @@ import {
   toggleBold,
   toggleItalic,
   toggleInlineCode,
+  toggleStrikethrough,
+  toggleUnderline,
+  applyTextColor,
+  applyHighlight,
   insertLink,
   toggleHeading,
+  toggleBlockquote,
+  toggleOrderedList,
+  toggleUnorderedList,
   createToolbarPlugin,
   createToolbarUI,
 } from "../src/index";
@@ -46,6 +53,239 @@ describe("toggleItalic", () => {
     expect(editor.getDocument()).toBe("hello *world*");
     editor.destroy();
   });
+
+  it("does not mistake bold markers for italic in multi-line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**aaa**\n**bbb**",
+    });
+
+    editor.setSelection(0, 15);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("***aaa***\n***bbb***");
+    editor.destroy();
+  });
+
+  it("strips italic markers without touching bold in mixed content", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "*aaa*\n**bbb**",
+    });
+
+    editor.setSelection(0, 13);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("*aaa*\n***bbb***");
+    editor.destroy();
+  });
+
+  it("strips one layer from triple-star (bold+italic) in multi-line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "***ccc***\n***ddd***",
+    });
+
+    editor.setSelection(0, 19);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("**ccc**\n**ddd**");
+    editor.destroy();
+  });
+
+  it("wraps bold-only content with italic without stripping bold", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**abc**",
+    });
+
+    editor.setSelection(0, 7);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("***abc***");
+    editor.destroy();
+  });
+
+  it("adds italic to bold text when partially selected (star-count path)", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "**abc**" });
+
+    editor.setSelection(1, 7);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("***abc***");
+    editor.destroy();
+  });
+
+  it("adds italic to bold-only multi-line without stripping bold", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**a1**\n**a2**",
+    });
+
+    editor.setSelection(0, 13);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("***a1***\n***a2***");
+    editor.destroy();
+  });
+
+  it("removes italic from bold+italic multi-line keeping bold", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "***a1***\n***a2***",
+    });
+
+    editor.setSelection(0, 17);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("**a1**\n**a2**");
+    editor.destroy();
+  });
+
+  it("adds italic to bold-only multi-line with partial first-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**a1**\n**a2**",
+    });
+
+    editor.setSelection(1, 13);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("***a1***\n***a2***");
+    editor.destroy();
+  });
+
+  it("wraps inner selection in bold region with italic", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**abc**",
+    });
+
+    editor.setSelection(2, 5);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("***abc***");
+    editor.destroy();
+  });
+
+  it("strips one layer from triple-star when inner text selected", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "***abc***",
+    });
+
+    editor.setSelection(3, 6);
+    toggleItalic(editor);
+
+    expect(editor.getDocument()).toBe("**abc**");
+    editor.destroy();
+  });
+});
+
+describe("multi-line star-count", () => {
+  it("handles asymmetric stars across multi-line selection", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "**ab***\n***cd***",
+    });
+    e.setSelection(2, 16);
+    toggleItalic(e);
+    expect(e.getDocument()).toBe("***ab**\n**cd**");
+    e.destroy();
+  });
+});
+
+describe("star-count boundary rules", () => {
+  it("* wraps 0 stars → 1 star for italic", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "abc" });
+    e.setSelection(0, 3);
+    toggleItalic(e);
+    expect(e.getDocument()).toBe("*abc*");
+    e.destroy();
+  });
+
+  it("* unwraps 1 star → 0 stars for italic", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "*abc*" });
+    e.setSelection(1, 4);
+    toggleItalic(e);
+    expect(e.getDocument()).toBe("abc");
+    e.destroy();
+  });
+
+  it("* wraps 2 stars → 3 stars for italic", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "**abc**" });
+    e.setSelection(2, 5);
+    toggleItalic(e);
+    expect(e.getDocument()).toBe("***abc***");
+    e.destroy();
+  });
+
+  it("* unwraps 3 stars → 2 stars for italic", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "***abc***" });
+    e.setSelection(3, 6);
+    toggleItalic(e);
+    expect(e.getDocument()).toBe("**abc**");
+    e.destroy();
+  });
+
+  it("** wraps 0 stars → 2 stars for bold", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "abc" });
+    e.setSelection(0, 3);
+    toggleBold(e);
+    expect(e.getDocument()).toBe("**abc**");
+    e.destroy();
+  });
+
+  it("** wraps 1 star → 3 stars for bold", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "*abc*" });
+    e.setSelection(1, 4);
+    toggleBold(e);
+    expect(e.getDocument()).toBe("***abc***");
+    e.destroy();
+  });
+
+  it("** unwraps 2 stars → 0 stars for bold", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "**abc**" });
+    e.setSelection(2, 5);
+    toggleBold(e);
+    expect(e.getDocument()).toBe("abc");
+    e.destroy();
+  });
+
+  it("** unwraps 3 stars → 1 star for bold", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "***abc***" });
+    e.setSelection(3, 6);
+    toggleBold(e);
+    expect(e.getDocument()).toBe("*abc*");
+    e.destroy();
+  });
+  it("asymmetric: left has stars, right has none → independent adjust for italic", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "***abc***" });
+    e.setSelection(1, 5);
+    toggleItalic(e);
+    expect(e.getDocument()).toBe("**ab*c***");
+    e.destroy();
+  });
 });
 
 describe("toggleInlineCode", () => {
@@ -58,6 +298,47 @@ describe("toggleInlineCode", () => {
 
     expect(editor.getDocument()).toBe("hello `world`");
     editor.destroy();
+  });
+});
+
+describe("toggleInlineCode multi-line", () => {
+  it("wraps each line with backticks", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "a\nb" });
+    e.setSelection(0, 3);
+    toggleInlineCode(e);
+    expect(e.getDocument()).toBe("`a`\n`b`");
+    e.destroy();
+  });
+
+  it("unwraps each line from backticks", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "`a`\n`b`" });
+    e.setSelection(0, 7);
+    toggleInlineCode(e);
+    expect(e.getDocument()).toBe("a\nb");
+    e.destroy();
+  });
+
+  it("partial selection across inline code lines", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "`a`\n`b`" });
+    e.setSelection(1, 5);
+    toggleInlineCode(e);
+    expect(e.getDocument()).toBe("`a\n`b`");
+    e.destroy();
+  });
+
+  it("partial selection on ordered list wraps selected portion", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "1. a\n1. bc\n1. def",
+    });
+    e.setSelection(9, 17);
+    toggleInlineCode(e);
+    expect(e.getDocument()).toBe("1. a\n1. b`c`\n1. `def`");
+    e.destroy();
   });
 });
 
@@ -118,6 +399,296 @@ describe("toggleHeading", () => {
     expect(editor.getDocument()).toBe("# Title");
     editor.destroy();
   });
+
+  it("applies heading to each line in multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\nb" });
+
+    editor.setSelection(0, 3);
+    toggleHeading(editor, 2);
+
+    expect(editor.getDocument()).toBe("## a\n## b");
+    editor.destroy();
+  });
+
+  it("removes heading from each line in multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "## a\n## b" });
+
+    editor.setSelection(0, 9);
+    toggleHeading(editor, 2);
+
+    expect(editor.getDocument()).toBe("a\nb");
+    editor.destroy();
+  });
+
+  it("applies heading to ordered list items, stripping list markers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. first\n2. second",
+    });
+
+    editor.setSelection(0, 18);
+    toggleHeading(editor, 2);
+
+    expect(editor.getDocument()).toBe("1. ## first\n2. ## second");
+    editor.destroy();
+  });
+
+  it("applies heading to unordered list items, stripping list markers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "- first\n- second",
+    });
+
+    editor.setSelection(0, 16);
+    toggleHeading(editor, 2);
+
+    expect(editor.getDocument()).toBe("- ## first\n- ## second");
+    editor.destroy();
+  });
+
+  it("removes heading from list items with heading, keeping list markers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. ## first\n2. ## second",
+    });
+
+    editor.setSelection(0, 24);
+    toggleHeading(editor, 2);
+
+    expect(editor.getDocument()).toBe("1. first\n2. second");
+    editor.destroy();
+  });
+});
+
+describe("toggleStrikethrough multi-line", () => {
+  it("wraps each line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "a\nb" });
+    e.setSelection(0, 3);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("~~a~~\n~~b~~");
+    e.destroy();
+  });
+
+  it("unwraps each line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "~~a~~\n~~b~~" });
+    e.setSelection(0, 11);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("a\nb");
+    e.destroy();
+  });
+
+  it("partial selection across strikethrough lines", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "~~a~~\n~~b~~" });
+    e.setSelection(2, 8);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("~~a\n~~b~~");
+    e.destroy();
+  });
+
+  it("partial selection maintains orphaned markers", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "~~a~~\n~~bc~~" });
+    e.setSelection(3, 9);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("~~a\nb~~c~~");
+    e.destroy();
+  });
+
+  it("partial selection on ordered list wraps selected portion", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "1. a\n1. bc\n1. def",
+    });
+    e.setSelection(9, 17);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("1. a\n1. b~~c~~\n1. ~~def~~");
+    e.destroy();
+  });
+
+  it("wraps bold-only content with strikethrough without stripping bold", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "**a**\n**b**" });
+    e.setSelection(0, 11);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("~~**a**~~\n~~**b**~~");
+    e.destroy();
+  });
+
+  it("wraps bold-only CJK content with strikethrough correctly", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "**滴答**\n**滴答**",
+    });
+    e.setSelection(0, 13);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("~~**滴答**~~\n~~**滴答**~~");
+    e.destroy();
+  });
+
+  it("partial selection on bold content leaves unselected bold markers intact", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "**a**\n**b**" });
+    e.setSelection(1, 11);
+    toggleStrikethrough(e);
+    expect(e.getDocument()).toBe("*~~*a**~~\n~~**b**~~");
+    e.destroy();
+  });
+});
+
+describe("toggleUnderline multi-line", () => {
+  it("wraps each line with <u>", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "a\nb" });
+    e.setSelection(0, 3);
+    toggleUnderline(e);
+    expect(e.getDocument()).toBe("<u>a</u>\n<u>b</u>");
+    e.destroy();
+  });
+
+  it("unwraps each line from <u>", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "<u>a</u>\n<u>b</u>",
+    });
+    e.setSelection(0, 17);
+    toggleUnderline(e);
+    expect(e.getDocument()).toBe("a\nb");
+    e.destroy();
+  });
+
+  it("wraps list items without touching list markers", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "- a\n- b",
+    });
+    e.setSelection(0, 7);
+    toggleUnderline(e);
+    expect(e.getDocument()).toBe("- <u>a</u>\n- <u>b</u>");
+    e.destroy();
+  });
+
+  it("unwraps list items without touching list markers", () => {
+    const c = document.createElement("div");
+    const e = createEditor({
+      container: c,
+      initialValue: "- <u>a</u>\n- <u>b</u>",
+    });
+    e.setSelection(0, 19);
+    toggleUnderline(e);
+    expect(e.getDocument()).toBe("- a\n- b");
+    e.destroy();
+  });
+});
+
+describe("applyTextColor multi-line", () => {
+  it("wraps each line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "a\nb" });
+    e.setSelection(0, 3);
+    applyTextColor(e, "red");
+    expect(e.getDocument()).toBe(
+      '<span style="color:red">a</span>\n<span style="color:red">b</span>',
+    );
+    e.destroy();
+  });
+
+  it("skips list markers", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "1. a\n1. b" });
+    e.setSelection(0, 9);
+    applyTextColor(e, "blue");
+    expect(e.getDocument()).toBe(
+      '1. <span style="color:blue">a</span>\n1. <span style="color:blue">b</span>',
+    );
+    e.destroy();
+  });
+
+  it("partial selection per line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "abc\ndef" });
+    e.setSelection(1, 6);
+    applyTextColor(e, "green");
+    expect(e.getDocument()).toBe(
+      'a<span style="color:green">bc</span>\n<span style="color:green">de</span>f',
+    );
+    e.destroy();
+  });
+});
+
+describe("applyHighlight multi-line", () => {
+  it("wraps each line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "a\nb" });
+    e.setSelection(0, 3);
+    applyHighlight(e, "yellow");
+    expect(e.getDocument()).toBe(
+      '<mark style="background:yellow">a</mark>\n<mark style="background:yellow">b</mark>',
+    );
+    e.destroy();
+  });
+
+  it("skips list markers", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "- a\n- b" });
+    e.setSelection(0, 7);
+    applyHighlight(e, "#ff0");
+    expect(e.getDocument()).toBe(
+      '- <mark style="background:#ff0">a</mark>\n- <mark style="background:#ff0">b</mark>',
+    );
+    e.destroy();
+  });
+
+  it("partial selection per line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "abc\ndef" });
+    e.setSelection(1, 6);
+    applyHighlight(e, "#ff0");
+    expect(e.getDocument()).toBe(
+      'a<mark style="background:#ff0">bc</mark>\n<mark style="background:#ff0">de</mark>f',
+    );
+    e.destroy();
+  });
+});
+
+describe("toggleBlockquote multi-line", () => {
+  it("adds > prefix to each line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "a\nb" });
+    e.setSelection(0, 3);
+    toggleBlockquote(e);
+    expect(e.getDocument()).toBe("> a\n> b");
+    e.destroy();
+  });
+
+  it("removes > prefix from each line", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "> a\n> b" });
+    e.setSelection(0, 7);
+    toggleBlockquote(e);
+    expect(e.getDocument()).toBe("a\nb");
+    e.destroy();
+  });
+
+  it("does not treat empty > as quoted", () => {
+    const c = document.createElement("div");
+    const e = createEditor({ container: c, initialValue: "> \n> b" });
+    e.setSelection(0, 6);
+    toggleBlockquote(e);
+    expect(e.getDocument()).toBe("> > \n> > b");
+    e.destroy();
+  });
 });
 
 describe("createToolbarPlugin", () => {
@@ -150,7 +721,9 @@ describe("createToolbarPlugin", () => {
     // Spot-check the four user-facing categories; the full catalogue is
     // documented in src/index.ts and intentionally not pinned here so
     // adding more commands later isn't a test churn.
-    expect(ids).toEqual(expect.arrayContaining(["h1", "h2", "bold", "image", "hr"]));
+    expect(ids).toEqual(
+      expect.arrayContaining(["h1", "h2", "bold", "image", "hr"]),
+    );
     for (const cmd of plugin.slashCommands ?? []) {
       expect(typeof cmd.run).toBe("function");
     }
@@ -180,23 +753,381 @@ describe("createToolbarUI", () => {
     const toolbar = createToolbarUI(editor);
     document.body.appendChild(toolbar.element);
 
-    const button = toolbar.element.querySelector<HTMLButtonElement>('[data-toolbar-action="unordered-list"]');
+    const button = toolbar.element.querySelector<HTMLButtonElement>(
+      '[data-toolbar-action="unordered-list"]',
+    );
     expect(button).not.toBeNull();
     expect(button?.title).toBe("");
     expect(button?.getAttribute("aria-label")).toBe("Unordered list");
     expect(button?.dataset.toolbarTooltip).toBe("Unordered list");
-    expect(button?.getAttribute("aria-describedby")).toMatch(/^nexus-toolbar-tooltip-/);
+    expect(button?.getAttribute("aria-describedby")).toMatch(
+      /^nexus-toolbar-tooltip-/,
+    );
 
     button?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
 
-    const tooltip = document.getElementById(button?.getAttribute("aria-describedby") ?? "");
+    const tooltip = document.getElementById(
+      button?.getAttribute("aria-describedby") ?? "",
+    );
     expect(tooltip?.getAttribute("role")).toBe("tooltip");
     expect(tooltip?.textContent).toBe("Unordered list");
 
     button?.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
-    expect(document.getElementById(button?.getAttribute("aria-describedby") ?? "")).toBeNull();
+    expect(
+      document.getElementById(button?.getAttribute("aria-describedby") ?? ""),
+    ).toBeNull();
 
     toolbar.destroy();
+    editor.destroy();
+  });
+});
+
+describe("toggleOrderedList", () => {
+  it("adds ordered prefix to current line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello" });
+
+    editor.setSelection(0);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. hello");
+    editor.destroy();
+  });
+
+  it("removes ordered prefix when already OL", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. hello" });
+
+    editor.setSelection(3);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("hello");
+    editor.destroy();
+  });
+
+  it("switches UL to OL on single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- hello" });
+
+    editor.setSelection(2);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. hello");
+    editor.destroy();
+  });
+
+  it("adds ordered prefix to all selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\nb\nc" });
+
+    editor.setSelection(0, 5);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. a\n1. b\n1. c");
+    editor.destroy();
+  });
+
+  it("removes ordered prefix from all selected OL lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. a\n2. b\n3. c",
+    });
+
+    editor.setSelection(0, 13);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("a\nb\nc");
+    editor.destroy();
+  });
+
+  it("switches all selected lines to OL even when mixed", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. a\n- b\nc" });
+
+    editor.setSelection(0, 9);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. a\n1. b\n1. c");
+    editor.destroy();
+  });
+
+  it("does not add prefix to empty lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\n\nc" });
+
+    editor.setSelection(0, 4);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. a\n\n1. c");
+    editor.destroy();
+  });
+
+  it("preserves indentation of selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "  1. a\n  - b" });
+
+    editor.setSelection(0, 12);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("  1. a\n  1. b");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList", () => {
+  it("adds unordered prefix to current line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello" });
+
+    editor.setSelection(0);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- hello");
+    editor.destroy();
+  });
+
+  it("removes unordered prefix when already UL", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- hello" });
+
+    editor.setSelection(2);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("hello");
+    editor.destroy();
+  });
+
+  it("switches OL to UL on single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. hello" });
+
+    editor.setSelection(3);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- hello");
+    editor.destroy();
+  });
+
+  it("adds unordered prefix to all selected lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\nb\nc" });
+
+    editor.setSelection(0, 5);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- a\n- b\n- c");
+    editor.destroy();
+  });
+
+  it("switches all selected lines to UL even when mixed", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. a\n- b\nc" });
+
+    editor.setSelection(0, 9);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- a\n- b\n- c");
+    editor.destroy();
+  });
+
+  it("preserves checkbox when switching OL to UL", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. [x] done" });
+
+    editor.setSelection(0);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- [x] done");
+    editor.destroy();
+  });
+
+  it("does not add prefix to empty lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\n\nc" });
+
+    editor.setSelection(0, 4);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- a\n\n- c");
+    editor.destroy();
+  });
+});
+
+describe("toggleBold multi-line", () => {
+  it("wraps each line in multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\nb\nc" });
+
+    editor.setSelection(0, 5);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("**a**\n**b**\n**c**");
+    editor.destroy();
+  });
+
+  it("removes bold from each wrapped line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "**a**\n**b**" });
+
+    editor.setSelection(0, 11);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("a\nb");
+    editor.destroy();
+  });
+
+  it("wraps list item content without touching markers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. aaa\n2. bbb" });
+
+    editor.setSelection(0, 13);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("1. **aaa**\n2. **bbb**");
+    editor.destroy();
+  });
+
+  it("removes bold from list item content", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. **aaa**\n2. **bbb**",
+    });
+
+    editor.setSelection(0, 21);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("1. aaa\n2. bbb");
+    editor.destroy();
+  });
+
+  it("makes all lines bold when mixed", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "**a**\nb" });
+
+    editor.setSelection(0, 7);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("**a**\n**b**");
+    editor.destroy();
+  });
+
+  it("preserves empty lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "a\n\nc" });
+
+    editor.setSelection(0, 4);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("**a**\n\n**c**");
+    editor.destroy();
+  });
+});
+
+describe("toggleBold cross-marker selection", () => {
+  it("handles selection that excludes trailing marker", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello **world**" });
+
+    editor.setSelection(0, 13);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("**hello world**");
+    editor.destroy();
+  });
+
+  it("handles selection starting inside marker", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "**hello** world" });
+
+    editor.setSelection(2, 14);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("**hello world**");
+    editor.destroy();
+  });
+
+  it("unwraps when only inner content of bold is selected", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "aa **hello** bb" });
+
+    editor.setSelection(3, 10);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("aa hello bb");
+    editor.destroy();
+  });
+
+  it("splits bold at selection start when inside marked region", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**hello world**",
+    });
+
+    editor.setSelection(2, 6);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("hell**o world**");
+    editor.destroy();
+  });
+
+  it("splits bold at selection end when inside marked region", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**hello world**",
+    });
+
+    editor.setSelection(7, 13);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("**hello** world");
+    editor.destroy();
+  });
+});
+
+describe("toggleBold multi-line partial selection", () => {
+  it("strips markers from partial last line and preserves unselected bold", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. **aaa**\n2. **bbbb**",
+    });
+
+    editor.setSelection(0, 18);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("1. aaa\n2. bb**bb**");
+    editor.destroy();
+  });
+
+  it("preserves unselected bold at start of first line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "1. **aaa**\n2. **bbbb**",
+    });
+
+    editor.setSelection(4, 22);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("1. **aaa\n2. bbbb");
+    editor.destroy();
+  });
+
+  it("re-wraps orphaned trailing bold after partial strip", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "**xxx**\n **yyyzzz**",
+    });
+
+    editor.setSelection(0, 14);
+    toggleBold(editor);
+
+    expect(editor.getDocument()).toBe("xxx\n yyy**zzz**");
     editor.destroy();
   });
 });


### PR DESCRIPTION
- feat(plugin-toolbar): multi-line selection support for bold/italic/strikethrough/inline-code/highlight/link
- feat(plugin-toolbar): multi-line blockquote toggle
- feat(plugin-toolbar): multi-line heading toggle with list marker aware
- feat(core): live preview CSS + Prec.highest guards to prevent selection into list markers
- fix(core): list item inline HTML (span, u) now rendered inline instead of breaking list flow
- fix(core): StrikethroughMark added to MARKER_NODE_NAMES
- fix(core): regex fallback for overlapping bold+strikethrough markers in live preview
- fix(plugin-toolbar): toggleWrap star-count algorithm for bold+italic boundary cases
- fix(plugin-toolbar): dead code in toggleBlockquote single-line condition
- docs: update ROADMAP.md/ROADMAP.zh.md with #28, #29, #30
- docs(openspec): add multi-line-formatting change proposal


## Summary / 摘要

多行选区格式化支持（粗体/斜体/删除线/行内代码/高亮/引用/标题），列表标记选区守卫，列表内联 HTML 修复，以及边界情况修复。

## Motivation / 背景与动机

多行格式化是最常用的编辑操作之一，当前仅支持单行。同时在开发过程中发现并修复了多个相关问题：列表标记可被选区覆盖、列表内 `<span>`/`<u>` 在活预览中错误换行、bold+italic 边界 star-count 错误等。

- Roadmap (docs/ROADMAP.md): #28, #29, #30
- OpenSpec change: `openspec/changes/add-multi-line-formatting/`

## Changes / 变更内容

- `packages/core`:
  - **lezer-mdast-adapter.ts**: 列表内 HTML 节点标记 `inline: true`，阻止被渲染为块级 widget；补 `StrikethroughMark` 到 `MARKER_NODE_NAMES`
  - **live-preview.ts**: 列表标记添加 `user-select: none` + `Prec.highest` mousedown/mouseup 守卫防止选区进入标记；内联 HTML 渲染路径保留列表结构；新增 `~~...~~` regex 回退检测处理 bold+strikethrough 重叠标记
  - **test/live-preview.test.ts**: 新增列表标记不可选区、内联 HTML 渲染、删除线嵌套粗体、重叠标记回退等测试
  - **test/live-preview-ranges.test.ts**: 适配 live-preview.ts 内部重构

- `packages/plugin-toolbar/*`:
  - **index.ts**: `toggleWrap` 全面重写 — 支持多行选区；star-count 算法处理 bold/italic 交替；splitsCluster 时用 star-count 保留粗体标记；`toggleBlockquote` 多行支持（移除死代码条件判断）；`toggleHeading` 多行支持（用 `extractLineContent` 剥离列表标记后操作）
  - **formatting.ts**: 新增 `extractLineContent`（分离列表前缀与正文）、`isFullContent`、`isLineWrapped`、`unwrapLine`；多行颜色/高亮/链接切换
  - **toolbar-ui.ts**: 工具栏按钮样式适配
  - **test/plugin-toolbar.test.ts**: 新增 50+ 条测试覆盖多行粗体/斜体/删除线/行内代码/高亮/链接/引用/标题，star-count 边界，列表标记剥离，CJK 场景

- `openspec/`: 新增 `add-multi-line-formatting` 变更提案（proposal + design + specs + tasks）

- `docs/`: ROADMAP.md / ROADMAP.zh.md 更新 #28（多行格式化）、#29（列表标记守卫）、#30（列表内联 HTML 渲染）

## Testing / 测试

- [x] `pnpm test` passes / 全绿
- [x] `plugin-toolbar` vitest: **93 passed**
- [x] `core` live-preview vitest: **51 passed**
- [x] Manual UI check in electron-demo / 手动验证列表多行格式化、列表标记不可选区、内联 HTML 不换行

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — 无公共 API 变更
- [x] Touched `live-preview-table.ts` → N/A（未修改表格 widget）
- [x] New capability / breaking change → OpenSpec proposal linked / 已附 OpenSpec 变更提案
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

https://github.com/user-attachments/assets/4571a1ca-f8fc-453d-b547-e7c9039be784

