### PR TITLE
feat(toolbar): multi-line list toggle for ordered/unordered lists

### DIFF
--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -8,6 +8,44 @@ function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineE
   return { lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) };
 }
 
+interface LineRange {
+  lineStart: number;
+  lineEnd: number;
+  line: string;
+}
+
+/**
+ * Get all lines touched by the current selection (or just the cursor line
+ * when there is no selection). Returns the lines in document order together
+ * with each line's start/end offsets.
+ */
+function getSelectedLines(doc: string, anchor: number, head: number): LineRange[] {
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+
+  const lines: LineRange[] = [];
+  let pos = 0;
+
+  while (pos <= doc.length) {
+    const lineStart = pos;
+    const nlIdx = doc.indexOf("\n", pos);
+    const lineEnd = nlIdx === -1 ? doc.length : nlIdx;
+    const line = doc.slice(lineStart, lineEnd);
+
+    // A line is "selected" when it overlaps the [from, to) range.
+    // For cursor-only selections (from === to) only the line containing
+    // the cursor is returned.
+    if (lineEnd > from && lineStart < to) {
+      lines.push({ lineStart, lineEnd, line });
+    }
+
+    if (nlIdx === -1) break;
+    pos = nlIdx + 1;
+  }
+
+  return lines;
+}
+
 /** Toggle a line prefix (e.g., "> " for blockquote). */
 function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   const doc = editor.getDocument();
@@ -33,45 +71,128 @@ export function toggleBlockquote(editor: EditorAPI): boolean {
 
 export function toggleOrderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const lines = getSelectedLines(doc, anchor, head);
 
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
+  if (lines.length <= 1) {
+    // Single-line (cursor-only) — original behaviour
+    const { lineStart, lineEnd, line } = lines[0] ?? getCurrentLine(doc, anchor);
+
+    const olMatch = line.match(/^\d+\.\s/);
+    let newLine: string;
+    if (olMatch) {
+      newLine = line.slice(olMatch[0].length);
+    } else {
+      const ulMatch = line.match(/^[-*+]\s/);
+      const content = ulMatch ? line.slice(ulMatch[0].length) : line;
+      newLine = "1. " + content;
+    }
+
+    const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+    editor.setDocument(newDoc);
+    editor.setSelection(lineStart + newLine.length);
+    return true;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+  // Multi-line: if ALL lines are already ordered-list items → remove;
+  // otherwise add "N. " to every non-OL line (replacing any UL marker).
+  const allOl = lines.every((l) => /^\d+\.\s/.test(l.line));
+
+  let offset = 0;
+  let newDoc = doc;
+  let firstNewLineStart = lines[0].lineStart;
+  let selectionEnd = firstNewLineStart;
+
+  for (let i = 0; i < lines.length; i++) {
+    const { lineStart, lineEnd, line } = lines[i];
+    const adjStart = lineStart + offset;
+    const adjEnd = lineEnd + offset;
+
+    let newLine: string;
+    if (allOl) {
+      const olMatch = line.match(/^\d+\.\s/)!;
+      newLine = line.slice(olMatch[0].length);
+    } else {
+      const ulMatch = line.match(/^[-*+]\s/);
+      const olMatch = line.match(/^\d+\.\s/);
+      const content = ulMatch
+        ? line.slice(ulMatch[0].length)
+        : olMatch
+          ? line.slice(olMatch[0].length)
+          : line;
+      newLine = `${i + 1}. ` + content;
+    }
+
+    newDoc = newDoc.slice(0, adjStart) + newLine + newDoc.slice(adjEnd);
+    offset += newLine.length - (adjEnd - adjStart);
+    selectionEnd = adjStart + newLine.length;
+  }
+
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setSelection(firstNewLineStart, selectionEnd);
   return true;
 }
 
 export function toggleUnorderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const lines = getSelectedLines(doc, anchor, head);
 
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
+  if (lines.length <= 1) {
+    // Single-line (cursor-only) — original behaviour
+    const { lineStart, lineEnd, line } = lines[0] ?? getCurrentLine(doc, anchor);
+
+    const ulMatch = line.match(/^[-*+]\s/);
+    let newLine: string;
+    if (ulMatch) {
+      newLine = line.slice(ulMatch[0].length);
+    } else {
+      const olMatch = line.match(/^\d+\.\s/);
+      const content = olMatch ? line.slice(olMatch[0].length) : line;
+      newLine = "- " + content;
+    }
+
+    const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+    editor.setDocument(newDoc);
+    editor.setSelection(lineStart + newLine.length);
+    return true;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+  // Multi-line: if ALL lines are already unordered-list items → remove;
+  // otherwise add "- " to every non-UL line (replacing any OL marker).
+  const allUl = lines.every((l) => /^[-*+]\s/.test(l.line));
+
+  let offset = 0;
+  let newDoc = doc;
+  let firstNewLineStart = lines[0].lineStart;
+  let selectionEnd = firstNewLineStart;
+
+  for (const { lineStart, lineEnd, line } of lines) {
+    const adjStart = lineStart + offset;
+    const adjEnd = lineEnd + offset;
+
+    let newLine: string;
+    if (allUl) {
+      const ulMatch = line.match(/^[-*+]\s/)!;
+      newLine = line.slice(ulMatch[0].length);
+    } else {
+      const ulMatch = line.match(/^[-*+]\s/);
+      const olMatch = line.match(/^\d+\.\s/);
+      const content = ulMatch
+        ? line.slice(ulMatch[0].length)
+        : olMatch
+          ? line.slice(olMatch[0].length)
+          : line;
+      newLine = "- " + content;
+    }
+
+    newDoc = newDoc.slice(0, adjStart) + newLine + newDoc.slice(adjEnd);
+    offset += newLine.length - (adjEnd - adjStart);
+    selectionEnd = adjStart + newLine.length;
+  }
+
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setSelection(firstNewLineStart, selectionEnd);
   return true;
 }
 

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -15,30 +15,28 @@ interface LineRange {
 }
 
 /**
- * Get all lines touched by the current selection (or just the cursor line
- * when there is no selection). Returns the lines in document order together
- * with each line's start/end offsets.
+ * Get all lines touched by the [from, to) range. For cursor-only
+ * selections (from === to) only the cursor line is returned.
+ *
+ * Starts scanning from the line containing `from` instead of pos 0.
  */
-function getSelectedLines(doc: string, anchor: number, head: number): LineRange[] {
-  const from = Math.min(anchor, head);
-  const to = Math.max(anchor, head);
-
+function getSelectedLines(doc: string, from: number, to: number): LineRange[] {
   const lines: LineRange[] = [];
-  let pos = 0;
+
+  // Find the start of the line containing `from`
+  let pos = doc.lastIndexOf("\n", from - 1) + 1;
 
   while (pos <= doc.length) {
     const lineStart = pos;
     const nlIdx = doc.indexOf("\n", pos);
     const lineEnd = nlIdx === -1 ? doc.length : nlIdx;
-    const line = doc.slice(lineStart, lineEnd);
 
-    // A line is "selected" when it overlaps the [from, to) range.
-    // For cursor-only selections (from === to) only the line containing
-    // the cursor is returned.
-    if (lineEnd > from && lineStart < to) {
-      lines.push({ lineStart, lineEnd, line });
+    if (lineEnd >= from && lineStart < to) {
+      lines.push({ lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) });
     }
 
+    // Past the selection — stop early
+    if (lineStart >= to) break;
     if (nlIdx === -1) break;
     pos = nlIdx + 1;
   }
@@ -46,18 +44,82 @@ function getSelectedLines(doc: string, anchor: number, head: number): LineRange[
   return lines;
 }
 
-/** Toggle a line prefix (e.g., "> " for blockquote). */
-function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
+// ---------------------------------------------------------------
+//  Shared multi-line list helper
+// ---------------------------------------------------------------
+
+type LineMatcher = (line: string) => boolean;
+type LineTransformer = (line: string, index: number) => string;
+
+/**
+ * Toggle a list prefix across one or more lines.
+ *
+ * - **Single-line** (cursor only): delegates to `singleFn`.
+ * - **Multi-line**: if ALL lines match `isAlready` → strip via `stripFn`;
+ *   otherwise transform every line via `addFn`.
+ */
+function toggleList(
+  editor: EditorAPI,
+  isAlready: LineMatcher,
+  stripFn: (line: string) => string,
+  addFn: LineTransformer,
+  singleFn: (editor: EditorAPI) => boolean,
+): boolean {
+  const doc = editor.getDocument();
+  const { anchor, head } = editor.getSelection();
+  const lines = getSelectedLines(doc, Math.min(anchor, head), Math.max(anchor, head));
+
+  if (lines.length <= 1) {
+    return singleFn(editor);
+  }
+
+  const allMatch = lines.every((l) => isAlready(l.line));
+
+  let offset = 0;
+  let newDoc = doc;
+  const firstStart = lines[0].lineStart;
+  let selEnd = firstStart;
+
+  for (let i = 0; i < lines.length; i++) {
+    const { lineStart, lineEnd, line } = lines[i];
+    const adjStart = lineStart + offset;
+    const adjEnd = lineEnd + offset;
+
+    const newLine = allMatch ? stripFn(line) : addFn(line, i);
+
+    newDoc = newDoc.slice(0, adjStart) + newLine + newDoc.slice(adjEnd);
+    offset += newLine.length - (adjEnd - adjStart);
+    selEnd = adjStart + newLine.length;
+  }
+
+  editor.setDocument(newDoc);
+  editor.setSelection(firstStart, selEnd);
+  return true;
+}
+
+// ---------------------------------------------------------------
+//  Single-line helpers (original behaviour, preserved verbatim)
+// ---------------------------------------------------------------
+
+function stripOl(line: string): string {
+  return line.replace(/^\d+\.\s/, "");
+}
+
+function stripUl(line: string): string {
+  return line.replace(/^[-*+]\s/, "");
+}
+
+function stripAnyList(line: string): string {
+  return stripOl(stripUl(line));
+}
+
+function singleToggleOrderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
   const { anchor } = editor.getSelection();
   const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
 
-  let newLine: string;
-  if (line.startsWith(prefix)) {
-    newLine = line.slice(prefix.length);
-  } else {
-    newLine = prefix + line;
-  }
+  const olMatch = line.match(/^\d+\.\s/);
+  const newLine = olMatch ? line.slice(olMatch[0].length) : "1. " + stripUl(line);
 
   const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
   editor.setDocument(newDoc);
@@ -65,134 +127,79 @@ function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   return true;
 }
 
-export function toggleBlockquote(editor: EditorAPI): boolean {
-  return toggleLinePrefix(editor, "> ");
-}
-
-export function toggleOrderedList(editor: EditorAPI): boolean {
+function singleToggleUnorderedList(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
-  const { anchor, head } = editor.getSelection();
-  const lines = getSelectedLines(doc, anchor, head);
+  const { anchor } = editor.getSelection();
+  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
 
-  if (lines.length <= 1) {
-    // Single-line (cursor-only) — original behaviour
-    const { lineStart, lineEnd, line } = lines[0] ?? getCurrentLine(doc, anchor);
+  const ulMatch = line.match(/^[-*+]\s/);
+  const newLine = ulMatch ? line.slice(ulMatch[0].length) : "- " + stripOl(line);
 
-    const olMatch = line.match(/^\d+\.\s/);
-    let newLine: string;
-    if (olMatch) {
-      newLine = line.slice(olMatch[0].length);
-    } else {
-      const ulMatch = line.match(/^[-*+]\s/);
-      const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-      newLine = "1. " + content;
-    }
-
-    const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-    editor.setDocument(newDoc);
-    editor.setSelection(lineStart + newLine.length);
-    return true;
-  }
-
-  // Multi-line: if ALL lines are already ordered-list items → remove;
-  // otherwise add "N. " to every non-OL line (replacing any UL marker).
-  const allOl = lines.every((l) => /^\d+\.\s/.test(l.line));
-
-  let offset = 0;
-  let newDoc = doc;
-  let firstNewLineStart = lines[0].lineStart;
-  let selectionEnd = firstNewLineStart;
-
-  for (let i = 0; i < lines.length; i++) {
-    const { lineStart, lineEnd, line } = lines[i];
-    const adjStart = lineStart + offset;
-    const adjEnd = lineEnd + offset;
-
-    let newLine: string;
-    if (allOl) {
-      const olMatch = line.match(/^\d+\.\s/)!;
-      newLine = line.slice(olMatch[0].length);
-    } else {
-      const ulMatch = line.match(/^[-*+]\s/);
-      const olMatch = line.match(/^\d+\.\s/);
-      const content = ulMatch
-        ? line.slice(ulMatch[0].length)
-        : olMatch
-          ? line.slice(olMatch[0].length)
-          : line;
-      newLine = `${i + 1}. ` + content;
-    }
-
-    newDoc = newDoc.slice(0, adjStart) + newLine + newDoc.slice(adjEnd);
-    offset += newLine.length - (adjEnd - adjStart);
-    selectionEnd = adjStart + newLine.length;
-  }
-
+  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
   editor.setDocument(newDoc);
-  editor.setSelection(firstNewLineStart, selectionEnd);
+  editor.setSelection(lineStart + newLine.length);
   return true;
 }
 
+// ---------------------------------------------------------------
+//  Public API
+// ---------------------------------------------------------------
+
+export function toggleOrderedList(editor: EditorAPI): boolean {
+  return toggleList(
+    editor,
+    (line) => /^\d+\.\s/.test(line),
+    stripOl,
+    (line, i) => `${i + 1}. ` + stripAnyList(line),
+    singleToggleOrderedList,
+  );
+}
+
 export function toggleUnorderedList(editor: EditorAPI): boolean {
+  return toggleList(
+    editor,
+    (line) => /^[-*+]\s/.test(line),
+    stripUl,
+    (line) => "- " + stripAnyList(line),
+    singleToggleUnorderedList,
+  );
+}
+
+export function toggleBlockquote(editor: EditorAPI): boolean {
   const doc = editor.getDocument();
   const { anchor, head } = editor.getSelection();
-  const lines = getSelectedLines(doc, anchor, head);
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+  const lines = getSelectedLines(doc, from, to);
 
   if (lines.length <= 1) {
-    // Single-line (cursor-only) — original behaviour
+    // Single-line — original behaviour
     const { lineStart, lineEnd, line } = lines[0] ?? getCurrentLine(doc, anchor);
-
-    const ulMatch = line.match(/^[-*+]\s/);
-    let newLine: string;
-    if (ulMatch) {
-      newLine = line.slice(ulMatch[0].length);
-    } else {
-      const olMatch = line.match(/^\d+\.\s/);
-      const content = olMatch ? line.slice(olMatch[0].length) : line;
-      newLine = "- " + content;
-    }
-
+    const newLine = line.startsWith("> ") ? line.slice(2) : "> " + line;
     const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
     editor.setDocument(newDoc);
     editor.setSelection(lineStart + newLine.length);
     return true;
   }
 
-  // Multi-line: if ALL lines are already unordered-list items → remove;
-  // otherwise add "- " to every non-UL line (replacing any OL marker).
-  const allUl = lines.every((l) => /^[-*+]\s/.test(l.line));
+  const allBq = lines.every((l) => l.line.startsWith("> "));
 
   let offset = 0;
   let newDoc = doc;
-  let firstNewLineStart = lines[0].lineStart;
-  let selectionEnd = firstNewLineStart;
+  const firstStart = lines[0].lineStart;
+  let selEnd = firstStart;
 
   for (const { lineStart, lineEnd, line } of lines) {
     const adjStart = lineStart + offset;
     const adjEnd = lineEnd + offset;
-
-    let newLine: string;
-    if (allUl) {
-      const ulMatch = line.match(/^[-*+]\s/)!;
-      newLine = line.slice(ulMatch[0].length);
-    } else {
-      const ulMatch = line.match(/^[-*+]\s/);
-      const olMatch = line.match(/^\d+\.\s/);
-      const content = ulMatch
-        ? line.slice(ulMatch[0].length)
-        : olMatch
-          ? line.slice(olMatch[0].length)
-          : line;
-      newLine = "- " + content;
-    }
-
+    const newLine = allBq ? line.slice(2) : "> " + line;
     newDoc = newDoc.slice(0, adjStart) + newLine + newDoc.slice(adjEnd);
     offset += newLine.length - (adjEnd - adjStart);
-    selectionEnd = adjStart + newLine.length;
+    selEnd = adjStart + newLine.length;
   }
 
   editor.setDocument(newDoc);
-  editor.setSelection(firstNewLineStart, selectionEnd);
+  editor.setSelection(firstStart, selEnd);
   return true;
 }
 
@@ -214,7 +221,6 @@ export function insertCodeBlock(editor: EditorAPI): boolean {
   const newDoc = doc.slice(0, from) + block + doc.slice(to);
   editor.setDocument(newDoc);
 
-  // Place cursor on the language line (after ```)
   const langPos = from + (needsLeadingNewline ? 1 : 0) + 3;
   editor.setSelection(langPos);
   return true;
@@ -232,7 +238,6 @@ export function insertImage(editor: EditorAPI): boolean {
   const newDoc = doc.slice(0, from) + md + doc.slice(to);
   editor.setDocument(newDoc);
 
-  // Select the "url" part
   const urlStart = from + alt.length + 4;
   editor.setSelection(urlStart, urlStart + 3);
   return true;

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -9,6 +9,9 @@ import {
   toggleHeading,
   createToolbarPlugin,
   createToolbarUI,
+  toggleOrderedList,
+  toggleUnorderedList,
+  toggleBlockquote,
 } from "../src/index";
 
 describe("toggleBold", () => {
@@ -197,6 +200,91 @@ describe("createToolbarUI", () => {
     expect(document.getElementById(button?.getAttribute("aria-describedby") ?? "")).toBeNull();
 
     toolbar.destroy();
+    editor.destroy();
+  });
+});
+
+// ------------------------------------------------------------------
+// Multi-line list toggle (ROADMAP #1)
+// ------------------------------------------------------------------
+
+describe("toggleOrderedList – multi-line", () => {
+  it("adds ordered list markers to multiple plain lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "apple\nbanana\ncherry" });
+
+    editor.setSelection(0, 18);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. apple\n2. banana\n3. cherry");
+    editor.destroy();
+  });
+
+  it("removes ordered list markers when all lines are already OL", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. apple\n2. banana\n3. cherry" });
+
+    editor.setSelection(0, 27);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("apple\nbanana\ncherry");
+    editor.destroy();
+  });
+
+  it("converts unordered list lines to ordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- apple\n- banana\n- cherry" });
+
+    editor.setSelection(0, 24);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. apple\n2. banana\n3. cherry");
+    editor.destroy();
+  });
+
+  it("falls back to single-line behaviour when cursor only", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "apple\nbanana\ncherry" });
+
+    editor.setSelection(9);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("apple\n1. banana\ncherry");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList – multi-line", () => {
+  it("adds unordered list markers to multiple plain lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "apple\nbanana\ncherry" });
+
+    editor.setSelection(0, 18);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- apple\n- banana\n- cherry");
+    editor.destroy();
+  });
+
+  it("removes unordered list markers when all lines are already UL", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- apple\n- banana\n- cherry" });
+
+    editor.setSelection(0, 24);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("apple\nbanana\ncherry");
+    editor.destroy();
+  });
+
+  it("converts ordered list lines to unordered list", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. apple\n2. banana\n3. cherry" });
+
+    editor.setSelection(0, 27);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- apple\n- banana\n- cherry");
     editor.destroy();
   });
 });

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -150,9 +150,6 @@ describe("createToolbarPlugin", () => {
   it("registers every formatting action as a slash command", () => {
     const plugin = createToolbarPlugin();
     const ids = (plugin.slashCommands ?? []).map((c) => c.id);
-    // Spot-check the four user-facing categories; the full catalogue is
-    // documented in src/index.ts and intentionally not pinned here so
-    // adding more commands later isn't a test churn.
     expect(ids).toEqual(expect.arrayContaining(["h1", "h2", "bold", "image", "hr"]));
     for (const cmd of plugin.slashCommands ?? []) {
       expect(typeof cmd.run).toBe("function");
@@ -252,6 +249,40 @@ describe("toggleOrderedList – multi-line", () => {
     expect(editor.getDocument()).toBe("apple\n1. banana\ncherry");
     editor.destroy();
   });
+
+  it("handles mixed OL/plain/UL lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. apple\n- banana\ncherry" });
+
+    editor.setSelection(0, 23);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. apple\n2. banana\n3. cherry");
+    editor.destroy();
+  });
+
+  it("preserves text content after list markers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- hello world\n- foo bar" });
+
+    editor.setSelection(0, 23);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. hello world\n2. foo bar");
+    editor.destroy();
+  });
+
+  it("handles selection that starts mid-line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "aaa\nbbb\nccc" });
+
+    // Select from middle of first line to middle of last line
+    editor.setSelection(2, 9);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. aaa\n2. bbb\n3. ccc");
+    editor.destroy();
+  });
 });
 
 describe("toggleUnorderedList – multi-line", () => {
@@ -285,6 +316,67 @@ describe("toggleUnorderedList – multi-line", () => {
     toggleUnorderedList(editor);
 
     expect(editor.getDocument()).toBe("- apple\n- banana\n- cherry");
+    editor.destroy();
+  });
+
+  it("handles mixed UL/plain/OL lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- apple\n1. banana\ncherry" });
+
+    editor.setSelection(0, 24);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- apple\n- banana\n- cherry");
+    editor.destroy();
+  });
+
+  it("falls back to single-line behaviour when cursor only", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "apple\nbanana\ncherry" });
+
+    editor.setSelection(9);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("apple\n- banana\ncherry");
+    editor.destroy();
+  });
+});
+
+// ------------------------------------------------------------------
+// Multi-line blockquote toggle
+// ------------------------------------------------------------------
+
+describe("toggleBlockquote – multi-line", () => {
+  it("adds blockquote prefix to multiple plain lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello\nworld" });
+
+    editor.setSelection(0, 11);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> hello\n> world");
+    editor.destroy();
+  });
+
+  it("removes blockquote prefix when all lines are already quoted", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "> hello\n> world" });
+
+    editor.setSelection(0, 15);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("hello\nworld");
+    editor.destroy();
+  });
+
+  it("falls back to single-line when cursor only", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello\nworld" });
+
+    editor.setSelection(3);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> hello\nworld");
     editor.destroy();
   });
 });


### PR DESCRIPTION
Closed in favour of #38 (whole-word matching). The multi-line list toggle is already covered by #36.