### PR TITLE
feat:add biome husky infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,34 @@ jobs:
       - name: Build Electron demo
         run: pnpm build:electron-demo
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
   publish:
     name: Publish Packages
     runs-on: ubuntu-latest
-    needs: verify
+    needs: [verify, lint]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish)
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist-electron/
 release/
 *.tsbuildinfo
 
+# Coverage
+coverage/
+
 # Logs
 *.log
 npm-debug.log*
@@ -23,4 +26,6 @@ pnpm-debug.log*
 .DS_Store
 Thumbs.db
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec biome check --staged --no-errors-on-unmatched

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "biomejs.biome",
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/apps/electron-demo/electron/main.ts
+++ b/apps/electron-demo/electron/main.ts
@@ -1,15 +1,21 @@
-import { app, BrowserWindow, dialog, ipcMain, net, protocol, shell } from "electron";
-import { readFile, writeFile, readdir, mkdir, rename, stat } from "node:fs/promises";
-import { existsSync, watch, type FSWatcher } from "node:fs";
+import { type FSWatcher, existsSync, watch } from "node:fs";
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { net, BrowserWindow, app, dialog, ipcMain, protocol, shell } from "electron";
 
 // Must be called before app ready — declares our custom scheme as privileged
 // so images served via nexus-vault:// pass fetch/<img> with credentials / CORS.
 protocol.registerSchemesAsPrivileged([
   {
     scheme: "nexus-vault",
-    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, bypassCSP: true },
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      bypassCSP: true,
+    },
   },
 ]);
 
@@ -68,7 +74,10 @@ function createWindow(): void {
   mainWindow.webContents.on("before-input-event", (_event, input) => {
     const meta = input.meta || input.control;
     if (input.type === "keyDown") {
-      if ((meta && input.shift && (input.key === "I" || input.key === "i")) || input.key === "F12") {
+      if (
+        (meta && input.shift && (input.key === "I" || input.key === "i")) ||
+        input.key === "F12"
+      ) {
         mainWindow?.webContents.toggleDevTools();
       }
     }
@@ -100,7 +109,7 @@ ipcMain.handle(
   async (_event: Electron.IpcMainInvokeEvent, filePath: string, content: string) => {
     await writeFile(filePath, content, "utf-8");
     return { path: filePath };
-  }
+  },
 );
 
 ipcMain.handle(
@@ -119,7 +128,7 @@ ipcMain.handle(
 
     await writeFile(result.filePath, content, "utf-8");
     return { path: result.filePath };
-  }
+  },
 );
 
 // -- vault helpers ------------------------------------------------------------
@@ -130,7 +139,7 @@ function assertInsideVault(target: string): string {
   }
   const resolved = path.resolve(target);
   const rel = path.relative(activeVault, resolved);
-  if (rel === "" || rel === "." ) return resolved;
+  if (rel === "" || rel === ".") return resolved;
   if (rel.startsWith("..") || path.isAbsolute(rel)) {
     throw new Error(`Path escapes vault: ${target}`);
   }
@@ -204,7 +213,7 @@ function startWatcher(vaultPath: string): void {
 
   try {
     activeWatcher = watch(vaultPath, { recursive: true }, () => notify());
-  } catch (err) {
+  } catch (_err) {
     // Linux without recursive support — fall back to non-recursive on the root.
     try {
       activeWatcher = watch(vaultPath, () => notify());
@@ -227,7 +236,9 @@ async function readVaultState(): Promise<VaultState> {
     const parsed = JSON.parse(raw) as Partial<VaultState>;
     return {
       lastVault: typeof parsed.lastVault === "string" ? parsed.lastVault : null,
-      recents: Array.isArray(parsed.recents) ? parsed.recents.filter((r) => typeof r === "string") : [],
+      recents: Array.isArray(parsed.recents)
+        ? parsed.recents.filter((r) => typeof r === "string")
+        : [],
     };
   } catch {
     return { lastVault: null, recents: [] };
@@ -316,77 +327,67 @@ ipcMain.handle("vault:write", async (_event, filePath: string, content: string) 
   return { path: abs };
 });
 
-ipcMain.handle(
-  "vault:create-file",
-  async (_event, parentDir: string, name: string) => {
-    const safeInput = name.trim() || "untitled";
-    // Allow the caller to pass a subpath like `Folder/NewNote` — we split it
-    // into an extra parent path relative to `parentDir` and create any
-    // intermediate folders as needed. This is what the wiki-link
-    // create-on-click flow needs when the user types `[[Projects/X]]`.
-    const normInput = safeInput.replace(/\\/g, "/");
-    const segments = normInput.split("/").filter((s) => s.length > 0);
-    if (segments.length === 0) throw new Error("Invalid file name");
-    const baseNameRaw = segments.pop()!;
-    const subDirs = segments.join("/");
+ipcMain.handle("vault:create-file", async (_event, parentDir: string, name: string) => {
+  const safeInput = name.trim() || "untitled";
+  // Allow the caller to pass a subpath like `Folder/NewNote` — we split it
+  // into an extra parent path relative to `parentDir` and create any
+  // intermediate folders as needed. This is what the wiki-link
+  // create-on-click flow needs when the user types `[[Projects/X]]`.
+  const normInput = safeInput.replace(/\\/g, "/");
+  const segments = normInput.split("/").filter((s) => s.length > 0);
+  if (segments.length === 0) throw new Error("Invalid file name");
+  // biome-ignore lint/style/noNonNullAssertion: guarded by length check above
+  const baseNameRaw = segments.pop()!;
+  const subDirs = segments.join("/");
 
-    const parent = assertInsideVault(
-      subDirs ? path.join(parentDir, subDirs) : parentDir
-    );
-    if (subDirs) {
-      await mkdir(parent, { recursive: true });
-    }
-
-    const hasExt = SUPPORTED_EXT.has(path.extname(baseNameRaw).toLowerCase());
-    const baseName = hasExt ? baseNameRaw : `${baseNameRaw}.md`;
-    const ext = path.extname(baseName);
-    const stem = baseName.slice(0, baseName.length - ext.length);
-
-    let candidate = path.join(parent, baseName);
-    let suffix = 1;
-    while (existsSync(candidate)) {
-      candidate = path.join(parent, `${stem}-${suffix}${ext}`);
-      suffix += 1;
-    }
-
-    const finalPath = assertInsideVault(candidate);
-    await writeFile(finalPath, "", "utf-8");
-    return { path: finalPath };
+  const parent = assertInsideVault(subDirs ? path.join(parentDir, subDirs) : parentDir);
+  if (subDirs) {
+    await mkdir(parent, { recursive: true });
   }
-);
 
-ipcMain.handle(
-  "vault:create-folder",
-  async (_event, parentDir: string, name: string) => {
-    const parent = assertInsideVault(parentDir);
-    const safeName = name.trim() || "new-folder";
-    const target = assertInsideVault(path.join(parent, safeName));
-    if (existsSync(target)) {
-      throw new Error(`Folder already exists: ${safeName}`);
-    }
-    await mkdir(target, { recursive: false });
-    return { path: target };
-  }
-);
+  const hasExt = SUPPORTED_EXT.has(path.extname(baseNameRaw).toLowerCase());
+  const baseName = hasExt ? baseNameRaw : `${baseNameRaw}.md`;
+  const ext = path.extname(baseName);
+  const stem = baseName.slice(0, baseName.length - ext.length);
 
-ipcMain.handle(
-  "vault:rename",
-  async (_event, oldPath: string, newName: string) => {
-    const src = assertInsideVault(oldPath);
-    const parent = path.dirname(src);
-    const trimmed = newName.trim();
-    if (!trimmed) throw new Error("New name cannot be empty");
-    if (trimmed.includes("/") || trimmed.includes("\\")) {
-      throw new Error("New name cannot contain path separators");
-    }
-    const target = assertInsideVault(path.join(parent, trimmed));
-    if (existsSync(target) && target !== src) {
-      throw new Error(`Target already exists: ${trimmed}`);
-    }
-    await rename(src, target);
-    return { path: target };
+  let candidate = path.join(parent, baseName);
+  let suffix = 1;
+  while (existsSync(candidate)) {
+    candidate = path.join(parent, `${stem}-${suffix}${ext}`);
+    suffix += 1;
   }
-);
+
+  const finalPath = assertInsideVault(candidate);
+  await writeFile(finalPath, "", "utf-8");
+  return { path: finalPath };
+});
+
+ipcMain.handle("vault:create-folder", async (_event, parentDir: string, name: string) => {
+  const parent = assertInsideVault(parentDir);
+  const safeName = name.trim() || "new-folder";
+  const target = assertInsideVault(path.join(parent, safeName));
+  if (existsSync(target)) {
+    throw new Error(`Folder already exists: ${safeName}`);
+  }
+  await mkdir(target, { recursive: false });
+  return { path: target };
+});
+
+ipcMain.handle("vault:rename", async (_event, oldPath: string, newName: string) => {
+  const src = assertInsideVault(oldPath);
+  const parent = path.dirname(src);
+  const trimmed = newName.trim();
+  if (!trimmed) throw new Error("New name cannot be empty");
+  if (trimmed.includes("/") || trimmed.includes("\\")) {
+    throw new Error("New name cannot contain path separators");
+  }
+  const target = assertInsideVault(path.join(parent, trimmed));
+  if (existsSync(target) && target !== src) {
+    throw new Error(`Target already exists: ${trimmed}`);
+  }
+  await rename(src, target);
+  return { path: target };
+});
 
 ipcMain.handle("vault:delete", async (_event, targetPath: string) => {
   const abs = assertInsideVault(targetPath);

--- a/apps/electron-demo/package.json
+++ b/apps/electron-demo/package.json
@@ -44,11 +44,7 @@
     "directories": {
       "output": "release"
     },
-    "files": [
-      "dist-electron/**/*",
-      "dist/**/*",
-      "package.json"
-    ],
+    "files": ["dist-electron/**/*", "dist/**/*", "package.json"],
     "extraMetadata": {
       "name": "nexus-editor",
       "main": "dist-electron/main.js",
@@ -60,17 +56,11 @@
       "target": [
         {
           "target": "dmg",
-          "arch": [
-            "arm64",
-            "x64"
-          ]
+          "arch": ["arm64", "x64"]
         },
         {
           "target": "zip",
-          "arch": [
-            "arm64",
-            "x64"
-          ]
+          "arch": ["arm64", "x64"]
         }
       ],
       "identity": null,
@@ -84,15 +74,11 @@
       "target": [
         {
           "target": "nsis",
-          "arch": [
-            "x64"
-          ]
+          "arch": ["x64"]
         },
         {
           "target": "portable",
-          "arch": [
-            "x64"
-          ]
+          "arch": ["x64"]
         }
       ]
     },
@@ -105,15 +91,11 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": [
-            "x64"
-          ]
+          "arch": ["x64"]
         },
         {
           "target": "deb",
-          "arch": [
-            "x64"
-          ]
+          "arch": ["x64"]
         }
       ],
       "category": "Office"

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -1,12 +1,12 @@
-import { createState, type AppState } from "./state";
-import { createEditorShell, type EditorShell } from "./editor-shell";
-import { loadSettings, createSettingsPanel, type EditorSettings } from "./settings";
-import { createOutlinePanel, type OutlinePanel } from "./outline-panel";
-import { createSearchBar, type SearchBar } from "./search-bar";
-import { createVaultPanel, type VaultPanel } from "./vault-panel";
-import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
-import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
-import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
+import { type BacklinksPanel, createBacklinksPanel } from "./backlinks-panel";
+import { type EditorShell, createEditorShell } from "./editor-shell";
+import { LinkIndex, findAnchorPosition, parseAnchor } from "./link-index";
+import { type OutlinePanel, createOutlinePanel } from "./outline-panel";
+import { installLongTaskWatch, perfEnd, perfStart } from "./perf";
+import { type SearchBar, createSearchBar } from "./search-bar";
+import { type EditorSettings, createSettingsPanel, loadSettings } from "./settings";
+import { type AppState, createState } from "./state";
+import { type VaultPanel, createVaultPanel } from "./vault-panel";
 
 installLongTaskWatch(50);
 
@@ -87,7 +87,7 @@ function createAppToolbar(): HTMLElement {
     outlineBtn,
     backlinksBtn,
     searchBtn,
-    settingsBtn
+    settingsBtn,
   );
   return toolbar;
 }
@@ -107,9 +107,7 @@ function renderStatus(): void {
   const dirtyMark = state.dirty ? " [modified]" : "";
   const stats = shell?.editor.getDocumentStats();
   const statsText = stats ? ` | ${stats.words} words, ${stats.lines} lines` : "";
-  const vaultLabel = state.vaultPath
-    ? ` | Vault: ${state.vaultPath.split(/[\\/]/).pop()}`
-    : "";
+  const vaultLabel = state.vaultPath ? ` | Vault: ${state.vaultPath.split(/[\\/]/).pop()}` : "";
   const errorText = state.error ? ` — Error: ${state.error}` : "";
   el.textContent = `${pathLabel}${dirtyMark}${statsText}${vaultLabel}${errorText}`;
 }
@@ -270,7 +268,10 @@ async function seedLinkIndex(): Promise<void> {
   perfEnd(total);
 }
 
-async function handleWikilinkNavigate(target: string, opts: { unresolved: boolean }): Promise<void> {
+async function handleWikilinkNavigate(
+  target: string,
+  opts: { unresolved: boolean },
+): Promise<void> {
   try {
     state.error = null;
     // Parse `#heading` / `^blockid` — bare part is what the resolver needs

--- a/apps/electron-demo/src/renderer/backlinks-panel.ts
+++ b/apps/electron-demo/src/renderer/backlinks-panel.ts
@@ -1,4 +1,4 @@
-import type { LinkIndex, BacklinkHit } from "./link-index";
+import type { BacklinkHit, LinkIndex } from "./link-index";
 
 export interface BacklinksPanelOptions {
   index: LinkIndex;
@@ -237,9 +237,13 @@ export function createBacklinksPanel(options: BacklinksPanelOptions): BacklinksP
       const t1 = performance.now();
       if ((globalThis as { NEXUS_PERF?: boolean }).NEXUS_PERF !== false && t1 - t0 > 5) {
         // eslint-disable-next-line no-console
-        console.log("%c[perf]", "color:#0aa;font-weight:bold",
-          "backlinks.unlinked-scan", `${(t1 - t0).toFixed(1)}ms`,
-          { hits: unlinked.length });
+        console.log(
+          "%c[perf]",
+          "color:#0aa;font-weight:bold",
+          "backlinks.unlinked-scan",
+          `${(t1 - t0).toFixed(1)}ms`,
+          { hits: unlinked.length },
+        );
       }
       header.textContent = `Backlinks · ${linked.length} linked · ${unlinked.length} mention${unlinked.length === 1 ? "" : "s"}`;
       unlinkedHeader.textContent = "";

--- a/apps/electron-demo/src/renderer/bridge.d.ts
+++ b/apps/electron-demo/src/renderer/bridge.d.ts
@@ -37,6 +37,7 @@ interface DemoBridge {
   vault: VaultBridge;
 }
 
+// biome-ignore lint/correctness/noUnusedVariables: declaration merging augments global Window
 interface Window {
   nexusDemo: DemoBridge;
 }

--- a/apps/electron-demo/src/renderer/editor-shell.ts
+++ b/apps/electron-demo/src/renderer/editor-shell.ts
@@ -1,16 +1,20 @@
 import {
-  createEditor,
-  createWikilinksPlugin,
   type EditorAPI,
   type LivePreviewRenderContext,
+  createEditor,
+  createWikilinksPlugin,
 } from "@floatboat/nexus-core";
-import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
-import { createToolbarPlugin, createToolbarUI, type ToolbarUI } from "@floatboat/nexus-plugin-toolbar";
 import { createSearchPlugin } from "@floatboat/nexus-plugin-search";
-import { createSlashMenuUI, type SlashMenuUI } from "@floatboat/nexus-plugin-slash";
-import type { AppState } from "./state";
+import { type SlashMenuUI, createSlashMenuUI } from "@floatboat/nexus-plugin-slash";
+import {
+  type ToolbarUI,
+  createToolbarPlugin,
+  createToolbarUI,
+} from "@floatboat/nexus-plugin-toolbar";
+import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 import { type EditorSettings, settingsToTheme } from "./settings";
+import type { AppState } from "./state";
 
 // Parse Obsidian-style size specifier from the alt text: `alt|width` or
 // `alt|widthxheight`. Returns { alt, width, height } with the size stripped
@@ -31,20 +35,16 @@ function parseImageSize(raw: string): { alt: string; width?: number; height?: nu
 
 // Rewrite relative image URLs to the custom nexus-vault:// scheme registered
 // in the main process. Absolute URLs (http, https, data, etc) pass through.
-function resolveImageSrc(
-  url: string,
-  activeFile: string | null,
-  vaultRoot: string | null
-): string {
+function resolveImageSrc(url: string, activeFile: string | null, vaultRoot: string | null): string {
   if (/^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith("//")) return url;
   if (!activeFile || !vaultRoot) return url;
 
-  const sep = activeFile.includes("\\") && !activeFile.includes("/") ? "\\" : "/";
+  const _sep = activeFile.includes("\\") && !activeFile.includes("/") ? "\\" : "/";
   const normActive = activeFile.replace(/\\/g, "/");
   const normVault = vaultRoot.replace(/\\/g, "/").replace(/\/+$/, "");
   const lastSlash = normActive.lastIndexOf("/");
   const activeDir = lastSlash >= 0 ? normActive.slice(0, lastSlash) : "";
-  const joined = activeDir + "/" + url.replace(/\\/g, "/");
+  const joined = `${activeDir}/${url.replace(/\\/g, "/")}`;
 
   const parts: string[] = [];
   for (const p of joined.split("/")) {
@@ -54,7 +54,7 @@ function resolveImageSrc(
   }
   const absNorm = (joined.startsWith("/") ? "/" : "") + parts.join("/");
 
-  if (absNorm !== normVault && !absNorm.startsWith(normVault + "/")) return url;
+  if (absNorm !== normVault && !absNorm.startsWith(`${normVault}/`)) return url;
   const rel = absNorm.slice(normVault.length + 1);
   const encoded = rel.split("/").map(encodeURIComponent).join("/");
   return `nexus-vault://vault/${encoded}`;
@@ -156,8 +156,8 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
               img.style.maxWidth = "100%";
               img.style.height = "auto";
               img.style.borderRadius = "4px";
-              if (typeof width === "number") img.style.width = width + "px";
-              if (typeof height === "number") img.style.height = height + "px";
+              if (typeof width === "number") img.style.width = `${width}px`;
+              if (typeof height === "number") img.style.height = `${height}px`;
 
               // Top-right action: jump cursor to image source.
               const srcBtn = document.createElement("button");
@@ -165,7 +165,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
               srcBtn.title = "View source";
               srcBtn.setAttribute("aria-label", "View image markdown source");
               srcBtn.textContent = "</>";
-              srcBtn.style.cssText = [
+              srcBtn.style.cssText = `${[
                 "position:absolute",
                 "top:6px",
                 "right:6px",
@@ -183,8 +183,14 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
                 "user-select:none",
                 "transition:opacity .15s",
                 "box-shadow:0 1px 2px rgba(0,0,0,0.08)",
-              ].join(";") + ";";
-              srcBtn.addEventListener("mousedown", (e) => { e.stopPropagation(); }, true);
+              ].join(";")};`;
+              srcBtn.addEventListener(
+                "mousedown",
+                (e) => {
+                  e.stopPropagation();
+                },
+                true,
+              );
               srcBtn.addEventListener("click", (e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -200,7 +206,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
               // back `|width` into the image's alt in markdown.
               const resizeDot = document.createElement("span");
               resizeDot.title = "Drag to resize";
-              resizeDot.style.cssText = [
+              resizeDot.style.cssText = `${[
                 "position:absolute",
                 "bottom:2px",
                 "right:2px",
@@ -212,7 +218,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
                 "z-index:2",
                 "cursor:nwse-resize",
                 "transition:opacity .15s",
-              ].join(";") + ";";
+              ].join(";")};`;
 
               let dragging = false;
               let startX = 0;
@@ -220,7 +226,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
               const onMove = (e: MouseEvent) => {
                 if (!dragging) return;
                 const newW = Math.max(40, Math.round(startW + (e.clientX - startX)));
-                img.style.width = newW + "px";
+                img.style.width = `${newW}px`;
                 img.style.height = "auto";
               };
               const onUp = (e: MouseEvent) => {
@@ -343,8 +349,13 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
       // decoration rebuild chain (live-preview buildDecorations), so this
       // number is the practical "time to render the opened file".
       // eslint-disable-next-line no-console
-      console.log("%c[perf]", "color:#0aa;font-weight:bold", "editor.setDocument",
-        `${(t1 - t0).toFixed(1)}ms`, { bytes: content.length });
+      console.log(
+        "%c[perf]",
+        "color:#0aa;font-weight:bold",
+        "editor.setDocument",
+        `${(t1 - t0).toFixed(1)}ms`,
+        { bytes: content.length },
+      );
     },
     destroy() {
       slashMenu.destroy();

--- a/apps/electron-demo/src/renderer/link-index.ts
+++ b/apps/electron-demo/src/renderer/link-index.ts
@@ -1,4 +1,4 @@
-import { scanWikiLinks, type WikiLinkMatch } from "@floatboat/nexus-core";
+import { type WikiLinkMatch, scanWikiLinks } from "@floatboat/nexus-core";
 
 /** Prefer requestIdleCallback for yielding; fall back to a macrotask otherwise. */
 function yieldToIdle(): Promise<void> {
@@ -79,9 +79,7 @@ export function stripAnchor(target: string): string {
   return target.slice(0, cut).trim();
 }
 
-export type LinkAnchor =
-  | { kind: "heading"; value: string }
-  | { kind: "block"; value: string };
+export type LinkAnchor = { kind: "heading"; value: string } | { kind: "block"; value: string };
 
 /**
  * Split a wiki-link target into the bare path part and its Obsidian anchor
@@ -119,7 +117,10 @@ function normalizeHeadingText(s: string): string {
  */
 export function findAnchorPosition(content: string, anchor: LinkAnchor): number | null {
   if (anchor.kind === "heading") {
-    const segments = anchor.value.split("#").map((s) => s.trim()).filter(Boolean);
+    const segments = anchor.value
+      .split("#")
+      .map((s) => s.trim())
+      .filter(Boolean);
     if (segments.length === 0) return null;
     const needle = normalizeHeadingText(segments[segments.length - 1]);
     const lines = content.split("\n");
@@ -307,6 +308,7 @@ export class LinkIndex {
       const wikiRanges = this.forward.get(source) ?? [];
       re.lastIndex = 0;
       let m: RegExpExecArray | null;
+      // biome-ignore lint/suspicious/noAssignInExpressions: standard RegExp loop idiom
       while ((m = re.exec(content)) !== null) {
         const start = m.index;
         const end = start + m[0].length;
@@ -353,6 +355,7 @@ export class LinkIndex {
     // a literal filename and falsely reports unresolved.
     const bare = stripAnchor(name);
     if (!bare) return null;
+    // biome-ignore lint/style/noParameterAssign: stripped anchor assigned back to param
     name = bare;
     const normFrom = fromPath ? normalizeSlashes(fromPath) : null;
     const candidates = contents;
@@ -440,7 +443,9 @@ export class LinkIndex {
     const raf: ((cb: () => void) => number) | undefined = (
       globalThis as { requestAnimationFrame?: (cb: () => void) => number }
     ).requestAnimationFrame;
-    const schedule = raf ? (cb: () => void) => raf(cb) : (cb: () => void) => setTimeout(cb, 0) as unknown as number;
+    const schedule = raf
+      ? (cb: () => void) => raf(cb)
+      : (cb: () => void) => setTimeout(cb, 0) as unknown as number;
     this.notifyHandle = schedule(() => {
       this.notifyHandle = null;
       this.notifyNow();

--- a/apps/electron-demo/src/renderer/outline-panel.ts
+++ b/apps/electron-demo/src/renderer/outline-panel.ts
@@ -91,7 +91,7 @@ export function createOutlinePanel(editor: EditorAPI): OutlinePanel {
       item.textContent = entry.text;
       item.title = entry.text;
       item.style.cssText = ITEM_BASE;
-      item.style.paddingLeft = (14 + (entry.level - 1) * 14) + "px";
+      item.style.paddingLeft = `${14 + (entry.level - 1) * 14}px`;
       item.style.fontWeight = entry.level <= 2 ? "600" : "400";
       item.style.fontSize = entry.level === 1 ? "14px" : "13px";
 

--- a/apps/electron-demo/src/renderer/perf.ts
+++ b/apps/electron-demo/src/renderer/perf.ts
@@ -55,11 +55,7 @@ export async function perfAsync<T>(
   }
 }
 
-export function perfSync<T>(
-  label: string,
-  fn: () => T,
-  extras?: Record<string, unknown>,
-): T {
+export function perfSync<T>(label: string, fn: () => T, extras?: Record<string, unknown>): T {
   const s = perfStart(label, extras);
   try {
     return fn();
@@ -72,7 +68,8 @@ let longTaskInstalled = false;
 export function installLongTaskWatch(thresholdMs = 50): void {
   if (longTaskInstalled) return;
   longTaskInstalled = true;
-  const PO = (globalThis as { PerformanceObserver?: typeof PerformanceObserver }).PerformanceObserver;
+  const PO = (globalThis as { PerformanceObserver?: typeof PerformanceObserver })
+    .PerformanceObserver;
   if (!PO) return;
   try {
     const obs = new PO((list) => {
@@ -80,12 +77,10 @@ export function installLongTaskWatch(thresholdMs = 50): void {
       for (const entry of list.getEntries()) {
         if (entry.duration < thresholdMs) continue;
         // eslint-disable-next-line no-console
-        console.warn(
-          PREFIX,
-          STYLE,
-          `long-task ${fmt(entry.duration)}`,
-          { name: entry.name, at: entry.startTime.toFixed(0) },
-        );
+        console.warn(PREFIX, STYLE, `long-task ${fmt(entry.duration)}`, {
+          name: entry.name,
+          at: entry.startTime.toFixed(0),
+        });
       }
     });
     obs.observe({ entryTypes: ["longtask"] });

--- a/apps/electron-demo/src/renderer/search-bar.ts
+++ b/apps/electron-demo/src/renderer/search-bar.ts
@@ -113,7 +113,17 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   const spacer = document.createElement("div");
   spacer.style.flex = "1";
 
-  bar.append(findInput, prevBtn, nextBtn, countLabel, replaceInput, replaceBtn, replaceAllBtn, spacer, closeBtn);
+  bar.append(
+    findInput,
+    prevBtn,
+    nextBtn,
+    countLabel,
+    replaceInput,
+    replaceBtn,
+    replaceAllBtn,
+    spacer,
+    closeBtn,
+  );
 
   // State
   let matches: Array<{ from: number; to: number }> = [];
@@ -138,7 +148,10 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
       const { anchor } = editor.getSelection();
       currentIdx = 0;
       for (let i = 0; i < matches.length; i++) {
-        if (matches[i].from >= anchor) { currentIdx = i; break; }
+        if (matches[i].from >= anchor) {
+          currentIdx = i;
+          break;
+        }
       }
       highlightCurrent();
     }
@@ -186,12 +199,22 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   // Event handlers
   findInput.addEventListener("input", updateMatches);
   findInput.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") { e.shiftKey ? goPrev() : goNext(); e.preventDefault(); }
-    if (e.key === "Escape") { close(); }
+    if (e.key === "Enter") {
+      e.shiftKey ? goPrev() : goNext();
+      e.preventDefault();
+    }
+    if (e.key === "Escape") {
+      close();
+    }
   });
   replaceInput.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") { doReplace(); e.preventDefault(); }
-    if (e.key === "Escape") { close(); }
+    if (e.key === "Enter") {
+      doReplace();
+      e.preventDefault();
+    }
+    if (e.key === "Escape") {
+      close();
+    }
   });
   nextBtn.addEventListener("click", goNext);
   prevBtn.addEventListener("click", goPrev);
@@ -200,7 +223,11 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   closeBtn.addEventListener("click", close);
 
   function open() {
-    if (visible) { findInput.focus(); findInput.select(); return; }
+    if (visible) {
+      findInput.focus();
+      findInput.select();
+      return;
+    }
     visible = true;
     bar.style.display = "flex";
     findInput.focus();

--- a/apps/electron-demo/src/renderer/settings.ts
+++ b/apps/electron-demo/src/renderer/settings.ts
@@ -1,4 +1,4 @@
-import { lightTheme, darkTheme, type NexusTheme } from "@floatboat/nexus-core";
+import { type NexusTheme, darkTheme, lightTheme } from "@floatboat/nexus-core";
 
 export interface EditorSettings {
   /** "light" | "dark" */
@@ -35,14 +35,18 @@ export function loadSettings(): EditorSettings {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) return { ...defaultSettings(), ...JSON.parse(raw) };
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
   return defaultSettings();
 }
 
 export function saveSettings(settings: EditorSettings): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 }
 
 export function settingsToTheme(settings: EditorSettings): NexusTheme {
@@ -145,6 +149,7 @@ function createToggle(value: boolean, onChange: (v: boolean) => void): HTMLEleme
   };
   update(value);
   btn.addEventListener("click", () => {
+    // biome-ignore lint/style/noParameterAssign: toggle pattern
     value = !value;
     update(value);
     onChange(value);
@@ -152,7 +157,11 @@ function createToggle(value: boolean, onChange: (v: boolean) => void): HTMLEleme
   return btn;
 }
 
-function createSelect(options: string[], value: string, onChange: (v: string) => void): HTMLElement {
+function createSelect(
+  options: string[],
+  value: string,
+  onChange: (v: string) => void,
+): HTMLElement {
   const sel = document.createElement("select");
   sel.style.cssText = `
     padding: 4px 8px; border-radius: 6px; font-size: 13px;
@@ -172,7 +181,13 @@ function createSelect(options: string[], value: string, onChange: (v: string) =>
   return sel;
 }
 
-function createNumberInput(value: number, min: number, max: number, step: number, onChange: (v: number) => void): HTMLElement {
+function createNumberInput(
+  value: number,
+  min: number,
+  max: number,
+  step: number,
+  onChange: (v: number) => void,
+): HTMLElement {
   const wrap = document.createElement("div");
   wrap.style.cssText = "display:flex;align-items:center;gap:8px;flex-shrink:0;";
 
@@ -186,7 +201,8 @@ function createNumberInput(value: number, min: number, max: number, step: number
 
   const label = document.createElement("span");
   label.textContent = String(value);
-  label.style.cssText = "font-size:13px;min-width:28px;text-align:right;color:var(--nexus-text-muted,#888);";
+  label.style.cssText =
+    "font-size:13px;min-width:28px;text-align:right;color:var(--nexus-text-muted,#888);";
 
   input.addEventListener("input", () => {
     const v = Number(input.value);
@@ -198,7 +214,11 @@ function createNumberInput(value: number, min: number, max: number, step: number
   return wrap;
 }
 
-function createTextInput(value: string, placeholder: string, onChange: (v: string) => void): HTMLElement {
+function createTextInput(
+  value: string,
+  placeholder: string,
+  onChange: (v: string) => void,
+): HTMLElement {
   const input = document.createElement("input");
   input.type = "text";
   input.value = value;
@@ -241,7 +261,10 @@ function sectionTitle(text: string): HTMLElement {
   return el;
 }
 
-export function createSettingsPanel(settings: EditorSettings, onChange: OnChange): SettingsPanelResult {
+export function createSettingsPanel(
+  settings: EditorSettings,
+  onChange: OnChange,
+): SettingsPanelResult {
   const backdrop = document.createElement("div");
   backdrop.style.cssText = PANEL_STYLES;
 
@@ -264,35 +287,135 @@ export function createSettingsPanel(settings: EditorSettings, onChange: OnChange
   body.style.cssText = SECTION_STYLES;
 
   const s = { ...settings };
-  const emit = () => { saveSettings(s); onChange(s); };
+  const emit = () => {
+    saveSettings(s);
+    onChange(s);
+  };
 
   // -- Display section --
   body.appendChild(sectionTitle("Display"));
-  body.appendChild(row("Color scheme", "Light or dark theme", createSelect(["light", "dark"], s.colorScheme, (v) => { s.colorScheme = v as "light" | "dark"; emit(); })));
-  body.appendChild(row("Line numbers", "Show line numbers in the gutter", createToggle(s.lineNumbers, (v) => { s.lineNumbers = v; emit(); })));
-  body.appendChild(row("Live preview", "Render markdown in real-time", createToggle(s.livePreview, (v) => { s.livePreview = v; emit(); })));
-  body.appendChild(row("Indent guides", "Show indentation guide lines", createToggle(s.indentGuides, (v) => { s.indentGuides = v; emit(); })));
-  body.appendChild(row("Content max width", "Limit line width for readability (e.g. 720px)", createTextInput(s.contentMaxWidth, "e.g. 720px", (v) => { s.contentMaxWidth = v; emit(); })));
-  body.appendChild(row("Text direction", "Left-to-right or right-to-left", createSelect(["ltr", "rtl"], s.direction, (v) => { s.direction = v as "ltr" | "rtl"; emit(); })));
+  body.appendChild(
+    row(
+      "Color scheme",
+      "Light or dark theme",
+      createSelect(["light", "dark"], s.colorScheme, (v) => {
+        s.colorScheme = v as "light" | "dark";
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Line numbers",
+      "Show line numbers in the gutter",
+      createToggle(s.lineNumbers, (v) => {
+        s.lineNumbers = v;
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Live preview",
+      "Render markdown in real-time",
+      createToggle(s.livePreview, (v) => {
+        s.livePreview = v;
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Indent guides",
+      "Show indentation guide lines",
+      createToggle(s.indentGuides, (v) => {
+        s.indentGuides = v;
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Content max width",
+      "Limit line width for readability (e.g. 720px)",
+      createTextInput(s.contentMaxWidth, "e.g. 720px", (v) => {
+        s.contentMaxWidth = v;
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Text direction",
+      "Left-to-right or right-to-left",
+      createSelect(["ltr", "rtl"], s.direction, (v) => {
+        s.direction = v as "ltr" | "rtl";
+        emit();
+      }),
+    ),
+  );
 
   // -- Font section --
   body.appendChild(sectionTitle("Font"));
-  body.appendChild(row("Font size", "Editor text size in pixels", createNumberInput(s.fontSize, 10, 28, 1, (v) => { s.fontSize = v; emit(); })));
-  body.appendChild(row("Body font", "Font for prose content", createTextInput(s.fontFamily, "system-ui, sans-serif", (v) => { s.fontFamily = v; emit(); })));
-  body.appendChild(row("Code font", "Monospace font for code blocks", createTextInput(s.fontFamilyMono, "ui-monospace, monospace", (v) => { s.fontFamilyMono = v; emit(); })));
+  body.appendChild(
+    row(
+      "Font size",
+      "Editor text size in pixels",
+      createNumberInput(s.fontSize, 10, 28, 1, (v) => {
+        s.fontSize = v;
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Body font",
+      "Font for prose content",
+      createTextInput(s.fontFamily, "system-ui, sans-serif", (v) => {
+        s.fontFamily = v;
+        emit();
+      }),
+    ),
+  );
+  body.appendChild(
+    row(
+      "Code font",
+      "Monospace font for code blocks",
+      createTextInput(s.fontFamilyMono, "ui-monospace, monospace", (v) => {
+        s.fontFamilyMono = v;
+        emit();
+      }),
+    ),
+  );
 
   // -- Behavior section --
   body.appendChild(sectionTitle("Behavior"));
-  body.appendChild(row("Tab size", "Number of spaces per tab", createNumberInput(s.tabSize, 1, 8, 1, (v) => { s.tabSize = v; emit(); })));
+  body.appendChild(
+    row(
+      "Tab size",
+      "Number of spaces per tab",
+      createNumberInput(s.tabSize, 1, 8, 1, (v) => {
+        s.tabSize = v;
+        emit();
+      }),
+    ),
+  );
 
   dialog.append(header, body);
   backdrop.appendChild(dialog);
 
   const close = () => backdrop.remove();
   closeBtn.addEventListener("click", close);
-  backdrop.addEventListener("click", (e) => { if (e.target === backdrop) close(); });
+  backdrop.addEventListener("click", (e) => {
+    if (e.target === backdrop) close();
+  });
 
-  const handleEsc = (e: KeyboardEvent) => { if (e.key === "Escape") { close(); document.removeEventListener("keydown", handleEsc); } };
+  const handleEsc = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      close();
+      document.removeEventListener("keydown", handleEsc);
+    }
+  };
   document.addEventListener("keydown", handleEsc);
 
   document.body.appendChild(backdrop);

--- a/apps/electron-demo/src/renderer/vault-panel.ts
+++ b/apps/electron-demo/src/renderer/vault-panel.ts
@@ -115,6 +115,7 @@ interface ContextMenuItem {
 }
 
 function showContextMenu(x: number, y: number, items: ContextMenuItem[]): void {
+  // biome-ignore lint/complexity/noForEach: concise one-liner for DOM cleanup
   document.querySelectorAll(".nexus-vault-ctxmenu").forEach((el) => el.remove());
 
   const menu = document.createElement("div");
@@ -323,7 +324,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
     for (const node of currentTree) renderNode(node, 0, tree);
   }
 
-  function beginInlineRename(row: HTMLElement, label: HTMLElement, node: VaultNode): void {
+  function beginInlineRename(_row: HTMLElement, label: HTMLElement, node: VaultNode): void {
     const input = document.createElement("input");
     input.type = "text";
     input.value = node.name;
@@ -374,7 +375,8 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
   }
 
   function openNodeContextMenu(x: number, y: number, node: VaultNode): void {
-    const parentDir = node.kind === "directory" ? node.path : node.path.replace(/[\\/][^\\/]+$/, "");
+    const parentDir =
+      node.kind === "directory" ? node.path : node.path.replace(/[\\/][^\\/]+$/, "");
     const items: ContextMenuItem[] = [];
 
     if (node.kind === "directory") {

--- a/apps/electron-demo/test/app-handlers.test.ts
+++ b/apps/electron-demo/test/app-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createState } from "../src/renderer/state";
 
 function mockBridge() {

--- a/apps/electron-demo/test/editor-shell.test.ts
+++ b/apps/electron-demo/test/editor-shell.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createEditorShell } from "../src/renderer/editor-shell";
-import { createState } from "../src/renderer/state";
 import { defaultSettings } from "../src/renderer/settings";
+import { createState } from "../src/renderer/state";
 
 describe("createEditorShell", () => {
   it("creates a core editor in the given container", () => {

--- a/apps/electron-demo/test/link-index.test.ts
+++ b/apps/electron-demo/test/link-index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { LinkIndex, stripAnchor, parseAnchor, findAnchorPosition } from "../src/renderer/link-index";
+import {
+  LinkIndex,
+  findAnchorPosition,
+  parseAnchor,
+  stripAnchor,
+} from "../src/renderer/link-index";
 
 describe("LinkIndex.resolve", () => {
   it("resolves a globally unique basename", () => {
@@ -204,7 +209,7 @@ describe("LinkIndex.resolve — anchor-aware", () => {
       { path: "/v/Projects/Ideas.md", content: "[[Projects/Nexus-Editor^block]]" },
     ]);
     expect(idx.resolve("Projects/Nexus-Editor^block", "/v/Projects/Ideas.md")).toBe(
-      "/v/Projects/Nexus-Editor.md"
+      "/v/Projects/Nexus-Editor.md",
     );
   });
 
@@ -256,9 +261,7 @@ describe("LinkIndex.getUnlinkedMentions", () => {
 
   it("excludes self-mentions in the target file", () => {
     const idx = new LinkIndex();
-    idx.rebuild([
-      { path: "/v/Meeting.md", content: "# Meeting — the word Meeting appears" },
-    ]);
+    idx.rebuild([{ path: "/v/Meeting.md", content: "# Meeting — the word Meeting appears" }]);
     expect(idx.getUnlinkedMentions("/v/Meeting.md")).toEqual([]);
   });
 

--- a/apps/electron-demo/test/sample-vault.test.ts
+++ b/apps/electron-demo/test/sample-vault.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
 import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { scanWikiLinks } from "@floatboat/nexus-core";
+import { describe, expect, it } from "vitest";
 import { LinkIndex, findAnchorPosition, parseAnchor } from "../src/renderer/link-index";
 
 const VAULT_ROOT = path.resolve(__dirname, "../sample-vault");
@@ -25,7 +25,7 @@ async function buildIndex(): Promise<LinkIndex> {
   const paths: string[] = [];
   await collect(VAULT_ROOT, paths);
   const files = await Promise.all(
-    paths.map(async (p) => ({ path: p, content: await readFile(p, "utf-8") }))
+    paths.map(async (p) => ({ path: p, content: await readFile(p, "utf-8") })),
   );
   const idx = new LinkIndex();
   idx.rebuild(files);
@@ -120,7 +120,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
       scanWikiLinks(file.content)
         .filter((match) => match.alias && match.alias !== match.target)
         .map((match) => ({ file, match, resolved: idx.resolve(match.target, file.path) }))
-        .filter((entry): entry is typeof entry & { resolved: string } => entry.resolved != null)
+        .filter((entry): entry is typeof entry & { resolved: string } => entry.resolved != null),
     );
 
     // This validates the fixture behavior without binding the test to one
@@ -136,7 +136,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
             sourcePath: file.path,
             target: match.target,
           }),
-        ])
+        ]),
       );
     }
   });
@@ -144,7 +144,9 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("Testing.md shows linked backlinks from current sample-vault references", async () => {
     const idx = await buildIndex();
     const testingPath = path.join(VAULT_ROOT, "Topics/Testing.md");
-    const linked = idx.getBacklinks(testingPath).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const linked = idx
+      .getBacklinks(testingPath)
+      .map((m) => path.relative(VAULT_ROOT, m.sourcePath));
     expect(linked.length).toBeGreaterThan(0);
     expect(linked).toContain("Projects/Nexus-Editor.md");
   });
@@ -160,7 +162,9 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("AI.md has an unlinked mention in Alice.md and Daily/2026-04-20.md has a linked one", async () => {
     const idx = await buildIndex();
     const ai = path.join(VAULT_ROOT, "Topics/AI.md");
-    const unlinked = idx.getUnlinkedMentions(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const unlinked = idx
+      .getUnlinkedMentions(ai)
+      .map((m) => path.relative(VAULT_ROOT, m.sourcePath));
     const linked = idx.getBacklinks(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
     expect(unlinked).toContain("People/Alice.md"); // plain text "AI" in Alice.md
     expect(linked).toContain("Daily/2026-04-20.md"); // [[AI]] in the daily
@@ -170,10 +174,10 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
     const idx = await buildIndex();
     const ideas = path.join(VAULT_ROOT, "Projects/Ideas.md");
     expect(idx.resolve("Projects/Nexus-Editor#Context", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"),
     );
     expect(idx.resolve("Projects/Nexus-Editor^some-block", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"),
     );
   });
 

--- a/apps/electron-demo/tsconfig.json
+++ b/apps/electron-demo/tsconfig.json
@@ -11,10 +11,5 @@
       "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts",
-    "electron/**/*.ts",
-    "test/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "electron/**/*.ts", "test/**/*.ts"]
 }

--- a/apps/electron-demo/vite.config.ts
+++ b/apps/electron-demo/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import path from "node:path";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   root: path.resolve(__dirname, "src/renderer"),
@@ -22,7 +22,13 @@ export default defineConfig({
             if (id.includes("mermaid")) return "mermaid";
             if (id.includes("@codemirror") || id.includes("codemirror")) return "codemirror";
             if (id.includes("highlight.js")) return "hljs";
-            if (id.includes("mdast") || id.includes("micromark") || id.includes("unified") || id.includes("remark")) return "markdown";
+            if (
+              id.includes("mdast") ||
+              id.includes("micromark") ||
+              id.includes("unified") ||
+              id.includes("remark")
+            )
+              return "markdown";
             if (id.includes("katex")) return "katex";
             return "vendor";
           }
@@ -32,29 +38,26 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@floatboat/nexus-core": path.resolve(
-        __dirname,
-        "../../packages/core/src/index.ts"
-      ),
+      "@floatboat/nexus-core": path.resolve(__dirname, "../../packages/core/src/index.ts"),
       "@floatboat/nexus-preset-gfm": path.resolve(
         __dirname,
-        "../../packages/preset-gfm/src/index.ts"
+        "../../packages/preset-gfm/src/index.ts",
       ),
       "@floatboat/nexus-plugin-history": path.resolve(
         __dirname,
-        "../../packages/plugin-history/src/index.ts"
+        "../../packages/plugin-history/src/index.ts",
       ),
       "@floatboat/nexus-plugin-toolbar": path.resolve(
         __dirname,
-        "../../packages/plugin-toolbar/src/index.ts"
+        "../../packages/plugin-toolbar/src/index.ts",
       ),
       "@floatboat/nexus-plugin-search": path.resolve(
         __dirname,
-        "../../packages/plugin-search/src/index.ts"
+        "../../packages/plugin-search/src/index.ts",
       ),
       "@floatboat/nexus-plugin-slash": path.resolve(
         __dirname,
-        "../../packages/plugin-slash/src/index.ts"
+        "../../packages/plugin-slash/src/index.ts",
       ),
     },
   },

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "include": ["**/*.ts", "**/*.tsx", "**/*.json", "**/*.md"],
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "useConst": "error",
+        "useTemplate": "error",
+        "noVar": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "include": ["**/*.md"],
+      "linter": {
+        "enabled": false
+      }
+    },
+    {
+      "include": ["packages/core/src/live-preview-table.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noForEach": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["**/test/**", "**/e2e/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "suspicious": {
+            "noAssignInExpressions": "off"
+          },
+          "complexity": {
+            "noForEach": "off"
+          }
+        }
+      }
+    }
+  ],
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,23 +7,30 @@
     "build": "pnpm --filter @floatboat/nexus-core build && pnpm --filter @floatboat/nexus-react build && pnpm --filter @floatboat/nexus-vue build && pnpm --filter @floatboat/nexus-preset-gfm build && pnpm --filter @floatboat/nexus-plugin-slash build && pnpm --filter @floatboat/nexus-plugin-history build && pnpm --filter @floatboat/nexus-plugin-search build && pnpm --filter @floatboat/nexus-plugin-toolbar build && pnpm --filter @floatboat/nexus-plugin-math build && pnpm --filter @floatboat/nexus-plugin-vim build",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "test": "vitest run",
+    "lint": "biome check .",
+    "format": "biome format --write .",
+    "lint:fix": "biome check --write .",
+    "prepare": "husky",
     "dev:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo dev",
     "build:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo build",
     "publish:packages": "pnpm -r --filter \"./packages/*\" publish --access public --no-git-checks"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@testing-library/react": "^16.3.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.6.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "@vitest/coverage-v8": "^2.1.9",
     "@vue/test-utils": "^2.4.6",
+    "husky": "^9.1.7",
     "jsdom": "^25.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "vue": "^3.5.22",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "vue": "^3.5.22"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -4,9 +4,9 @@ import { Annotation, EditorState } from "@codemirror/state";
 // setDocument from file open) so updateListener can skip the user-edit path —
 // no onChange emission, no AST reparse for the onChange pipeline.
 const silentDocChange = Annotation.define<boolean>();
-import { EditorView, keymap, dropCursor, lineNumbers, type Direction } from "@codemirror/view";
-import { indentWithTab, undo as cmUndo, redo as cmRedo } from "@codemirror/commands";
 import { closeBrackets } from "@codemirror/autocomplete";
+import { redo as cmRedo, undo as cmUndo, indentWithTab } from "@codemirror/commands";
+import { EditorView, dropCursor, keymap, lineNumbers } from "@codemirror/view";
 import type { Root } from "mdast";
 import type { Heading } from "mdast";
 import rehypeStringify from "rehype-stringify";
@@ -14,17 +14,17 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 
+import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { EventEmitter } from "./event-emitter";
-import { createLivePreviewExtension } from "./live-preview";
 import { createMarkdownLanguageSupport } from "./lezer-markdown";
 import { lezerStringToMdast, lezerTreeToMdast } from "./lezer-mdast-adapter";
-import { markdownFoldService } from "./markdown-fold";
+import { createLivePreviewExtension } from "./live-preview";
 import { resolveLocale } from "./locale";
 import { markdownAutoPair } from "./markdown-autopair";
+import { markdownFoldService } from "./markdown-fold";
 import { markdownKeymap } from "./markdown-keymap";
-import { indentationMarkers } from "@replit/codemirror-indentation-markers";
-import { createThemeExtension, lightTheme, type NexusTheme } from "./theme";
 import { computeSlashState } from "./slash-state";
+import { type NexusTheme, createThemeExtension, lightTheme } from "./theme";
 import type {
   EditorAPI,
   EditorCommand,
@@ -71,7 +71,7 @@ function debugNexus(message: string, details?: Record<string, unknown>): void {
 function createEmptyAst(): Root {
   return {
     type: "root",
-    children: []
+    children: [],
   };
 }
 
@@ -175,7 +175,7 @@ function createParser(plugins: NexusPlugin[]): ParserLike {
     parse(markdown) {
       const tree = processor.parse(markdown);
       return processor.runSync(tree) as Root;
-    }
+    },
   };
 }
 
@@ -245,7 +245,8 @@ export function createEditor(config: EditorConfig): EditorAPI {
   // Custom-parser callers run their plugins inside `parser.parse`, so the
   // transform pass would double-apply.
   const hasRemarkPlugins = plugins.some((plugin) => (plugin.remarkPlugins?.length ?? 0) > 0);
-  const transformProcessor = !customParser && hasRemarkPlugins ? createTransformProcessor(plugins) : null;
+  const transformProcessor =
+    !customParser && hasRemarkPlugins ? createTransformProcessor(plugins) : null;
   const transformAst = (ast: Root): Root =>
     transformProcessor ? transformProcessor.runSync(ast) : ast;
   const locale = resolveLocale(config.locale);
@@ -270,6 +271,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
   // Forward ref so emitChange/setDocument can run lezerTreeToMdast against
   // the live EditorState once the view is constructed.
   const viewRef: { current: EditorView | null } = { current: null };
+  // biome-ignore lint/style/useConst: assigned after EditorView construction
   let api!: EditorAPI;
 
   function setFocused(next: boolean) {
@@ -377,7 +379,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
       changes: {
         from: 0,
         to: view.state.doc.length,
-        insert: next
+        insert: next,
       },
       annotations: silent ? silentDocChange.of(true) : undefined,
     });
@@ -445,15 +447,13 @@ export function createEditor(config: EditorConfig): EditorAPI {
   }
 
   const themeExt = createThemeExtension(config.theme ?? lightTheme);
-  const tabSizeExt = config.tabSize && config.tabSize !== 4
-    ? EditorState.tabSize.of(config.tabSize)
-    : [];
+  const tabSizeExt =
+    config.tabSize && config.tabSize !== 4 ? EditorState.tabSize.of(config.tabSize) : [];
   const readOnlyExt = config.readOnly
     ? [EditorState.readOnly.of(true), EditorView.editable.of(false)]
     : [];
-  const directionExt = config.direction === "rtl"
-    ? EditorView.contentAttributes.of({ dir: "rtl" })
-    : [];
+  const directionExt =
+    config.direction === "rtl" ? EditorView.contentAttributes.of({ dir: "rtl" }) : [];
   const indentGuidesExt = config.indentGuides ? indentationMarkers() : [];
 
   const shortcutExtensions =
@@ -462,16 +462,16 @@ export function createEditor(config: EditorConfig): EditorAPI {
           keymap.of(
             shortcuts.map((shortcut) => ({
               key: shortcut.key,
-              run: () => shortcut.run(api)
-            }))
-          )
+              run: () => shortcut.run(api),
+            })),
+          ),
         ]
       : [];
 
   // 带 hotkey 的命名命令注册成 CodeMirror keymap；返回非 false 视为已消费。
   const hotkeyCommands = commands.filter(
     (command): command is EditorCommand & { hotkey: string } =>
-      typeof command.hotkey === "string" && command.hotkey.length > 0
+      typeof command.hotkey === "string" && command.hotkey.length > 0,
   );
   const commandKeymapExtensions =
     hotkeyCommands.length > 0
@@ -479,9 +479,9 @@ export function createEditor(config: EditorConfig): EditorAPI {
           keymap.of(
             hotkeyCommands.map((command) => ({
               key: command.hotkey,
-              run: () => command.run(api) !== false
-            }))
-          )
+              run: () => command.run(api) !== false,
+            })),
+          ),
         ]
       : [];
 
@@ -523,11 +523,13 @@ export function createEditor(config: EditorConfig): EditorAPI {
             }
             flushCompositionChange(view, "compositionend");
             return false;
-          }
+          },
         }),
         EditorView.updateListener.of((update) => {
           const silent = update.transactions.some((t) => t.annotation(silentDocChange) === true);
-          const compositionTransaction = update.transactions.some((t) => t.isUserEvent("input.type.compose"));
+          const compositionTransaction = update.transactions.some((t) =>
+            t.isUserEvent("input.type.compose"),
+          );
           if (update.docChanged || update.selectionSet) {
             const sel = update.state.selection.main;
             debugNexus("update", {
@@ -548,7 +550,11 @@ export function createEditor(config: EditorConfig): EditorAPI {
             // file from disk — that's not a user edit).
             if (!silent) {
               const markdown = update.state.doc.toString();
-              if (compositionTransaction || update.view.composing || update.view.compositionStarted) {
+              if (
+                compositionTransaction ||
+                update.view.composing ||
+                update.view.compositionStarted
+              ) {
                 debugNexus("composition-change-queued", {
                   documentLength: markdown.length,
                   compositionTransaction,
@@ -583,7 +589,9 @@ export function createEditor(config: EditorConfig): EditorAPI {
                   if (raw) {
                     coords = { left: raw.left, top: raw.top, bottom: raw.bottom };
                   }
-                } catch { /* out of range */ }
+                } catch {
+                  /* out of range */
+                }
               }
 
               emitter.emit("slashMenuChange", { ...state, coords });
@@ -657,9 +665,9 @@ export function createEditor(config: EditorConfig): EditorAPI {
         ...(widgetParser ? createWidgetExtension(widgetParser, widgetDefs) : []),
         ...shortcutExtensions,
         ...commandKeymapExtensions,
-        ...cmExtensions
-      ]
-    })
+        ...cmExtensions,
+      ],
+    }),
   });
 
   // Hand the view to lezerAstFromAnywhere consumers so getAst() / emitChange
@@ -711,7 +719,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
 
       view.dispatch({
         selection: { anchor, head },
-        scrollIntoView: true
+        scrollIntoView: true,
       });
     },
     setDocument(next, opts) {
@@ -838,7 +846,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
       composing = false;
       emitter.clear();
       view.destroy();
-    }
+    },
   };
 
   return api;

--- a/packages/core/src/event-emitter.ts
+++ b/packages/core/src/event-emitter.ts
@@ -1,5 +1,5 @@
 export class EventEmitter<EventMap extends { [K in keyof EventMap]: (...args: any[]) => void }> {
-  private listeners = new Map<keyof EventMap, Set<Function>>();
+  private listeners = new Map<keyof EventMap, Set<EventMap[keyof EventMap]>>();
 
   on<K extends keyof EventMap>(event: K, handler: EventMap[K]): void {
     let set = this.listeners.get(event);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,5 +42,5 @@ export type {
   SlashMenuState,
   TocEntry,
   WidgetDefinition,
-  WidgetRenderContext
+  WidgetRenderContext,
 } from "./types";

--- a/packages/core/src/lezer-footnote-extension.ts
+++ b/packages/core/src/lezer-footnote-extension.ts
@@ -1,4 +1,10 @@
-import type { MarkdownConfig, BlockContext, Line, LeafBlock, LeafBlockParser } from "@lezer/markdown";
+import type {
+  BlockContext,
+  LeafBlock,
+  LeafBlockParser,
+  Line,
+  MarkdownConfig,
+} from "@lezer/markdown";
 
 // GFM-style footnote syntax:
 //   * Inline reference: `[^id]` — emits FootnoteReference with FootnoteMark + FootnoteLabel children.
@@ -12,8 +18,8 @@ const OPEN_BRACKET = 91; // [
 const CARET = 94; // ^
 const CLOSE_BRACKET = 93; // ]
 const COLON = 58; // :
-const SPACE = 32;
-const TAB = 9;
+const _SPACE = 32;
+const _TAB = 9;
 const NEWLINE = 10;
 
 function isLabelChar(code: number): boolean {
@@ -27,14 +33,17 @@ class FootnoteDefinitionLeafParser implements LeafBlockParser {
     // GFM-footnote allows lazy continuation on indented lines (>= 4 spaces or
     // a tab) following the marker line. Anything else terminates.
     if (line.next < 0) return true; // EOF
-    const nonBlank = line.text.length > line.basePos &&
-      line.text.slice(line.basePos).trim().length > 0;
+    const nonBlank =
+      line.text.length > line.basePos && line.text.slice(line.basePos).trim().length > 0;
     if (!nonBlank) return false; // blank — keep accumulating until a real line forces close
     if (line.indent < 4) return true; // not indented enough → end definition
     return false;
   }
   finish(cx: BlockContext, leaf: LeafBlock): boolean {
-    cx.addLeafElement(leaf, cx.elt("FootnoteDefinition", leaf.start, leaf.start + leaf.content.length));
+    cx.addLeafElement(
+      leaf,
+      cx.elt("FootnoteDefinition", leaf.start, leaf.start + leaf.content.length),
+    );
     return true;
   }
 }

--- a/packages/core/src/lezer-helpers.ts
+++ b/packages/core/src/lezer-helpers.ts
@@ -1,5 +1,5 @@
-import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
+import type { EditorState } from "@codemirror/state";
 import type { SyntaxNode, Tree } from "@lezer/common";
 
 /**
@@ -15,7 +15,9 @@ export function iterateInRange(
   tree: Tree,
   from: number,
   to: number,
-  visit: (info: { name: string; from: number; to: number; node: SyntaxNode | null }) => void | boolean,
+  visit: (info: { name: string; from: number; to: number; node: SyntaxNode | null }) =>
+    | undefined
+    | boolean,
 ): void {
   tree.iterate({
     from,

--- a/packages/core/src/lezer-markdown.ts
+++ b/packages/core/src/lezer-markdown.ts
@@ -1,6 +1,6 @@
 import { markdown } from "@codemirror/lang-markdown";
-import { GFM } from "@lezer/markdown";
 import type { Extension } from "@codemirror/state";
+import { GFM } from "@lezer/markdown";
 
 import { footnoteExtension } from "./lezer-footnote-extension";
 

--- a/packages/core/src/lezer-mdast-adapter.ts
+++ b/packages/core/src/lezer-mdast-adapter.ts
@@ -1,9 +1,8 @@
-import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
+import type { EditorState } from "@codemirror/state";
 import type { SyntaxNode, Tree } from "@lezer/common";
-import { parser as commonmarkParser, GFM } from "@lezer/markdown";
+import { GFM, parser as commonmarkParser } from "@lezer/markdown";
 
-import { footnoteExtension } from "./lezer-footnote-extension";
 import type {
   Blockquote,
   Code,
@@ -31,6 +30,7 @@ import type {
   Text,
   ThematicBreak,
 } from "mdast";
+import { footnoteExtension } from "./lezer-footnote-extension";
 
 import { findChildByName, headingDepth } from "./lezer-helpers";
 
@@ -46,7 +46,10 @@ import { findChildByName, headingDepth } from "./lezer-helpers";
 // `position` info so collectLivePreviewRanges can read offsets.
 
 interface PositionedNode {
-  position: { start: { line: number; column: number; offset: number }; end: { line: number; column: number; offset: number } };
+  position: {
+    start: { line: number; column: number; offset: number };
+    end: { line: number; column: number; offset: number };
+  };
 }
 
 function position(from: number, to: number): PositionedNode["position"] {
@@ -156,14 +159,20 @@ function trimTableCellRange(
   line: string,
   lineFrom: number,
   start: number,
-  end: number
+  end: number,
 ): { from: number; to: number } {
+  // biome-ignore lint/style/noParameterAssign: trim whitespace in-place
   while (start < end && /[ \t]/.test(line[start])) start++;
+  // biome-ignore lint/style/noParameterAssign: trim whitespace in-place
   while (end > start && /[ \t]/.test(line[end - 1])) end--;
   return { from: lineFrom + start, to: lineFrom + end };
 }
 
-function tableCellContentRanges(source: Source, from: number, to: number): Array<{ from: number; to: number }> {
+function tableCellContentRanges(
+  source: Source,
+  from: number,
+  to: number,
+): Array<{ from: number; to: number }> {
   const line = readSlice(source, from, to);
   const pipes: number[] = [];
 
@@ -207,7 +216,9 @@ function adaptTableRowCells(source: Source, row: SyntaxNode): TableCell[] {
 
   const used = new Set<SyntaxNode>();
   return ranges.map((range) => {
-    const syntaxCell = syntaxCells.find((cell) => !used.has(cell) && cell.from >= range.from && cell.to <= range.to);
+    const syntaxCell = syntaxCells.find(
+      (cell) => !used.has(cell) && cell.from >= range.from && cell.to <= range.to,
+    );
     if (syntaxCell) {
       used.add(syntaxCell);
       return {
@@ -313,7 +324,9 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
       // Lezer Link: contains LinkMark `[`, label content, LinkMark `]`,
       // optional `(URL "title")`. We pull URL via child name.
       const url = findChildByName(node, "URL");
-      const urlText = url ? readSlice(source, url.from, url.to) : readSlice(source, node.from, node.to).replace(/^<|>$/g, "");
+      const urlText = url
+        ? readSlice(source, url.from, url.to)
+        : readSlice(source, node.from, node.to).replace(/^<|>$/g, "");
       // Walk children between the first `[` and the matching `]` and
       // recursively adapt nested inline nodes (Image, StrongEmphasis,
       // Emphasis, InlineCode, etc.) so things like
@@ -329,7 +342,10 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
           if (c.name !== "LinkMark") continue;
           seen++;
           if (seen === 1) labelStartMark = c;
-          else if (seen === 2) { labelEndMark = c; break; }
+          else if (seen === 2) {
+            labelEndMark = c;
+            break;
+          }
         }
         if (!labelStartMark || !labelEndMark) {
           // Autolink / bare URL — no `[]`, the whole node is the label.
@@ -365,13 +381,16 @@ function adaptInlineNode(source: Source, node: SyntaxNode): PhrasingContent | nu
       let alt = "";
       const first = node.firstChild;
       if (first && first.name === "LinkMark") {
-        let altFrom = first.to;
+        const altFrom = first.to;
         let altTo = node.to;
         let seen = 0;
         for (let c = node.firstChild; c; c = c.nextSibling) {
           if (c.name === "LinkMark") {
             seen++;
-            if (seen === 2) { altTo = c.from; break; }
+            if (seen === 2) {
+              altTo = c.from;
+              break;
+            }
           }
         }
         alt = readSlice(source, altFrom, altTo);
@@ -465,7 +484,7 @@ function adaptList(source: Source, node: SyntaxNode, ordered: boolean): List {
   return {
     type: "list",
     ordered,
-    start: ordered ? start ?? 1 : null,
+    start: ordered ? (start ?? 1) : null,
     spread: false,
     children: items,
     position: position(node.from, node.to),
@@ -554,14 +573,62 @@ interface CalloutPalette {
 }
 
 const CALLOUT_PALETTE: Record<string, CalloutPalette> = {
-  info: { border: "#0969da", bg: "rgba(9,105,218,0.08)", color: "#0969da", icon: "ℹ", defaultLabel: "INFO" },
-  note: { border: "#0969da", bg: "rgba(9,105,218,0.08)", color: "#0969da", icon: "ℹ", defaultLabel: "NOTE" },
-  tip: { border: "#1a7f37", bg: "rgba(26,127,55,0.08)", color: "#1a7f37", icon: "💡", defaultLabel: "TIP" },
-  success: { border: "#1a7f37", bg: "rgba(26,127,55,0.08)", color: "#1a7f37", icon: "✓", defaultLabel: "SUCCESS" },
-  important: { border: "#8250df", bg: "rgba(130,80,223,0.08)", color: "#8250df", icon: "❗", defaultLabel: "IMPORTANT" },
-  warning: { border: "#9a6700", bg: "rgba(154,103,0,0.08)", color: "#9a6700", icon: "⚠", defaultLabel: "WARNING" },
-  caution: { border: "#cf222e", bg: "rgba(207,34,46,0.08)", color: "#cf222e", icon: "🚫", defaultLabel: "CAUTION" },
-  danger: { border: "#cf222e", bg: "rgba(207,34,46,0.08)", color: "#cf222e", icon: "🚫", defaultLabel: "DANGER" },
+  info: {
+    border: "#0969da",
+    bg: "rgba(9,105,218,0.08)",
+    color: "#0969da",
+    icon: "ℹ",
+    defaultLabel: "INFO",
+  },
+  note: {
+    border: "#0969da",
+    bg: "rgba(9,105,218,0.08)",
+    color: "#0969da",
+    icon: "ℹ",
+    defaultLabel: "NOTE",
+  },
+  tip: {
+    border: "#1a7f37",
+    bg: "rgba(26,127,55,0.08)",
+    color: "#1a7f37",
+    icon: "💡",
+    defaultLabel: "TIP",
+  },
+  success: {
+    border: "#1a7f37",
+    bg: "rgba(26,127,55,0.08)",
+    color: "#1a7f37",
+    icon: "✓",
+    defaultLabel: "SUCCESS",
+  },
+  important: {
+    border: "#8250df",
+    bg: "rgba(130,80,223,0.08)",
+    color: "#8250df",
+    icon: "❗",
+    defaultLabel: "IMPORTANT",
+  },
+  warning: {
+    border: "#9a6700",
+    bg: "rgba(154,103,0,0.08)",
+    color: "#9a6700",
+    icon: "⚠",
+    defaultLabel: "WARNING",
+  },
+  caution: {
+    border: "#cf222e",
+    bg: "rgba(207,34,46,0.08)",
+    color: "#cf222e",
+    icon: "🚫",
+    defaultLabel: "CAUTION",
+  },
+  danger: {
+    border: "#cf222e",
+    bg: "rgba(207,34,46,0.08)",
+    color: "#cf222e",
+    icon: "🚫",
+    defaultLabel: "DANGER",
+  },
 };
 
 function escapeHtml(s: string): string {
@@ -575,20 +642,7 @@ function escapeHtml(s: string): string {
 function buildCalloutHtml(type: string, title: string | null, body: string): string {
   const palette = CALLOUT_PALETTE[type.toLowerCase()] ?? CALLOUT_PALETTE.info;
   const heading = title ?? palette.defaultLabel;
-  return (
-    `<div class="nexus-callout" data-callout-type="${escapeHtml(type)}" ` +
-      `style="border-left:4px solid ${palette.border};background:${palette.bg};` +
-      `padding:8px 14px;border-radius:6px;margin:6px 0;">` +
-      `<div class="nexus-callout-title" style="color:${palette.color};font-weight:600;` +
-      `display:flex;align-items:center;gap:6px;margin-bottom:4px;">` +
-      `<span aria-hidden="true">${palette.icon}</span>` +
-      `<span>${escapeHtml(heading)}</span>` +
-      `</div>` +
-      `<div class="nexus-callout-body" style="color:var(--nexus-text);white-space:pre-wrap;">` +
-      escapeHtml(body) +
-      `</div>` +
-    `</div>`
-  );
+  return `<div class="nexus-callout" data-callout-type="${escapeHtml(type)}" style="border-left:4px solid ${palette.border};background:${palette.bg};padding:8px 14px;border-radius:6px;margin:6px 0;"><div class="nexus-callout-title" style="color:${palette.color};font-weight:600;display:flex;align-items:center;gap:6px;margin-bottom:4px;"><span aria-hidden="true">${palette.icon}</span><span>${escapeHtml(heading)}</span></div><div class="nexus-callout-body" style="color:var(--nexus-text);white-space:pre-wrap;">${escapeHtml(body)}</div></div>`;
 }
 
 function adaptParagraph(source: Source, node: SyntaxNode): Paragraph | Html {
@@ -652,7 +706,7 @@ function adaptLinkReference(source: Source, node: SyntaxNode): Definition {
     identifier: m ? m[1] : "",
     label: m ? m[1] : undefined,
     url: m ? m[2] : "",
-    title: m ? m[3] ?? null : null,
+    title: m ? (m[3] ?? null) : null,
     position: position(node.from, node.to),
   };
 }
@@ -693,19 +747,29 @@ function adaptBlockChild(source: Source, node: SyntaxNode): Content | null {
     return adaptHeading(source, node);
   }
   switch (name) {
-    case "Paragraph": return adaptParagraph(source, node);
-    case "Blockquote": return adaptBlockquote(source, node);
-    case "BulletList": return adaptList(source, node, false);
-    case "OrderedList": return adaptList(source, node, true);
-    case "FencedCode": return adaptCode(source, node, true);
+    case "Paragraph":
+      return adaptParagraph(source, node);
+    case "Blockquote":
+      return adaptBlockquote(source, node);
+    case "BulletList":
+      return adaptList(source, node, false);
+    case "OrderedList":
+      return adaptList(source, node, true);
+    case "FencedCode":
+      return adaptCode(source, node, true);
     // @lezer/markdown emits "CodeBlock" for indented code blocks; keep
     // "IndentedCode" as a defensive alias for any non-default config.
     case "CodeBlock":
-    case "IndentedCode": return adaptCode(source, node, false);
-    case "HorizontalRule": return adaptThematicBreak(node);
-    case "Table": return adaptTable(source, node);
-    case "LinkReference": return adaptLinkReference(source, node);
-    case "FootnoteDefinition": return adaptFootnoteDefinition(source, node);
+    case "IndentedCode":
+      return adaptCode(source, node, false);
+    case "HorizontalRule":
+      return adaptThematicBreak(node);
+    case "Table":
+      return adaptTable(source, node);
+    case "LinkReference":
+      return adaptLinkReference(source, node);
+    case "FootnoteDefinition":
+      return adaptFootnoteDefinition(source, node);
     case "HTMLBlock":
     case "CommentBlock":
       return adaptHtml(source, node);

--- a/packages/core/src/live-preview-diag.ts
+++ b/packages/core/src/live-preview-diag.ts
@@ -41,7 +41,9 @@ interface ClickSnapshot {
   cmLineCount: number;
 }
 
-function diagOn(): boolean { return Boolean((globalThis as any).__NEXUS_DIAG__); }
+function diagOn(): boolean {
+  return Boolean((globalThis as any).__NEXUS_DIAG__);
+}
 
 let clickCounter = 0;
 let txCounter = 0;
@@ -49,7 +51,10 @@ let txCounter = 0;
 function describeTarget(el: EventTarget | null): string {
   if (!(el instanceof HTMLElement)) return String(el ?? "null");
   const tag = el.tagName.toLowerCase();
-  const cls = el.className && typeof el.className === "string" ? "." + el.className.split(/\s+/).slice(0, 3).join(".") : "";
+  const cls =
+    el.className && typeof el.className === "string"
+      ? `.${el.className.split(/\s+/).slice(0, 3).join(".")}`
+      : "";
   const role = el.getAttribute("role");
   const txt = (el.textContent ?? "").trim().slice(0, 30).replace(/\s+/g, " ");
   return `${tag}${cls}${role ? `[role=${role}]` : ""} "${txt}"`;
@@ -58,12 +63,7 @@ function describeTarget(el: EventTarget | null): string {
 function probeHeightmap(view: EditorView): HeightProbe[] {
   const docLen = view.state.doc.length;
   // Probe the whole doc at 10% intervals plus the viewport edges.
-  const positions = new Set<number>([
-    0,
-    view.viewport.from,
-    view.viewport.to,
-    docLen,
-  ]);
+  const positions = new Set<number>([0, view.viewport.from, view.viewport.to, docLen]);
   for (let i = 1; i < 10; i++) positions.add(Math.floor((docLen * i) / 10));
 
   const probes: HeightProbe[] = [];
@@ -108,7 +108,10 @@ function auditWidgets(view: EditorView): WidgetSample[] {
   return samples;
 }
 
-function diffProbes(before: HeightProbe[], after: HeightProbe[]): Array<{ pos: number; delta: number }> {
+function diffProbes(
+  before: HeightProbe[],
+  after: HeightProbe[],
+): Array<{ pos: number; delta: number }> {
   const deltas: Array<{ pos: number; delta: number }> = [];
   const map = new Map(before.map((p) => [p.pos, p.y]));
   for (const a of after) {
@@ -121,7 +124,12 @@ function diffProbes(before: HeightProbe[], after: HeightProbe[]): Array<{ pos: n
   return deltas;
 }
 
-function snapshot(view: EditorView, clickX: number, clickY: number, target: EventTarget | null): ClickSnapshot {
+function snapshot(
+  view: EditorView,
+  clickX: number,
+  clickY: number,
+  target: EventTarget | null,
+): ClickSnapshot {
   return {
     clickNo: ++clickCounter,
     clickX,
@@ -139,14 +147,17 @@ function snapshot(view: EditorView, clickX: number, clickY: number, target: Even
   };
 }
 
-function logClick(snap: ClickSnapshot, post: {
-  selectionHead: number;
-  scrollTop: number;
-  probes: HeightProbe[];
-  cursorY: number | null;
-  contentHeightAfter: number;
-  widgets: WidgetSample[];
-}): void {
+function logClick(
+  snap: ClickSnapshot,
+  post: {
+    selectionHead: number;
+    scrollTop: number;
+    probes: HeightProbe[];
+    cursorY: number | null;
+    contentHeightAfter: number;
+    widgets: WidgetSample[];
+  },
+): void {
   const probeDeltas = diffProbes(snap.probes, post.probes);
   const scrollDelta = post.scrollTop - snap.scrollTop;
   const clickToCursorDrift = post.cursorY != null ? Math.round(post.cursorY - snap.clickY) : null;
@@ -160,42 +171,49 @@ function logClick(snap: ClickSnapshot, post: {
   const probesPost = post.probes.map((p) => `${p.pos}→${p.y}`).join(" | ");
   const widgetDiff = compareWidgets(snap.widgets, post.widgets);
   const widgetsPre = snap.widgets.map((w) => `${w.kind}@${w.top}h${w.height}`).join(" | ");
-  const hmShift = probeDeltas.length > 0
-    ? "HEIGHTMAP SHIFTED: " + probeDeltas.map((d) => `pos ${d.pos} Δ${d.delta > 0 ? "+" : ""}${d.delta}px`).join(", ")
-    : "heightmap stable";
-  const wShift = widgetDiff.length > 0
-    ? "WIDGETS SHIFTED: " + widgetDiff.map((w) => `${w.kind} top:${w.beforeTop}→${w.afterTop} hΔ:${w.heightDelta}`).join(", ")
-    : `widgets(n=${snap.widgets.length}) stable`;
+  const hmShift =
+    probeDeltas.length > 0
+      ? `HEIGHTMAP SHIFTED: ${probeDeltas.map((d) => `pos ${d.pos} Δ${d.delta > 0 ? "+" : ""}${d.delta}px`).join(", ")}`
+      : "heightmap stable";
+  const wShift =
+    widgetDiff.length > 0
+      ? `WIDGETS SHIFTED: ${widgetDiff
+          .map((w) => `${w.kind} top:${w.beforeTop}→${w.afterTop} hΔ:${w.heightDelta}`)
+          .join(", ")}`
+      : `widgets(n=${snap.widgets.length}) stable`;
 
   console.log(
     `${icon} [NEXUS-DIAG] click #${snap.clickNo}\n` +
-    `  click        (${snap.clickX},${snap.clickY})\n` +
-    `  target       ${snap.targetDescribe}\n` +
-    `  posAtCoords  ${snap.posAtCoords} → after: ${post.selectionHead} (Δ=${post.selectionHead - (snap.posAtCoords ?? 0)})\n` +
-    `  scroll       ${snap.scrollTop} → ${post.scrollTop} (Δ=${scrollDelta})\n` +
-    `  viewport     [${snap.viewportFrom}, ${snap.viewportTo}]\n` +
-    `  contentH     ${snap.contentHeight} → ${post.contentHeightAfter} (Δ=${post.contentHeightAfter - snap.contentHeight})\n` +
-    `  cursorY      ${post.cursorY} vs clickY ${snap.clickY}  drift=${clickToCursorDrift}px\n` +
-    `  ${hmShift}\n` +
-    `  ${wShift}\n` +
-    `  probes(pre)  ${probesPre}\n` +
-    `  probes(post) ${probesPost}\n` +
-    `  widgets      ${widgetsPre}`
+      `  click        (${snap.clickX},${snap.clickY})\n` +
+      `  target       ${snap.targetDescribe}\n` +
+      `  posAtCoords  ${snap.posAtCoords} → after: ${post.selectionHead} (Δ=${post.selectionHead - (snap.posAtCoords ?? 0)})\n` +
+      `  scroll       ${snap.scrollTop} → ${post.scrollTop} (Δ=${scrollDelta})\n` +
+      `  viewport     [${snap.viewportFrom}, ${snap.viewportTo}]\n` +
+      `  contentH     ${snap.contentHeight} → ${post.contentHeightAfter} (Δ=${post.contentHeightAfter - snap.contentHeight})\n` +
+      `  cursorY      ${post.cursorY} vs clickY ${snap.clickY}  drift=${clickToCursorDrift}px\n` +
+      `  ${hmShift}\n` +
+      `  ${wShift}\n` +
+      `  probes(pre)  ${probesPre}\n` +
+      `  probes(post) ${probesPost}\n` +
+      `  widgets      ${widgetsPre}`,
   );
 }
 
-function compareWidgets(before: WidgetSample[], after: WidgetSample[]): Array<{ kind: string; beforeTop: number; afterTop: number; heightDelta: number }> {
+function compareWidgets(
+  before: WidgetSample[],
+  after: WidgetSample[],
+): Array<{ kind: string; beforeTop: number; afterTop: number; heightDelta: number }> {
   const out: Array<{ kind: string; beforeTop: number; afterTop: number; heightDelta: number }> = [];
   // Pair widgets by kind + order (approximate — no stable IDs).
   const byKind = new Map<string, WidgetSample[]>();
   for (const w of before) {
     if (!byKind.has(w.kind)) byKind.set(w.kind, []);
-    byKind.get(w.kind)!.push(w);
+    byKind.get(w.kind)?.push(w);
   }
   const afterByKind = new Map<string, WidgetSample[]>();
   for (const w of after) {
     if (!afterByKind.has(w.kind)) afterByKind.set(w.kind, []);
-    afterByKind.get(w.kind)!.push(w);
+    afterByKind.get(w.kind)?.push(w);
   }
   for (const [kind, bList] of byKind) {
     const aList = afterByKind.get(kind) ?? [];
@@ -234,7 +252,9 @@ export function createLivePreviewDiagnostics(): Extension {
           try {
             const c = view.coordsAtPos(sel);
             cursorY = c ? Math.round(c.top) : null;
-          } catch { cursorY = null; }
+          } catch {
+            cursorY = null;
+          }
 
           logClick(snap, {
             selectionHead: sel,
@@ -257,10 +277,9 @@ export function createLivePreviewDiagnostics(): Extension {
           bannerShown = true;
           const docLen = view.state.doc.length;
           console.log(
-            "%c[NEXUS-DIAG]%c active — docLen=" + docLen + " lines=" + (view.state.doc.lines) +
-              "\n  click anywhere to capture a snapshot.",
+            `%c[NEXUS-DIAG]%c active — docLen=${docLen} lines=${view.state.doc.lines}\n  click anywhere to capture a snapshot.`,
             "background:#f60;color:#fff;padding:2px 6px;border-radius:3px",
-            "color:#888"
+            "color:#888",
           );
         }
       }
@@ -277,12 +296,12 @@ export function createLivePreviewDiagnostics(): Extension {
             if (u.heightChanged) changed.push("H");
             const sel = u.state.selection.main.head;
             console.debug(
-              `[NEXUS-DIAG tx#${txCounter}] ${changed.join(",")} sel=${sel} scroll=${Math.round(u.view.scrollDOM.scrollTop)} contentH=${Math.round(u.view.contentHeight)}`
+              `[NEXUS-DIAG tx#${txCounter}] ${changed.join(",")} sel=${sel} scroll=${Math.round(u.view.scrollDOM.scrollTop)} contentH=${Math.round(u.view.contentHeight)}`,
             );
           }
         }
       }
-    }
+    },
   );
 
   return [clickHandler, updatePlugin];

--- a/packages/core/src/live-preview-highlight.ts
+++ b/packages/core/src/live-preview-highlight.ts
@@ -110,7 +110,11 @@ export function highlightCodeBlock(
   if (cached) {
     if (contentStart === 0) return cached;
     // Cached tokens are stored at contentStart=0; rebase on read.
-    return cached.map((t) => ({ from: t.from + contentStart, to: t.to + contentStart, className: t.className }));
+    return cached.map((t) => ({
+      from: t.from + contentStart,
+      to: t.to + contentStart,
+      className: t.className,
+    }));
   }
 
   let result: { _emitter: unknown };
@@ -124,7 +128,11 @@ export function highlightCodeBlock(
   emit(result._emitter, 0, tokens);
   cacheSet(key, tokens);
   if (contentStart === 0) return tokens;
-  return tokens.map((t) => ({ from: t.from + contentStart, to: t.to + contentStart, className: t.className }));
+  return tokens.map((t) => ({
+    from: t.from + contentStart,
+    to: t.to + contentStart,
+    className: t.className,
+  }));
 }
 
 // hljs's internal token stream walker. `_emitter.rootNode` is a TokenTree
@@ -137,29 +145,25 @@ function emit(emitter: unknown, offset: number, out: CodeHighlightToken[]): void
   walkNode(root.rootNode, offset, [], out);
 }
 
-function walkNode(
-  node: unknown,
-  pos: number,
-  scope: string[],
-  out: CodeHighlightToken[],
-): number {
+function walkNode(node: unknown, pos: number, scope: string[], out: CodeHighlightToken[]): number {
   const n = node as { children?: unknown[] };
   if (!n.children) return pos;
+  let cursor = pos;
   for (const c of n.children) {
     if (typeof c === "string") {
       if (c.length > 0 && scope.length > 0) {
         const className = scope.map((s) => `hljs-${s}`).join(" ");
-        out.push({ from: pos, to: pos + c.length, className });
+        out.push({ from: cursor, to: cursor + c.length, className });
       }
-      pos += c.length;
+      cursor += c.length;
       continue;
     }
     const child = c as { kind?: string; children?: unknown[] };
-    if (child && child.kind) {
-      pos = walkNode(child, pos, [...scope, child.kind], out);
-    } else if (child && child.children) {
-      pos = walkNode(child, pos, scope, out);
+    if (child?.kind) {
+      cursor = walkNode(child, cursor, [...scope, child.kind], out);
+    } else if (child?.children) {
+      cursor = walkNode(child, cursor, scope, out);
     }
   }
-  return pos;
+  return cursor;
 }

--- a/packages/core/src/live-preview-ranges.ts
+++ b/packages/core/src/live-preview-ranges.ts
@@ -35,7 +35,7 @@ export function selectionIntersects(
   from: number,
   to: number,
   selection: readonly SelectionRange[],
-  inclusiveEnd = false
+  inclusiveEnd = false,
 ): boolean {
   return selection.some((range) => {
     const rangeFrom = Math.min(range.anchor, range.head);
@@ -54,7 +54,7 @@ export function selectionOnSameLine(
   from: number,
   to: number,
   doc: string,
-  selection: readonly SelectionRange[]
+  selection: readonly SelectionRange[],
 ): boolean {
   // Find line boundaries for the node
   const nodeLineStart = doc.lastIndexOf("\n", from - 1) + 1;
@@ -69,7 +69,7 @@ export function selectionOnSameLine(
 
 function collectImageRanges(
   doc: string,
-  selection: readonly SelectionRange[]
+  _selection: readonly SelectionRange[],
 ): LivePreviewRange[] {
   const ranges: LivePreviewRange[] = [];
   const pattern = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
@@ -87,19 +87,28 @@ function collectImageRanges(
         type: "image",
         alt: match[1] || null,
         url: match[2],
-        title: match[3] || null
-      }
+        title: match[3] || null,
+      },
     });
   }
 
   return ranges;
 }
 
-function isInsideWikiLink(from: number, to: number, wikiLinkSpans: readonly [number, number][]): boolean {
+function isInsideWikiLink(
+  from: number,
+  to: number,
+  wikiLinkSpans: readonly [number, number][],
+): boolean {
   return wikiLinkSpans.some(([wikiFrom, wikiTo]) => from >= wikiFrom && to <= wikiTo);
 }
 
-function shouldSkipInsideWikiLink(node: Content, from: number, to: number, wikiLinkSpans: readonly [number, number][]): boolean {
+function shouldSkipInsideWikiLink(
+  node: Content,
+  from: number,
+  to: number,
+  wikiLinkSpans: readonly [number, number][],
+): boolean {
   return (
     isInsideWikiLink(from, to, wikiLinkSpans) &&
     node.type !== "heading" &&
@@ -114,7 +123,7 @@ function visit(
   doc: string,
   selection: readonly SelectionRange[],
   ranges: LivePreviewRange[],
-  wikiLinkSpans: readonly [number, number][]
+  wikiLinkSpans: readonly [number, number][],
 ): void {
   for (const child of node.children) {
     const from = child.position?.start.offset;
@@ -128,7 +137,13 @@ function visit(
         continue;
       }
 
-      if (child.type === "heading" || child.type === "list" || child.type === "code" || child.type === "definition" || child.type === "html") {
+      if (
+        child.type === "heading" ||
+        child.type === "list" ||
+        child.type === "code" ||
+        child.type === "definition" ||
+        child.type === "html"
+      ) {
         // Always emitted regardless of cursor position.
         // buildDecorations decides decoration treatment based on cursor.
         ranges.push({ from, to, node: child, source: doc.slice(from, to) });
@@ -159,7 +174,7 @@ function visit(
 export function collectLivePreviewRanges(
   ast: Root,
   doc: string,
-  selection: readonly SelectionRange[]
+  selection: readonly SelectionRange[],
 ): LivePreviewRange[] {
   const ranges: LivePreviewRange[] = [];
   const wikiLinkSpans = scanWikiLinks(doc).map((link) => [link.from, link.to] as [number, number]);

--- a/packages/core/src/live-preview-renderers.ts
+++ b/packages/core/src/live-preview-renderers.ts
@@ -8,7 +8,7 @@ import type {
   LivePreviewNode,
   LivePreviewNodeType,
   LivePreviewRenderContext,
-  LivePreviewRenderer
+  LivePreviewRenderer,
 } from "./types";
 
 function getText(node: LivePreviewNode): string {
@@ -29,7 +29,9 @@ function getText(node: LivePreviewNode): string {
 
         if ("children" in child && Array.isArray(child.children)) {
           return child.children
-            .map((nested) => ("value" in nested && typeof nested.value === "string" ? nested.value : ""))
+            .map((nested) =>
+              "value" in nested && typeof nested.value === "string" ? nested.value : "",
+            )
             .join("");
         }
 
@@ -87,7 +89,8 @@ export function createDefaultRenderer(context: LivePreviewRenderContext): HTMLEl
       // (~30px untracked height) → every blockquote would silently shift heightmap.
       const element = document.createElement("blockquote");
       element.textContent = context.text;
-      element.style.cssText = "display:block;margin:0;padding:8px 0 8px 16px;border-left:3px solid var(--nexus-border);color:var(--nexus-text-muted);";
+      element.style.cssText =
+        "display:block;margin:0;padding:8px 0 8px 16px;border-left:3px solid var(--nexus-border);color:var(--nexus-text-muted);";
       return element;
     }
     case "delete": {
@@ -99,7 +102,8 @@ export function createDefaultRenderer(context: LivePreviewRenderContext): HTMLEl
       // CRITICAL: margin:0 — browser default <hr> has ~8px top/bottom margin.
       // Use padding for visual spacing so CM6 measures the full height.
       const element = document.createElement("hr");
-      element.style.cssText = "display:block;margin:0;padding:8px 0;border:0;background:transparent;";
+      element.style.cssText =
+        "display:block;margin:0;padding:8px 0;border:0;background:transparent;";
       const inner = document.createElement("span");
       inner.style.cssText = "display:block;height:1px;background:var(--nexus-border);";
       element.appendChild(inner);
@@ -180,9 +184,7 @@ export function createDefaultRenderer(context: LivePreviewRenderContext): HTMLEl
           }
           // Extract cell text
           if ("children" in cell && Array.isArray(cell.children)) {
-            td.textContent = cell.children
-              .map((c: any) => ("value" in c ? c.value : ""))
-              .join("");
+            td.textContent = cell.children.map((c: any) => ("value" in c ? c.value : "")).join("");
           }
           tr.appendChild(td);
         }
@@ -215,7 +217,7 @@ export function renderLivePreviewNode(
   source: string,
   renderers: Partial<Record<LivePreviewNodeType, LivePreviewRenderer>>,
   from = 0,
-  to = 0
+  to = 0,
 ): HTMLElement {
   const context: LivePreviewRenderContext = {
     node,
@@ -223,7 +225,7 @@ export function renderLivePreviewNode(
     source,
     text: getText(node),
     from,
-    to
+    to,
   };
 
   return renderers[node.type]?.(context) ?? createDefaultRenderer(context);

--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -1,4 +1,4 @@
-import { EditorView, WidgetType, runScopeHandlers } from "@codemirror/view";
+import { type EditorView, WidgetType, runScopeHandlers } from "@codemirror/view";
 import type { Table } from "mdast";
 
 import type { LivePreviewLabels } from "./types";
@@ -53,7 +53,12 @@ const ROW_GRIP_WIDTH = 16;
 const MIN_COLUMN_WIDTH = 48;
 const renderedSourceOffsets = new WeakMap<Node, { start: number; end: number }>();
 
-function getNodeSourceOffsets(node: any, tableFrom: number, rawSourceStart: number, inlineCode = false): { start: number; end: number } | null {
+function getNodeSourceOffsets(
+  node: any,
+  tableFrom: number,
+  rawSourceStart: number,
+  inlineCode = false,
+): { start: number; end: number } | null {
   const startOffset = node?.position?.start?.offset;
   const endOffset = node?.position?.end?.offset;
   if (typeof startOffset !== "number" || typeof endOffset !== "number") return null;
@@ -132,18 +137,6 @@ function placeRawSourceCaret(td: HTMLElement, rawOffset: number): void {
   selection?.addRange(range);
 }
 
-function extractCellText(cell: any): string {
-  if (!cell || !("children" in cell) || !Array.isArray(cell.children)) return "";
-  return cell.children
-    .map((c: any) => {
-      if ("value" in c && typeof c.value === "string") return c.value;
-      if ("children" in c && Array.isArray(c.children))
-        return c.children.map((n: any) => ("value" in n ? n.value : "")).join("");
-      return "";
-    })
-    .join("");
-}
-
 /**
  * Render an inline mdast node into DOM. Supports the inline subset that
  * appears inside table cells: text, link, strong, emphasis, delete,
@@ -191,8 +184,7 @@ function renderInlineMdast(node: any, mediaOnly = false, tableFrom = 0, rawSourc
       a.href = typeof node.url === "string" ? node.url : "#";
       a.target = "_blank";
       a.rel = "noopener noreferrer";
-      a.style.cssText =
-        "color:var(--nexus-accent);text-decoration:underline;cursor:pointer;";
+      a.style.cssText = "color:var(--nexus-accent);text-decoration:underline;cursor:pointer;";
       // Stop CM6's editor-level mousedown handler from reading this as a
       // cursor-placement click — we want the browser's native link click
       // to win so the user can ⌘-click open in a new tab.
@@ -203,22 +195,26 @@ function renderInlineMdast(node: any, mediaOnly = false, tableFrom = 0, rawSourc
         a.style.display = "block";
         a.style.lineHeight = "0";
       }
-      for (const child of node.children ?? []) a.appendChild(renderInlineMdast(child, mediaOnly, tableFrom, rawSourceStart));
+      for (const child of node.children ?? [])
+        a.appendChild(renderInlineMdast(child, mediaOnly, tableFrom, rawSourceStart));
       return a;
     }
     case "strong": {
       const el = document.createElement("strong");
-      for (const child of node.children ?? []) el.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
+      for (const child of node.children ?? [])
+        el.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
       return el;
     }
     case "emphasis": {
       const el = document.createElement("em");
-      for (const child of node.children ?? []) el.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
+      for (const child of node.children ?? [])
+        el.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
       return el;
     }
     case "delete": {
       const el = document.createElement("del");
-      for (const child of node.children ?? []) el.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
+      for (const child of node.children ?? [])
+        el.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
       return el;
     }
     case "inlineCode": {
@@ -266,7 +262,7 @@ function renderInlineMdast(node: any, mediaOnly = false, tableFrom = 0, rawSourc
             "border:1px solid var(--nexus-border-subtle)",
             "object-fit:contain",
           ];
-      img.style.cssText = styles.join(";") + ";";
+      img.style.cssText = `${styles.join(";")};`;
       // Stop CM6's cell mousedown handler from intercepting clicks on the
       // image (otherwise ⌘-clicking the image to open the link wouldn't
       // work, and a plain click would unexpectedly enter cell-edit mode).
@@ -276,7 +272,8 @@ function renderInlineMdast(node: any, mediaOnly = false, tableFrom = 0, rawSourc
     default: {
       if (Array.isArray(node.children)) {
         const frag = document.createDocumentFragment();
-        for (const child of node.children) frag.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
+        for (const child of node.children)
+          frag.appendChild(renderInlineMdast(child, false, tableFrom, rawSourceStart));
         return frag;
       }
       const text = document.createTextNode(typeof node.value === "string" ? node.value : "");
@@ -291,7 +288,8 @@ function renderCellRich(td: HTMLElement, astCell: any, tableFrom = 0, rawSourceS
   td.textContent = "";
   if (!astCell || !Array.isArray(astCell.children)) return;
   const mediaOnly = isCellMediaOnly(astCell);
-  for (const child of astCell.children) td.appendChild(renderInlineMdast(child, mediaOnly, tableFrom, rawSourceStart));
+  for (const child of astCell.children)
+    td.appendChild(renderInlineMdast(child, mediaOnly, tableFrom, rawSourceStart));
 }
 
 const GRIP_BG = "var(--nexus-bg-muted)";
@@ -309,15 +307,19 @@ export class EditableTableWidget extends WidgetType {
     private tableFrom: number,
     private source: string,
     private viewRef: { current: EditorView | null },
-    private labels: Required<LivePreviewLabels>
-  ) { super(); }
+    private labels: Required<LivePreviewLabels>,
+  ) {
+    super();
+  }
 
   eq(other: EditableTableWidget): boolean {
     if (this.editing) return true;
     return this.source === other.source;
   }
 
-  ignoreEvent(): boolean { return true; }
+  ignoreEvent(): boolean {
+    return true;
+  }
 
   destroy(): void {
     this.cleanupEditingLocks?.();
@@ -333,7 +335,9 @@ export class EditableTableWidget extends WidgetType {
   private dispatch(newSource: string): void {
     const v = this.viewRef.current;
     if (!v) return;
-    v.dispatch({ changes: { from: this.tableFrom, to: this.tableFrom + this.source.length, insert: newSource } });
+    v.dispatch({
+      changes: { from: this.tableFrom, to: this.tableFrom + this.source.length, insert: newSource },
+    });
   }
 
   private deleteColumn(colIdx: number): void {
@@ -342,7 +346,7 @@ export class EditableTableWidget extends WidgetType {
       const cells = line.split("|").filter((_, i, a) => i > 0 && i < a.length - 1);
       if (cells.length === 0) return line;
       cells.splice(colIdx, 1);
-      return "|" + cells.join("|") + "|";
+      return `|${cells.join("|")}|`;
     });
     this.dispatch(newLines.join("\n"));
   }
@@ -359,13 +363,15 @@ export class EditableTableWidget extends WidgetType {
 
   private addColumn(): void {
     const lines = this.source.split("\n");
-    const nl = lines.map((l) => SEPARATOR_RE.test(l) ? l.replace(/\|?\s*$/, " | --- |") : l.replace(/\|?\s*$/, " |  |"));
+    const nl = lines.map((l) =>
+      SEPARATOR_RE.test(l) ? l.replace(/\|?\s*$/, " | --- |") : l.replace(/\|?\s*$/, " |  |"),
+    );
     this.dispatch(nl.join("\n"));
   }
 
   private addRow(): void {
     const cc = (this.node.children?.[0] as any)?.children?.length ?? 2;
-    const nr = "\n| " + Array(cc).fill("  ").join(" | ") + " |";
+    const nr = `\n| ${Array(cc).fill("  ").join(" | ")} |`;
     const v = this.viewRef.current;
     if (!v) return;
     v.dispatch({ changes: { from: this.tableFrom + this.source.length, insert: nr } });
@@ -374,11 +380,12 @@ export class EditableTableWidget extends WidgetType {
   private moveColumn(from: number, to: number): void {
     const lines = this.source.split("\n");
     const nl = lines.map((line) => {
-      const p = line.split("|"), cells = p.slice(1, -1);
+      const p = line.split("|");
+      const cells = p.slice(1, -1);
       if (from >= cells.length || to >= cells.length) return line;
       const [m] = cells.splice(from, 1);
       cells.splice(to, 0, m);
-      return "|" + cells.join("|") + "|";
+      return `|${cells.join("|")}|`;
     });
     this.dispatch(nl.join("\n"));
   }
@@ -387,7 +394,8 @@ export class EditableTableWidget extends WidgetType {
     const lines = this.source.split("\n");
     const dl: number[] = [];
     for (let i = 0; i < lines.length; i++) if (!SEPARATOR_RE.test(lines[i])) dl.push(i);
-    const s = dl[from], d = dl[to];
+    const s = dl[from];
+    const d = dl[to];
     if (s === undefined || d === undefined) return;
     const [m] = lines.splice(s, 1);
     lines.splice(d, 0, m);
@@ -409,7 +417,8 @@ export class EditableTableWidget extends WidgetType {
     }
     const sourceLines = this.source.split("\n");
     const dataLineIndices: number[] = [];
-    for (let i = 0; i < sourceLines.length; i++) if (!SEPARATOR_RE.test(sourceLines[i])) dataLineIndices.push(i);
+    for (let i = 0; i < sourceLines.length; i++)
+      if (!SEPARATOR_RE.test(sourceLines[i])) dataLineIndices.push(i);
 
     // State
     let selectedCol = -1;
@@ -420,11 +429,11 @@ export class EditableTableWidget extends WidgetType {
     let rangeEnd: { row: number; col: number } | null = null;
     let isRangeSelecting = false;
     let cellMouseDown = false; // true between mousedown and mouseup on a cell
-    let rangeActive = false;   // true when a multi-cell range is displayed (survives mouseup)
+    let rangeActive = false; // true when a multi-cell range is displayed (survives mouseup)
 
     // Custom drag state (no HTML5 drag API)
-    let draggingCol = -1;   // which column is being dragged
-    let draggingRow = -1;   // which row is being dragged
+    let draggingCol = -1; // which column is being dragged
+    let draggingRow = -1; // which row is being dragged
     let dropTargetCol = -1;
     let dropTargetRow = -1;
     const editingLocks = {
@@ -459,7 +468,12 @@ export class EditableTableWidget extends WidgetType {
 
     function blurActiveCellForDrag(): void {
       const active = document.activeElement;
-      if (!(active instanceof HTMLElement) || !wrapper.contains(active) || !active.classList.contains("nexus-cell")) return;
+      if (
+        !(active instanceof HTMLElement) ||
+        !wrapper.contains(active) ||
+        !active.classList.contains("nexus-cell")
+      )
+        return;
       active.blur();
       releaseEditingLock("focus");
       active.contentEditable = "false";
@@ -471,14 +485,18 @@ export class EditableTableWidget extends WidgetType {
     // CRITICAL: use padding, not margin. CM6 measures block widget height via
     // getBoundingClientRect which EXCLUDES margin. margin:8px caused 16px of
     // untracked height per table → cumulative click-drift below every table.
-    wrapper.style.cssText = "display:inline-block;position:relative;padding:8px 0;user-select:none;";
+    wrapper.style.cssText =
+      "display:inline-block;position:relative;padding:8px 0;user-select:none;";
 
     // ── Table ──
     const table = document.createElement("table");
     table.setAttribute("role", "grid");
     table.setAttribute("aria-label", "Editable table");
     table.style.cssText = "border-collapse:collapse;display:table;";
-    if (rows.length === 0) { wrapper.appendChild(table); return wrapper; }
+    if (rows.length === 0) {
+      wrapper.appendChild(table);
+      return wrapper;
+    }
 
     // ── Column-width persistence ──
     // Keyed by the table's header source line so widths stick across
@@ -496,19 +514,19 @@ export class EditableTableWidget extends WidgetType {
         colgroup = document.createElement("colgroup") as HTMLTableColElement;
         for (let i = 0; i < widths.length; i++) {
           const col = document.createElement("col");
-          col.style.width = widths[i] + "px";
+          col.style.width = `${widths[i]}px`;
           colgroup.appendChild(col);
         }
         table.insertBefore(colgroup, table.firstChild);
       } else {
         const cols = Array.from(colgroup.children);
         for (let i = 0; i < widths.length && i < cols.length; i++) {
-          (cols[i] as HTMLElement).style.width = widths[i] + "px";
+          (cols[i] as HTMLElement).style.width = `${widths[i]}px`;
         }
       }
       const total = widths.reduce((s, w) => s + w, 0);
       table.style.tableLayout = "fixed";
-      table.style.width = total + "px";
+      table.style.width = `${total}px`;
     };
 
     /**
@@ -585,7 +603,13 @@ export class EditableTableWidget extends WidgetType {
         const isSelected = sel.from !== sel.to && sel.from <= self.tableFrom && sel.to >= tableEnd;
         selectionOverlay.style.display = isSelected ? "block" : "none";
         // If cursor moved outside table, no active interaction, no active range, clear range selection
-        if (rangeStart && !isRangeSelecting && !cellMouseDown && !rangeActive && (sel.head < self.tableFrom || sel.head > tableEnd)) {
+        if (
+          rangeStart &&
+          !isRangeSelecting &&
+          !cellMouseDown &&
+          !rangeActive &&
+          (sel.head < self.tableFrom || sel.head > tableEnd)
+        ) {
           clearRangeSelection();
         }
       } else {
@@ -597,29 +621,21 @@ export class EditableTableWidget extends WidgetType {
 
     // ── Drag indicator overlay (full-height vertical line) ──
     const colIndicator = document.createElement("div");
-    colIndicator.style.cssText =
-      "position:absolute;width:2px;background:" + SELECT_BORDER + ";pointer-events:none;" +
-      "top:0;bottom:0;display:none;z-index:2;border-radius:1px;";
+    colIndicator.style.cssText = `position:absolute;width:2px;background:${SELECT_BORDER};pointer-events:none;top:0;bottom:0;display:none;z-index:2;border-radius:1px;`;
     wrapper.appendChild(colIndicator);
 
     const rowIndicator = document.createElement("div");
-    rowIndicator.style.cssText =
-      "position:absolute;height:2px;background:" + SELECT_BORDER + ";pointer-events:none;" +
-      "left:0;right:0;display:none;z-index:2;border-radius:1px;";
+    rowIndicator.style.cssText = `position:absolute;height:2px;background:${SELECT_BORDER};pointer-events:none;left:0;right:0;display:none;z-index:2;border-radius:1px;`;
     wrapper.appendChild(rowIndicator);
 
     // Floating pill that follows the mouse during column drag
     const floatingPill = document.createElement("div");
-    floatingPill.style.cssText =
-      "position:absolute;width:16px;height:6px;border-radius:3px;background:" + SELECT_BORDER + ";" +
-      "pointer-events:none;display:none;z-index:3;top:4px;";
+    floatingPill.style.cssText = `position:absolute;width:16px;height:6px;border-radius:3px;background:${SELECT_BORDER};pointer-events:none;display:none;z-index:3;top:4px;`;
     wrapper.appendChild(floatingPill);
 
     // Floating pill for row drag
     const floatingRowPill = document.createElement("div");
-    floatingRowPill.style.cssText =
-      "position:absolute;width:6px;height:16px;border-radius:3px;background:" + SELECT_BORDER + ";" +
-      "pointer-events:none;display:none;z-index:3;left:5px;";
+    floatingRowPill.style.cssText = `position:absolute;width:6px;height:16px;border-radius:3px;background:${SELECT_BORDER};pointer-events:none;display:none;z-index:3;left:5px;`;
     wrapper.appendChild(floatingRowPill);
 
     // ── Helpers ──
@@ -649,7 +665,8 @@ export class EditableTableWidget extends WidgetType {
     function rowAtClientY(clientY: number): number {
       // Skip header (index 0), only match data rows (index >= 1)
       const dataRows = Array.from(table.querySelectorAll("tr")).filter((_, i) => i > 0);
-      for (let i = 1; i < dataRows.length; i++) { // start at 1 to skip header row
+      for (let i = 1; i < dataRows.length; i++) {
+        // start at 1 to skip header row
         const rect = dataRows[i].getBoundingClientRect();
         if (clientY >= rect.top && clientY <= rect.bottom) return i;
       }
@@ -657,7 +674,11 @@ export class EditableTableWidget extends WidgetType {
     }
 
     function showColIndicator(targetCol: number): void {
-      if (draggingCol < 0 || targetCol === draggingCol) { colIndicator.style.display = "none"; dropTargetCol = -1; return; }
+      if (draggingCol < 0 || targetCol === draggingCol) {
+        colIndicator.style.display = "none";
+        dropTargetCol = -1;
+        return;
+      }
       dropTargetCol = targetCol;
       const cells = getHeaderCells();
       const cell = cells[targetCol] as HTMLElement | undefined;
@@ -667,20 +688,25 @@ export class EditableTableWidget extends WidgetType {
       const bounds = getContentBounds();
       const rawX = draggingCol < targetCol ? cellRect.right : cellRect.left;
       const clampedX = Math.max(bounds.left, Math.min(rawX, bounds.right));
-      colIndicator.style.left = (clampedX - wrapperRect.left - 1) + "px";
+      colIndicator.style.left = `${clampedX - wrapperRect.left - 1}px`;
       colIndicator.style.display = "block";
     }
 
     function showRowIndicator(targetRow: number): void {
-      if (draggingRow < 0 || targetRow === draggingRow) { rowIndicator.style.display = "none"; dropTargetRow = -1; return; }
+      if (draggingRow < 0 || targetRow === draggingRow) {
+        rowIndicator.style.display = "none";
+        dropTargetRow = -1;
+        return;
+      }
       dropTargetRow = targetRow;
       const dataRows = Array.from(table.querySelectorAll("tr")).filter((_, i) => i > 0);
       const row = dataRows[targetRow] as HTMLElement | undefined;
       if (!row) return;
       const wrapperRect = wrapper.getBoundingClientRect();
       const rowRect = row.getBoundingClientRect();
-      const y = draggingRow < targetRow ? rowRect.bottom - wrapperRect.top : rowRect.top - wrapperRect.top;
-      rowIndicator.style.top = (y - 1) + "px";
+      const y =
+        draggingRow < targetRow ? rowRect.bottom - wrapperRect.top : rowRect.top - wrapperRect.top;
+      rowIndicator.style.top = `${y - 1}px`;
       rowIndicator.style.display = "block";
     }
 
@@ -700,9 +726,7 @@ export class EditableTableWidget extends WidgetType {
 
     // ── Range selection border overlay ──
     const rangeBorder = document.createElement("div");
-    rangeBorder.style.cssText =
-      "position:absolute;border:2px solid " + SELECT_BORDER + ";pointer-events:none;" +
-      "display:none;z-index:1;border-radius:2px;";
+    rangeBorder.style.cssText = `position:absolute;border:2px solid ${SELECT_BORDER};pointer-events:none;display:none;z-index:1;border-radius:2px;`;
     wrapper.appendChild(rangeBorder);
 
     function getNormalizedRange(): { r1: number; c1: number; r2: number; c2: number } | null {
@@ -725,14 +749,22 @@ export class EditableTableWidget extends WidgetType {
 
     function renderRangeSelection(): void {
       const range = getNormalizedRange();
-      if (!range) { rangeBorder.style.display = "none"; return; }
+      if (!range) {
+        rangeBorder.style.display = "none";
+        return;
+      }
 
       // Highlight cells in range
       const dataRows = Array.from(table.querySelectorAll("tr")).filter((_, i) => i > 0);
       dataRows.forEach((tr, rowIdx) => {
         tr.querySelectorAll(".nexus-cell").forEach((cell, colIdx) => {
           const h = cell as HTMLElement;
-          if (rowIdx >= range.r1 && rowIdx <= range.r2 && colIdx >= range.c1 && colIdx <= range.c2) {
+          if (
+            rowIdx >= range.r1 &&
+            rowIdx <= range.r2 &&
+            colIdx >= range.c1 &&
+            colIdx <= range.c2
+          ) {
             h.style.background = SELECT_BG;
           } else {
             h.style.background = h.tagName === "TH" ? "var(--nexus-bg-subtle)" : "";
@@ -743,16 +775,19 @@ export class EditableTableWidget extends WidgetType {
       // Position the border overlay around the selected range
       const topLeft = getCellElement(range.r1, range.c1);
       const bottomRight = getCellElement(range.r2, range.c2);
-      if (!topLeft || !bottomRight) { rangeBorder.style.display = "none"; return; }
+      if (!topLeft || !bottomRight) {
+        rangeBorder.style.display = "none";
+        return;
+      }
 
       const wrapperRect = wrapper.getBoundingClientRect();
       const tlRect = topLeft.getBoundingClientRect();
       const brRect = bottomRight.getBoundingClientRect();
 
-      rangeBorder.style.left = (tlRect.left - wrapperRect.left - 1) + "px";
-      rangeBorder.style.top = (tlRect.top - wrapperRect.top - 1) + "px";
-      rangeBorder.style.width = (brRect.right - tlRect.left) + "px";
-      rangeBorder.style.height = (brRect.bottom - tlRect.top) + "px";
+      rangeBorder.style.left = `${tlRect.left - wrapperRect.left - 1}px`;
+      rangeBorder.style.top = `${tlRect.top - wrapperRect.top - 1}px`;
+      rangeBorder.style.width = `${brRect.right - tlRect.left}px`;
+      rangeBorder.style.height = `${brRect.bottom - tlRect.top}px`;
       rangeBorder.style.display = "block";
     }
 
@@ -779,7 +814,12 @@ export class EditableTableWidget extends WidgetType {
         const cells = dataRows[r].querySelectorAll(".nexus-cell");
         for (let c = 0; c < cells.length; c++) {
           const rect = cells[c].getBoundingClientRect();
-          if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+          if (
+            clientX >= rect.left &&
+            clientX <= rect.right &&
+            clientY >= rect.top &&
+            clientY <= rect.bottom
+          ) {
             return { row: r, col: c };
           }
         }
@@ -808,7 +848,9 @@ export class EditableTableWidget extends WidgetType {
       selectedCol = colIdx;
       const gripCells = table.querySelectorAll(".nexus-col-grip");
       if (gripCells[colIdx]) (gripCells[colIdx] as HTMLElement).style.background = SELECT_BORDER;
-      getColumnCells(colIdx).forEach((el) => { el.style.background = SELECT_BG; });
+      getColumnCells(colIdx).forEach((el) => {
+        el.style.background = SELECT_BG;
+      });
     }
 
     function highlightRow(rowIdx: number): void {
@@ -826,9 +868,7 @@ export class EditableTableWidget extends WidgetType {
 
     function createGripPill(): HTMLElement {
       const pill = document.createElement("div");
-      pill.style.cssText =
-        "width:16px;height:6px;border-radius:3px;background:" + GRIP_BG + ";" +
-        "margin:0 auto;transition:background .15s;";
+      pill.style.cssText = `width:16px;height:6px;border-radius:3px;background:${GRIP_BG};margin:0 auto;transition:background .15s;`;
       return pill;
     }
 
@@ -845,13 +885,16 @@ export class EditableTableWidget extends WidgetType {
 
     function onDragMove(e: MouseEvent): void {
       e.preventDefault();
-      if (!wrapper.isConnected) { onDragEnd(); return; }
+      if (!wrapper.isConnected) {
+        onDragEnd();
+        return;
+      }
       const wrapperRect = wrapper.getBoundingClientRect();
 
       if (draggingCol >= 0) {
         const bounds = getContentBounds();
         const clampedX = Math.max(bounds.left, Math.min(e.clientX, bounds.right));
-        floatingPill.style.left = (clampedX - wrapperRect.left - 8) + "px";
+        floatingPill.style.left = `${clampedX - wrapperRect.left - 8}px`;
 
         const target = colAtClientX(clampedX);
         if (target >= 0 && target !== draggingCol) {
@@ -870,7 +913,7 @@ export class EditableTableWidget extends WidgetType {
         const minY = firstBodyRow ? firstBodyRow.top : wrapperRect.top;
         const maxY = lastRow ? lastRow.bottom : wrapperRect.bottom;
         const clampedY = Math.max(minY, Math.min(e.clientY, maxY));
-        floatingRowPill.style.top = (clampedY - wrapperRect.top - 8) + "px";
+        floatingRowPill.style.top = `${clampedY - wrapperRect.top - 8}px`;
 
         const target = rowAtClientY(clampedY);
         if (target >= 0 && target !== draggingRow) {
@@ -920,11 +963,13 @@ export class EditableTableWidget extends WidgetType {
       clearRangeSelection();
       clearSelection();
       // Highlight source column
-      getColumnCells(colIdx).forEach((el) => { el.style.background = DRAG_HIGHLIGHT_BG; });
+      getColumnCells(colIdx).forEach((el) => {
+        el.style.background = DRAG_HIGHLIGHT_BG;
+      });
       // Hide grip row, show floating pill instead
       gripRow.style.opacity = "0";
       const wrapperRect = wrapper.getBoundingClientRect();
-      floatingPill.style.left = (startX - wrapperRect.left - 8) + "px";
+      floatingPill.style.left = `${startX - wrapperRect.left - 8}px`;
       floatingPill.style.display = "block";
       document.addEventListener("mousemove", onDragMove);
       document.addEventListener("mouseup", onDragEnd);
@@ -949,7 +994,7 @@ export class EditableTableWidget extends WidgetType {
       }
       // Show floating row pill
       const wrapperRect = wrapper.getBoundingClientRect();
-      floatingRowPill.style.top = (startY - wrapperRect.top - 8) + "px";
+      floatingRowPill.style.top = `${startY - wrapperRect.top - 8}px`;
       floatingRowPill.style.display = "block";
       // Hide the source row grip
       const grip = trs[rowIdx]?.querySelector(".nexus-row-grip") as HTMLElement | null;
@@ -976,8 +1021,12 @@ export class EditableTableWidget extends WidgetType {
       const pill = createGripPill();
       gripCell.appendChild(pill);
 
-      gripCell.addEventListener("mouseenter", () => { if (draggingCol < 0) pill.style.background = GRIP_BG_HOVER; });
-      gripCell.addEventListener("mouseleave", () => { if (draggingCol < 0) pill.style.background = GRIP_BG; });
+      gripCell.addEventListener("mouseenter", () => {
+        if (draggingCol < 0) pill.style.background = GRIP_BG_HOVER;
+      });
+      gripCell.addEventListener("mouseleave", () => {
+        if (draggingCol < 0) pill.style.background = GRIP_BG;
+      });
 
       const colIdx = c;
 
@@ -1008,7 +1057,9 @@ export class EditableTableWidget extends WidgetType {
     // 切换期间置位，让旧单元格 blur 跳过这个会抢焦点的派发；新单元格 focus 已接管编辑态。
     let navigatingBetweenCells = false;
     function tableDataRows(): HTMLElement[] {
-      return Array.from(table.querySelectorAll<HTMLElement>("tr")).filter((row) => row.querySelector(".nexus-cell"));
+      return Array.from(table.querySelectorAll<HTMLElement>("tr")).filter((row) =>
+        row.querySelector(".nexus-cell"),
+      );
     }
     function cellAt(rowIndex: number, colIndex: number): HTMLElement | null {
       if (rowIndex < 0 || colIndex < 0) return null;
@@ -1053,13 +1104,29 @@ export class EditableTableWidget extends WidgetType {
       // 与单元格点击激活一致：focus/重渲染稳定后再摆一次光标，避免落点丢失。
       window.setTimeout(place, 0);
       // 稍后回看焦点是否仍在目标单元格（若被抢走，说明仍有 dispatch/blur 干扰）。
-      window.setTimeout(() => tableNavDebug("focusCellForNavigation:settled", { active: describeActiveCell() }), 60);
+      window.setTimeout(
+        () => tableNavDebug("focusCellForNavigation:settled", { active: describeActiveCell() }),
+        60,
+      );
     }
-    function navigateFromCell(key: string, cell: HTMLElement, rowIndex: number, colIndex: number): boolean {
+    function navigateFromCell(
+      key: string,
+      cell: HTMLElement,
+      rowIndex: number,
+      colIndex: number,
+    ): boolean {
       const offset = caretOffsetInCell(cell);
       const length = (cell.dataset.source ?? cell.textContent ?? "").length;
       const dataRowCount = tableDataRows().length;
-      tableNavDebug("navigateFromCell", { key, offset, length, rowIndex, colIndex, colCount, dataRowCount });
+      tableNavDebug("navigateFromCell", {
+        key,
+        offset,
+        length,
+        rowIndex,
+        colIndex,
+        colCount,
+        dataRowCount,
+      });
 
       if (key === "ArrowUp") {
         const target = cellAt(rowIndex - 1, colIndex);
@@ -1105,18 +1172,15 @@ export class EditableTableWidget extends WidgetType {
     for (const astRow of rows) {
       const isHeader = rowIdx === 0;
       const tr = document.createElement("tr");
-      const astCells = "children" in astRow && Array.isArray(astRow.children) ? astRow.children : [];
+      const astCells =
+        "children" in astRow && Array.isArray(astRow.children) ? astRow.children : [];
       const sourceLineIdx = dataLineIndices[rowIdx];
       const curRowIdx = rowIdx;
 
       // Row grip
       const rowGrip = document.createElement(isHeader ? "th" : "td");
       rowGrip.className = "nexus-row-grip";
-      rowGrip.style.cssText =
-        "width:16px;min-width:16px;max-width:16px;padding:6px 2px;text-align:center;" +
-        "cursor:" + (isHeader ? "default" : "grab") + ";user-select:none;border:none;" +
-        "border-right:1px solid var(--nexus-border);vertical-align:middle;" +
-        "opacity:0;transition:opacity .15s;";
+      rowGrip.style.cssText = `width:16px;min-width:16px;max-width:16px;padding:6px 2px;text-align:center;cursor:${isHeader ? "default" : "grab"};user-select:none;border:none;border-right:1px solid var(--nexus-border);vertical-align:middle;opacity:0;transition:opacity .15s;`;
 
       if (!isHeader) {
         const rowPill = createGripPill();
@@ -1125,8 +1189,12 @@ export class EditableTableWidget extends WidgetType {
         rowPill.style.borderRadius = "3px";
         rowGrip.appendChild(rowPill);
 
-        rowGrip.addEventListener("mouseenter", () => { if (draggingRow < 0) rowPill.style.background = GRIP_BG_HOVER; });
-        rowGrip.addEventListener("mouseleave", () => { if (draggingRow < 0) rowPill.style.background = GRIP_BG; });
+        rowGrip.addEventListener("mouseenter", () => {
+          if (draggingRow < 0) rowPill.style.background = GRIP_BG_HOVER;
+        });
+        rowGrip.addEventListener("mouseleave", () => {
+          if (draggingRow < 0) rowPill.style.background = GRIP_BG;
+        });
 
         rowGrip.addEventListener("mousedown", (e) => {
           e.preventDefault();
@@ -1155,8 +1223,9 @@ export class EditableTableWidget extends WidgetType {
         // Stash the raw markdown source for this cell so we can (a) render
         // it as rich DOM by default — links, bold, code, etc. — and (b)
         // swap back to the raw text when the cell is focused for editing.
-        // Without this, `extractCellText` flattens `[X](url)` to `X` and the
-        // source-line dispatch in the input handler would clobber the link.
+        // Without raw source stashing, flattening rich nodes to textContent
+        // loses things like `[X](url)` to `X` and the source-line dispatch in
+        // the input handler would clobber the link.
         let rawSource = "";
         let rawSourceStart = 0;
         const startOffset = astCell?.position?.start?.offset;
@@ -1192,7 +1261,7 @@ export class EditableTableWidget extends WidgetType {
           // handle.
           const resizeHandle = document.createElement("div");
           resizeHandle.className = "nexus-col-resize";
-          resizeHandle.style.cssText = [
+          resizeHandle.style.cssText = `${[
             "position:absolute",
             "top:0",
             "right:-3px",
@@ -1201,7 +1270,7 @@ export class EditableTableWidget extends WidgetType {
             "cursor:col-resize",
             "z-index:3",
             "user-select:none",
-          ].join(";") + ";";
+          ].join(";")};`;
           const handleColIdx = colIdx;
           resizeHandle.addEventListener("mousedown", (e) => {
             if (e.button !== 0) return;
@@ -1236,8 +1305,8 @@ export class EditableTableWidget extends WidgetType {
           // between rows.
           const renderedWidth = td.getBoundingClientRect().width;
           if (renderedWidth > 0) {
-            td.style.maxWidth = renderedWidth + "px";
-            td.style.width = renderedWidth + "px";
+            td.style.maxWidth = `${renderedWidth}px`;
+            td.style.width = `${renderedWidth}px`;
           }
           // Inside the capped cell, let long URLs wrap (the rendered
           // text was usually shorter than the raw markdown).
@@ -1273,7 +1342,7 @@ export class EditableTableWidget extends WidgetType {
           rangeEnd = { row: cellRow, col: cellCol };
           const onCellMouseMove = (me: MouseEvent): void => {
             const target = cellAtPoint(me.clientX, me.clientY);
-            if (target && (target.row !== rangeStart!.row || target.col !== rangeStart!.col)) {
+            if (target && (target.row !== rangeStart?.row || target.col !== rangeStart?.col)) {
               cellMouseMoved = true;
               isRangeSelecting = true;
               rangeEnd = target;
@@ -1362,7 +1431,10 @@ export class EditableTableWidget extends WidgetType {
             const v = self.viewRef.current;
             if (!v) return;
             const sel = v.state.selection.main;
-            tableNavDebug("blur-dispatch:run", { anchor: sel.anchor, active: describeActiveCell() });
+            tableNavDebug("blur-dispatch:run", {
+              anchor: sel.anchor,
+              active: describeActiveCell(),
+            });
             try {
               v.dispatch({ selection: { anchor: sel.anchor, head: sel.head } });
             } catch {
@@ -1384,7 +1456,7 @@ export class EditableTableWidget extends WidgetType {
             // their textContent would strip URLs and lose inline markdown.
             vals.push(el.dataset.source ?? el.textContent ?? "");
           });
-          const newLine = "| " + vals.join(" | ") + " |";
+          const newLine = `| ${vals.join(" | ")} |`;
           let off = self.tableFrom;
           for (let i = 0; i < sourceLineIdx; i++) off += sourceLines[i].length + 1;
           const end = off + sourceLines[sourceLineIdx].length;
@@ -1404,7 +1476,12 @@ export class EditableTableWidget extends WidgetType {
           }
 
           // 方向键在单元格之间移动（电子表格式）；边界外不消费，交回默认。
-          if (e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "ArrowLeft" || e.key === "ArrowRight") {
+          if (
+            e.key === "ArrowUp" ||
+            e.key === "ArrowDown" ||
+            e.key === "ArrowLeft" ||
+            e.key === "ArrowRight"
+          ) {
             if (navigateFromCell(e.key, td, cellRow, cellCol)) {
               e.preventDefault();
               return;
@@ -1443,7 +1520,18 @@ export class EditableTableWidget extends WidgetType {
           const cellIdx = cells.indexOf(clickedCell);
           clickedCol = Math.max(0, cellIdx - 1);
         }
-        showContextMenu(e.clientX, e.clientY, self, self.labels, curRowIdx, isHeader, clickedCol, colCount, rows.length, wrapper);
+        showContextMenu(
+          e.clientX,
+          e.clientY,
+          self,
+          self.labels,
+          curRowIdx,
+          isHeader,
+          clickedCol,
+          colCount,
+          rows.length,
+          wrapper,
+        );
       });
 
       table.appendChild(tr);
@@ -1461,7 +1549,8 @@ export class EditableTableWidget extends WidgetType {
     }
 
     // ── "+" buttons ──
-    const btnCss = "position:absolute;width:20px;height:20px;border:1px solid var(--nexus-border-subtle);" +
+    const btnCss =
+      "position:absolute;width:20px;height:20px;border:1px solid var(--nexus-border-subtle);" +
       "border-radius:50%;background:var(--nexus-bg);cursor:pointer;font-size:14px;line-height:1;" +
       "display:flex;align-items:center;justify-content:center;color:var(--nexus-text-muted);padding:0;" +
       "opacity:0;transition:opacity .15s;z-index:1;";
@@ -1469,63 +1558,95 @@ export class EditableTableWidget extends WidgetType {
     const addCol = document.createElement("button");
     addCol.textContent = "+";
     addCol.title = self.labels.addColumn;
-    addCol.style.cssText = btnCss + "right:-24px;top:50%;transform:translateY(-50%);";
+    addCol.style.cssText = `${btnCss}right:-24px;top:50%;transform:translateY(-50%);`;
     addCol.addEventListener("click", () => self.addColumn());
     wrapper.appendChild(addCol);
 
     const addRow = document.createElement("button");
     addRow.textContent = "+";
     addRow.title = self.labels.addRow;
-    addRow.style.cssText = btnCss + "bottom:-24px;left:50%;transform:translateX(-50%);";
+    addRow.style.cssText = `${btnCss}bottom:-24px;left:50%;transform:translateX(-50%);`;
     addRow.addEventListener("click", () => self.addRow());
     wrapper.appendChild(addRow);
 
     // ── Per-element hover (suppressed during drag) ──
-    function isDragging(): boolean { return draggingCol >= 0 || draggingRow >= 0; }
+    function isDragging(): boolean {
+      return draggingCol >= 0 || draggingRow >= 0;
+    }
 
     const headerTr = table.querySelectorAll("tr")[1] as HTMLElement | undefined;
-    gripRow.addEventListener("mouseenter", () => { if (!isDragging()) gripRow.style.opacity = "1"; });
-    gripRow.addEventListener("mouseleave", () => { if (!isDragging()) gripRow.style.opacity = "0"; });
+    gripRow.addEventListener("mouseenter", () => {
+      if (!isDragging()) gripRow.style.opacity = "1";
+    });
+    gripRow.addEventListener("mouseleave", () => {
+      if (!isDragging()) gripRow.style.opacity = "0";
+    });
     if (headerTr) {
-      headerTr.addEventListener("mouseenter", () => { if (!isDragging()) gripRow.style.opacity = "1"; });
-      headerTr.addEventListener("mouseleave", () => { if (!isDragging()) gripRow.style.opacity = "0"; });
+      headerTr.addEventListener("mouseenter", () => {
+        if (!isDragging()) gripRow.style.opacity = "1";
+      });
+      headerTr.addEventListener("mouseleave", () => {
+        if (!isDragging()) gripRow.style.opacity = "0";
+      });
     }
 
     table.querySelectorAll("tr").forEach((tr, trIdx) => {
       if (trIdx === 0) return;
       const grip = tr.querySelector(".nexus-row-grip") as HTMLElement | null;
       if (!grip) return;
-      tr.addEventListener("mouseenter", () => { if (!isDragging()) grip.style.opacity = "1"; });
-      tr.addEventListener("mouseleave", () => { if (!isDragging()) grip.style.opacity = "0"; });
+      tr.addEventListener("mouseenter", () => {
+        if (!isDragging()) grip.style.opacity = "1";
+      });
+      tr.addEventListener("mouseleave", () => {
+        if (!isDragging()) grip.style.opacity = "0";
+      });
     });
 
-    addCol.addEventListener("mouseenter", () => { if (!isDragging()) addCol.style.opacity = "1"; });
-    addCol.addEventListener("mouseleave", () => { if (!isDragging()) addCol.style.opacity = "0"; });
+    addCol.addEventListener("mouseenter", () => {
+      if (!isDragging()) addCol.style.opacity = "1";
+    });
+    addCol.addEventListener("mouseleave", () => {
+      if (!isDragging()) addCol.style.opacity = "0";
+    });
     table.querySelectorAll("tr").forEach((tr, trIdx) => {
       if (trIdx === 0) return;
       const cells = tr.querySelectorAll("th,td");
       const lastCell = cells[cells.length - 1] as HTMLElement | null;
       if (lastCell) {
-        lastCell.addEventListener("mouseenter", () => { if (!isDragging()) addCol.style.opacity = "1"; });
-        lastCell.addEventListener("mouseleave", () => { if (!isDragging()) addCol.style.opacity = "0"; });
+        lastCell.addEventListener("mouseenter", () => {
+          if (!isDragging()) addCol.style.opacity = "1";
+        });
+        lastCell.addEventListener("mouseleave", () => {
+          if (!isDragging()) addCol.style.opacity = "0";
+        });
       }
     });
 
-    addRow.addEventListener("mouseenter", () => { addRow.style.opacity = "1"; });
-    addRow.addEventListener("mouseleave", () => { addRow.style.opacity = "0"; });
+    addRow.addEventListener("mouseenter", () => {
+      addRow.style.opacity = "1";
+    });
+    addRow.addEventListener("mouseleave", () => {
+      addRow.style.opacity = "0";
+    });
     const allDataRows = Array.from(table.querySelectorAll("tr")).filter((_, i) => i > 0);
     const lastDataRow = allDataRows[allDataRows.length - 1] as HTMLElement | undefined;
     if (lastDataRow) {
-      lastDataRow.addEventListener("mouseenter", () => { addRow.style.opacity = "1"; });
-      lastDataRow.addEventListener("mouseleave", () => { addRow.style.opacity = "0"; });
+      lastDataRow.addEventListener("mouseenter", () => {
+        addRow.style.opacity = "1";
+      });
+      lastDataRow.addEventListener("mouseleave", () => {
+        addRow.style.opacity = "0";
+      });
     }
 
     wrapper.addEventListener("click", (e) => {
       // Skip if a range drag just completed (this click is the tail of that drag)
       if (rangeActive) return;
-      if (!(e.target as HTMLElement).closest(".nexus-cell") &&
-          !(e.target as HTMLElement).closest(".nexus-row-grip") &&
-          !(e.target as HTMLElement).closest(".nexus-col-grip")) {
+      if (
+        !(e.target as HTMLElement).closest(".nexus-cell") &&
+        !(e.target as HTMLElement).closest(".nexus-row-grip") &&
+        !(e.target as HTMLElement).closest(".nexus-col-grip")
+      ) {
         clearSelection();
         clearRangeSelection();
       }
@@ -1533,7 +1654,10 @@ export class EditableTableWidget extends WidgetType {
 
     // Click outside table clears all selection
     const onDocMouseDown = (e: MouseEvent): void => {
-      if (!wrapper.isConnected) { document.removeEventListener("mousedown", onDocMouseDown); return; }
+      if (!wrapper.isConnected) {
+        document.removeEventListener("mousedown", onDocMouseDown);
+        return;
+      }
       if (!wrapper.contains(e.target as Node)) {
         clearSelection();
         clearRangeSelection();
@@ -1557,7 +1681,7 @@ export class EditableTableWidget extends WidgetType {
             for (let c = range.c1; c <= range.c2; c++) {
               if (c < cells.length) cells[c] = "  ";
             }
-            lines[lineIdx] = "|" + cells.join("|") + "|";
+            lines[lineIdx] = `|${cells.join("|")}|`;
           }
           self.dispatch(lines.join("\n"));
           clearRangeSelection();
@@ -1581,18 +1705,23 @@ export class EditableTableWidget extends WidgetType {
 }
 
 function showContextMenu(
-  x: number, y: number,
+  x: number,
+  y: number,
   widget: EditableTableWidget,
   labels: Required<LivePreviewLabels>,
-  rowIdx: number, isHeader: boolean,
-  colIdx: number, colCount: number, rowCount: number,
-  container: HTMLElement
+  rowIdx: number,
+  isHeader: boolean,
+  colIdx: number,
+  colCount: number,
+  _rowCount: number,
+  container: HTMLElement,
 ): void {
   const ownerDocument = container.ownerDocument;
   const ownerWindow = ownerDocument.defaultView;
   const fullscreenEl = ownerDocument.fullscreenElement as HTMLElement | null;
-  const mountTarget: HTMLElement =
-    fullscreenEl && fullscreenEl.contains(container) ? fullscreenEl : ownerDocument.body;
+  const mountTarget: HTMLElement = fullscreenEl?.contains(container)
+    ? fullscreenEl
+    : ownerDocument.body;
   mountTarget.querySelector(".nexus-table-ctx")?.remove();
 
   const menu = ownerDocument.createElement("div");
@@ -1600,16 +1729,13 @@ function showContextMenu(
   const menuText = "var(--nexus-menu-text, var(--nexus-text, #111827))";
   const menuBorder = "var(--nexus-menu-border, var(--nexus-border-subtle, rgba(15,23,42,.14)))";
   const itemHoverBg = "var(--nexus-menu-hover-bg, var(--nexus-bg-muted, rgba(124,108,250,.10)))";
-  const disabledText = "var(--nexus-menu-disabled-text, var(--nexus-text-faint, rgba(17,24,39,.42)))";
+  const disabledText =
+    "var(--nexus-menu-disabled-text, var(--nexus-text-faint, rgba(17,24,39,.42)))";
   menu.className = "nexus-table-ctx";
   menu.setAttribute("role", "menu");
-  menu.style.cssText =
-    `position:fixed;z-index:9999;box-sizing:border-box;display:flex;flex-direction:column;gap:2px;background:${menuBg};` +
-    `color:${menuText};border:1px solid ${menuBorder};border-radius:10px;` +
-    "box-shadow:0 18px 42px rgba(15,23,42,.18);padding:6px;min-width:180px;font-size:13px;line-height:1.4;" +
-    "backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px);";
-  menu.style.left = x + "px";
-  menu.style.top = y + "px";
+  menu.style.cssText = `position:fixed;z-index:9999;box-sizing:border-box;display:flex;flex-direction:column;gap:2px;background:${menuBg};color:${menuText};border:1px solid ${menuBorder};border-radius:10px;box-shadow:0 18px 42px rgba(15,23,42,.18);padding:6px;min-width:180px;font-size:13px;line-height:1.4;backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px);`;
+  menu.style.left = `${x}px`;
+  menu.style.top = `${y}px`;
   menu.addEventListener("contextmenu", (event) => event.preventDefault());
 
   function addItem(label: string, action: () => void, disabled = false): void {
@@ -1626,9 +1752,16 @@ function showContextMenu(
       item.style.color = disabledText;
       item.style.cursor = "default";
     } else {
-      item.addEventListener("mouseenter", () => { item.style.background = itemHoverBg; });
-      item.addEventListener("mouseleave", () => { item.style.background = ""; });
-      item.addEventListener("click", () => { cleanup(); action(); });
+      item.addEventListener("mouseenter", () => {
+        item.style.background = itemHoverBg;
+      });
+      item.addEventListener("mouseleave", () => {
+        item.style.background = "";
+      });
+      item.addEventListener("click", () => {
+        cleanup();
+        action();
+      });
     }
     menu.appendChild(item);
   }
@@ -1647,10 +1780,10 @@ function showContextMenu(
   const rect = menu.getBoundingClientRect();
   const margin = 8;
   if (rect.right > viewportWidth - margin) {
-    menu.style.left = Math.max(margin, x - rect.width) + "px";
+    menu.style.left = `${Math.max(margin, x - rect.width)}px`;
   }
   if (rect.bottom > viewportHeight - margin) {
-    menu.style.top = Math.max(margin, y - rect.height) + "px";
+    menu.style.top = `${Math.max(margin, y - rect.height)}px`;
   }
 
   function cleanup(): void {

--- a/packages/core/src/live-preview.ts
+++ b/packages/core/src/live-preview.ts
@@ -1,14 +1,43 @@
-import { type EditorState, RangeSet, RangeSetBuilder, StateEffect, StateField, type Extension, type Range, type SelectionRange, type Transaction } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView, ViewPlugin, WidgetType } from "@codemirror/view";
 import { ensureSyntaxTree } from "@codemirror/language";
-import type { Code, FootnoteDefinition, FootnoteReference, Heading, Html, List, Root, Table } from "mdast";
+import {
+  type EditorState,
+  type Extension,
+  type Range,
+  RangeSet,
+  RangeSetBuilder,
+  type SelectionRange,
+  StateEffect,
+  StateField,
+  type Transaction,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+} from "@codemirror/view";
+import type {
+  Code,
+  FootnoteDefinition,
+  FootnoteReference,
+  Heading,
+  Html,
+  List,
+  Root,
+  Table,
+} from "mdast";
 
-import type { CodeHighlightToken } from "./types";
 import { lezerStringToMdast, lezerTreeToMdast } from "./lezer-mdast-adapter";
 import { highlightCodeBlock } from "./live-preview-highlight";
+import type { CodeHighlightToken } from "./types";
 
 import { createLivePreviewDiagnostics } from "./live-preview-diag";
-import { collectLivePreviewRanges, selectionIntersects, selectionOnSameLine } from "./live-preview-ranges";
+import {
+  collectLivePreviewRanges,
+  selectionIntersects,
+  selectionOnSameLine,
+} from "./live-preview-ranges";
 import { renderLivePreviewNode } from "./live-preview-renderers";
 import { EditableTableWidget, isTableEditing } from "./live-preview-table";
 import type {
@@ -81,7 +110,7 @@ function walkCodeBlocks(node: unknown, visit: (n: Code) => void): void {
 }
 
 function normalizeConfig(
-  config: boolean | LivePreviewConfig | undefined
+  config: boolean | LivePreviewConfig | undefined,
 ): NormalizedLivePreviewConfig {
   if (!config) {
     return { enabled: false, renderers: {}, labels: DEFAULT_LABELS };
@@ -92,7 +121,7 @@ function normalizeConfig(
   return {
     enabled: config.enabled ?? true,
     renderers: config.renderers ?? {},
-    labels: { ...DEFAULT_LABELS, ...config.labels }
+    labels: { ...DEFAULT_LABELS, ...config.labels },
   };
 }
 
@@ -112,6 +141,7 @@ function createWidget(
     readonly _eqKey = eqKey;
     toDOM(): HTMLElement {
       if (element) return element;
+      // biome-ignore lint/style/noNonNullAssertion: builder is non-null when element is null
       element = builder!();
       return element;
     }
@@ -123,18 +153,31 @@ function createWidget(
       const otherKey = (other as { _eqKey?: string })._eqKey;
       return otherKey === this._eqKey;
     }
-    ignoreEvent() { return swallowEvents; }
+    ignoreEvent() {
+      return swallowEvents;
+    }
     // For block widgets, giving CM6 a pre-measure height prevents the heightmap
     // from assigning 0 and then jumping to the real height on first measure.
     // That jump shifts every click resolution below the widget until remeasured.
-    get estimatedHeight(): number { return heightHint ?? -1; }
+    get estimatedHeight(): number {
+      return heightHint ?? -1;
+    }
   })();
 }
 
 class CodeCopyWidget extends WidgetType {
-  constructor(private readonly code: string, private readonly lang: string) { super(); }
-  eq(other: CodeCopyWidget): boolean { return other.code === this.code && other.lang === this.lang; }
-  ignoreEvent(): boolean { return true; }
+  constructor(
+    private readonly code: string,
+    private readonly lang: string,
+  ) {
+    super();
+  }
+  eq(other: CodeCopyWidget): boolean {
+    return other.code === this.code && other.lang === this.lang;
+  }
+  ignoreEvent(): boolean {
+    return true;
+  }
   toDOM(): HTMLElement {
     // CM6 measures inline widget DOM elements via offsetHeight and uses that to
     // size the line box. A <button> with position:absolute still has a measurable
@@ -170,21 +213,32 @@ class CodeCopyWidget extends WidgetType {
       "opacity:0.7",
       "z-index:1",
       "user-select:none",
-      "transition:opacity .15s"
+      "transition:opacity .15s",
     ].join(";");
-    btn.addEventListener("mouseenter", () => { btn.style.opacity = "1"; });
-    btn.addEventListener("mouseleave", () => { btn.style.opacity = "0.7"; });
-    btn.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+    btn.addEventListener("mouseenter", () => {
+      btn.style.opacity = "1";
+    });
+    btn.addEventListener("mouseleave", () => {
+      btn.style.opacity = "0.7";
+    });
+    btn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
     btn.addEventListener("click", async (e) => {
       e.preventDefault();
       e.stopPropagation();
       try {
         await navigator.clipboard.writeText(this.code);
         btn.textContent = "Copied";
-        setTimeout(() => { btn.textContent = defaultLabel; }, 1200);
+        setTimeout(() => {
+          btn.textContent = defaultLabel;
+        }, 1200);
       } catch {
         btn.textContent = "Failed";
-        setTimeout(() => { btn.textContent = defaultLabel; }, 1200);
+        setTimeout(() => {
+          btn.textContent = defaultLabel;
+        }, 1200);
       }
     });
     wrapper.appendChild(btn);
@@ -199,7 +253,10 @@ class CodeCopyWidget extends WidgetType {
 
 type MermaidAPI = {
   render(id: string, text: string): Promise<{ svg: string }>;
-  parse(text: string, opts?: { suppressErrors?: boolean }): Promise<boolean | { diagramType: string }> | boolean | { diagramType: string };
+  parse(
+    text: string,
+    opts?: { suppressErrors?: boolean },
+  ): Promise<boolean | { diagramType: string }> | boolean | { diagramType: string };
 };
 
 let mermaidPromise: Promise<MermaidAPI> | null = null;
@@ -222,14 +279,18 @@ class MermaidWidget extends WidgetType {
     private readonly source: string,
     private readonly viewRef: { current: EditorView | null },
     private readonly blockFrom: number,
-    private readonly sourceOffsetInBlock: number
-  ) { super(); }
+    private readonly sourceOffsetInBlock: number,
+  ) {
+    super();
+  }
 
   eq(other: MermaidWidget): boolean {
     return other.source === this.source;
   }
 
-  ignoreEvent(): boolean { return true; }
+  ignoreEvent(): boolean {
+    return true;
+  }
 
   get estimatedHeight(): number {
     const cached = MERMAID_CACHE.get(this.source);
@@ -240,7 +301,7 @@ class MermaidWidget extends WidgetType {
     // Container: margin:0, padding for visual spacing (CLAUDE.md rule #11 / thematicBreak pattern).
     const container = document.createElement("div");
     container.className = "nexus-mermaid";
-    container.style.cssText = [
+    container.style.cssText = `${[
       "display:block",
       "position:relative",
       "margin:0",
@@ -250,7 +311,7 @@ class MermaidWidget extends WidgetType {
       "min-height:80px",
       "text-align:center",
       "overflow:hidden",
-    ].join(";") + ";";
+    ].join(";")};`;
 
     // Edit icon — always rendered, always on top. stopPropagation so the
     // click doesn't get swallowed as a widget-surface click.
@@ -259,7 +320,7 @@ class MermaidWidget extends WidgetType {
     editBtn.title = "Edit mermaid source";
     editBtn.setAttribute("aria-label", "Edit mermaid source");
     editBtn.textContent = "✎";
-    editBtn.style.cssText = [
+    editBtn.style.cssText = `${[
       "position:absolute",
       "top:4px",
       "right:8px",
@@ -276,10 +337,17 @@ class MermaidWidget extends WidgetType {
       "z-index:2",
       "user-select:none",
       "transition:opacity .15s",
-    ].join(";") + ";";
-    editBtn.addEventListener("mouseenter", () => { editBtn.style.opacity = "1"; });
-    editBtn.addEventListener("mouseleave", () => { editBtn.style.opacity = "0.7"; });
-    editBtn.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+    ].join(";")};`;
+    editBtn.addEventListener("mouseenter", () => {
+      editBtn.style.opacity = "1";
+    });
+    editBtn.addEventListener("mouseleave", () => {
+      editBtn.style.opacity = "0.7";
+    });
+    editBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
     editBtn.addEventListener("click", (e) => {
       e.preventDefault();
       e.stopPropagation();
@@ -345,12 +413,17 @@ class MermaidWidget extends WidgetType {
       body.style.cssText = "white-space:pre-wrap;";
 
       const hint = document.createElement("div");
-      hint.style.cssText = "margin-top:8px;font-family:system-ui,sans-serif;color:var(--nexus-text-muted);";
+      hint.style.cssText =
+        "margin-top:8px;font-family:system-ui,sans-serif;color:var(--nexus-text-muted);";
       const editLink = document.createElement("a");
       editLink.href = "#";
       editLink.textContent = "Edit source";
-      editLink.style.cssText = "color:var(--nexus-accent);text-decoration:underline;cursor:pointer;";
-      editLink.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+      editLink.style.cssText =
+        "color:var(--nexus-accent);text-decoration:underline;cursor:pointer;";
+      editLink.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
       editLink.addEventListener("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -376,7 +449,7 @@ class MermaidWidget extends WidgetType {
     const cleanupOrphans = (usedId: string) => {
       const orphan = document.getElementById(usedId);
       if (orphan && orphan.parentElement === document.body) orphan.remove();
-      const dOrphan = document.getElementById("d" + usedId);
+      const dOrphan = document.getElementById(`d${usedId}`);
       if (dOrphan && dOrphan.parentElement === document.body) dOrphan.remove();
     };
 
@@ -421,7 +494,12 @@ class MermaidWidget extends WidgetType {
 const BLOCK_NODE_TYPES = new Set(["thematicBreak"]);
 
 const HEADING_FONT_SIZE: Record<number, string> = {
-  1: "1.6em", 2: "1.4em", 3: "1.2em", 4: "1.1em", 5: "1.05em", 6: "1em"
+  1: "1.6em",
+  2: "1.4em",
+  3: "1.2em",
+  4: "1.1em",
+  5: "1.05em",
+  6: "1em",
 };
 
 function shouldRebuildHeadingForCompositionStart(view: EditorView): boolean {
@@ -435,7 +513,7 @@ function buildHeadingDecorations(
   doc: string,
   selection: readonly SelectionRange[],
   decos: Range<Decoration>[],
-  compositionActive: boolean
+  compositionActive: boolean,
 ): void {
   const firstChild = range.node.children[0];
   const textStart = firstChild?.position?.start?.offset;
@@ -450,8 +528,10 @@ function buildHeadingDecorations(
     if (cursorOnHeading) {
       decos.push(
         Decoration.mark({
-          attributes: { style: `font-weight: bold; font-size: ${fontSize}; color: var(--nexus-text-muted)` }
-        }).range(range.from, textStart)
+          attributes: {
+            style: `font-weight: bold; font-size: ${fontSize}; color: var(--nexus-text-muted)`,
+          },
+        }).range(range.from, textStart),
       );
     } else {
       decos.push(Decoration.replace({}).range(range.from, textStart));
@@ -463,9 +543,9 @@ function buildHeadingDecorations(
           style: `font-weight: bold; font-size: ${fontSize}`,
           "data-heading-level": String(range.node.depth),
           role: "heading",
-          "aria-level": String(range.node.depth)
-        }
-      }).range(textStart, range.to)
+          "aria-level": String(range.node.depth),
+        },
+      }).range(textStart, range.to),
     );
   }
 }
@@ -478,7 +558,7 @@ function buildListDecorations(
   doc: string,
   selection: readonly SelectionRange[],
   decos: Range<Decoration>[],
-  viewRef: { current: EditorView | null }
+  viewRef: { current: EditorView | null },
 ): void {
   // Iterate ListItems via mdast structure (not regex over flat source lines).
   // Nested sub-lists are children of a ListItem, not of the outer list, so
@@ -527,7 +607,7 @@ function buildListDecorations(
     decos.push(
       Decoration.replace({
         widget: createWidget(bullet, false, undefined, bulletKey),
-      }).range(markerStart, markerEnd)
+      }).range(markerStart, markerEnd),
     );
 
     const afterMarker = headLine.slice(markerMatch[0].length);
@@ -547,13 +627,15 @@ function buildListDecorations(
       const toggleFrom = checkStart + 1;
       // mousedown 先于 click：阻止 CM6 在 widget 上启动选区拖拽 / 移动光标，
       // 否则点击会被解读成"把光标放到该行"而非切换复选框。
-      checkbox.addEventListener("mousedown", (e) => { e.preventDefault(); });
+      checkbox.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+      });
       checkbox.addEventListener("click", (e) => {
         e.preventDefault();
         const v = viewRef.current;
         if (!v) return;
         v.dispatch({
-          changes: { from: toggleFrom, to: toggleFrom + 1, insert: isChecked ? " " : "x" }
+          changes: { from: toggleFrom, to: toggleFrom + 1, insert: isChecked ? " " : "x" },
         });
       });
 
@@ -563,14 +645,14 @@ function buildListDecorations(
           // swallowEvents=true → ignoreEvent() 返回 true，CM6 不再抢占点击，
           // 复选框自身的 click 处理器得以触发完成切换。
           widget: createWidget(checkbox, true, undefined, taskKey),
-        }).range(checkStart, checkEnd)
+        }).range(checkStart, checkEnd),
       );
 
       if (isChecked && checkEnd < headLineEnd) {
         decos.push(
           Decoration.mark({
-            attributes: { style: "text-decoration: line-through; color: var(--nexus-text-muted)" }
-          }).range(checkEnd, headLineEnd)
+            attributes: { style: "text-decoration: line-through; color: var(--nexus-text-muted)" },
+          }).range(checkEnd, headLineEnd),
         );
       }
     }
@@ -594,7 +676,7 @@ function defaultSanitizeHtml(rawHtml: string): string {
   // Strip inline event handlers: `onclick="…"` / `onload='…'` / onfoo=bareword.
   html = html.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "");
   // Strip `javascript:` URLs in href / src attributes.
-  html = html.replace(/(href|src|xlink:href)\s*=\s*(['"])\s*javascript:[^'"]*\2/gi, '$1=$2#$2');
+  html = html.replace(/(href|src|xlink:href)\s*=\s*(['"])\s*javascript:[^'"]*\2/gi, "$1=$2#$2");
   return html;
 }
 
@@ -603,7 +685,7 @@ function buildHtmlDecorations(
   selection: readonly SelectionRange[],
   decos: Range<Decoration>[],
   config: NormalizedLivePreviewConfig,
-  viewRef: { current: EditorView | null }
+  viewRef: { current: EditorView | null },
 ): void {
   // Show raw source while the user is editing the block — same pattern as
   // mermaid / code blocks. `inclusiveEnd: true` so the cursor parked at the
@@ -632,7 +714,8 @@ function buildHtmlDecorations(
   if (!inner) {
     inner = document.createElement("div");
     inner.className = "nexus-html-block-content";
-    inner.style.cssText = "display:block;margin:0;padding:0;line-height:normal;font-family:inherit;";
+    inner.style.cssText =
+      "display:block;margin:0;padding:0;line-height:normal;font-family:inherit;";
     inner.innerHTML = defaultSanitizeHtml(range.node.value ?? range.source);
   }
 
@@ -660,7 +743,7 @@ function buildHtmlDecorations(
   // hence why the early-return uses mousedown rather than click.
   wrapper.addEventListener("mousedown", (event) => {
     const target = event.target as HTMLElement | null;
-    if (target && target.closest(INTERACTIVE_SELECTOR)) {
+    if (target?.closest(INTERACTIVE_SELECTOR)) {
       // Let the native click/toggle/link/focus happen.
       return;
     }
@@ -683,7 +766,7 @@ function buildHtmlDecorations(
     Decoration.replace({
       widget: createWidget(wrapper, true, heightHint, htmlKey),
       block: true,
-    }).range(range.from, range.to)
+    }).range(range.from, range.to),
   );
 }
 
@@ -701,11 +784,41 @@ interface AlertStyle {
 }
 
 const ALERT_STYLES: Record<AlertType, AlertStyle> = {
-  NOTE: { borderColor: "#0969da", bg: "rgba(9,105,218,0.08)", textColor: "#0969da", icon: "ℹ", label: "Note" },
-  TIP: { borderColor: "#1a7f37", bg: "rgba(26,127,55,0.08)", textColor: "#1a7f37", icon: "💡", label: "Tip" },
-  IMPORTANT: { borderColor: "#8250df", bg: "rgba(130,80,223,0.08)", textColor: "#8250df", icon: "❗", label: "Important" },
-  WARNING: { borderColor: "#9a6700", bg: "rgba(154,103,0,0.08)", textColor: "#9a6700", icon: "⚠", label: "Warning" },
-  CAUTION: { borderColor: "#cf222e", bg: "rgba(207,34,46,0.08)", textColor: "#cf222e", icon: "🚫", label: "Caution" },
+  NOTE: {
+    borderColor: "#0969da",
+    bg: "rgba(9,105,218,0.08)",
+    textColor: "#0969da",
+    icon: "ℹ",
+    label: "Note",
+  },
+  TIP: {
+    borderColor: "#1a7f37",
+    bg: "rgba(26,127,55,0.08)",
+    textColor: "#1a7f37",
+    icon: "💡",
+    label: "Tip",
+  },
+  IMPORTANT: {
+    borderColor: "#8250df",
+    bg: "rgba(130,80,223,0.08)",
+    textColor: "#8250df",
+    icon: "❗",
+    label: "Important",
+  },
+  WARNING: {
+    borderColor: "#9a6700",
+    bg: "rgba(154,103,0,0.08)",
+    textColor: "#9a6700",
+    icon: "⚠",
+    label: "Warning",
+  },
+  CAUTION: {
+    borderColor: "#cf222e",
+    bg: "rgba(207,34,46,0.08)",
+    textColor: "#cf222e",
+    icon: "🚫",
+    label: "Caution",
+  },
 };
 
 /**
@@ -748,7 +861,7 @@ function detectAlert(source: string): {
 function buildBlockquoteDecorations(
   range: { from: number; to: number; source: string },
   selection: readonly SelectionRange[],
-  decos: Range<Decoration>[]
+  decos: Range<Decoration>[],
 ): { alertHeadEnd: number } | null {
   const source = range.source;
   const lines = source.split("\n");
@@ -762,13 +875,7 @@ function buildBlockquoteDecorations(
     if (style) {
       const radiusTop = i === 0 ? "6px 6px" : "0 0";
       const radiusBottom = i === lines.length - 1 ? "6px 6px" : "0 0";
-      return (
-        `color:var(--nexus-text);` +
-        `border-left:4px solid ${style.borderColor};` +
-        `background:${style.bg};` +
-        `padding:2px 12px;` +
-        `border-radius:${radiusTop} ${radiusBottom};`
-      );
+      return `color:var(--nexus-text);border-left:4px solid ${style.borderColor};background:${style.bg};padding:2px 12px;border-radius:${radiusTop} ${radiusBottom};`;
     }
     return (
       "color:var(--nexus-text-muted);" +
@@ -782,9 +889,7 @@ function buildBlockquoteDecorations(
     const lineStart = offset;
     const lineEnd = offset + line.length;
 
-    decos.push(
-      Decoration.line({ attributes: { style: lineStyleFor(i) } }).range(lineStart)
-    );
+    decos.push(Decoration.line({ attributes: { style: lineStyleFor(i) } }).range(lineStart));
 
     const markerMatch = BLOCKQUOTE_MARKER_RE.exec(line);
     if (!cursorInBlockquote && markerMatch) {
@@ -800,9 +905,7 @@ function buildBlockquoteDecorations(
         if (tagEnd > tagStart) {
           const badge = document.createElement("span");
           badge.className = "nexus-alert-label";
-          badge.style.cssText =
-            `display:inline-flex;align-items:center;gap:6px;` +
-            `color:${style.textColor};font-weight:600;font-size:0.95em;`;
+          badge.style.cssText = `display:inline-flex;align-items:center;gap:6px;color:${style.textColor};font-weight:600;font-size:0.95em;`;
           const iconSpan = document.createElement("span");
           iconSpan.textContent = style.icon;
           iconSpan.setAttribute("aria-hidden", "true");
@@ -813,7 +916,7 @@ function buildBlockquoteDecorations(
           decos.push(
             Decoration.replace({
               widget: createWidget(badge, false, undefined, `alert:${alert.type}:${tagStart}`),
-            }).range(tagStart, tagEnd)
+            }).range(tagStart, tagEnd),
           );
           alertHeadEnd = lineEnd;
         }
@@ -836,7 +939,7 @@ function buildCodeBlockDecorations(
   selection: readonly SelectionRange[],
   decos: Range<Decoration>[],
   viewRef: { current: EditorView | null },
-  codeTokens?: readonly import("./types").CodeHighlightToken[]
+  codeTokens?: readonly import("./types").CodeHighlightToken[],
 ): void {
   const source = range.source;
   const lines = source.split("\n");
@@ -852,7 +955,7 @@ function buildCodeBlockDecorations(
       Decoration.replace({
         widget: new MermaidWidget(range.node.value ?? "", viewRef, range.from, firstNewline + 1),
         block: true,
-      }).range(range.from, range.to)
+      }).range(range.from, range.to),
     );
     return;
   }
@@ -884,7 +987,11 @@ function buildCodeBlockDecorations(
 
     // Line decoration: ONLY background + border-radius (no font changes).
     // position:relative on first fence line anchors the absolute copy button.
-    const radius = isFirstLine ? "border-radius:4px 4px 0 0;" : isLastLine ? "border-radius:0 0 4px 4px;" : "";
+    const radius = isFirstLine
+      ? "border-radius:4px 4px 0 0;"
+      : isLastLine
+        ? "border-radius:0 0 4px 4px;"
+        : "";
     const firstLineExtra = isFirstLine && isFenced ? "position:relative;" : "";
     const lineAttrs: Record<string, string> = { style: LINE_BG + radius + firstLineExtra };
     if (isFirstLine) {
@@ -895,20 +1002,26 @@ function buildCodeBlockDecorations(
 
     // Fence lines: transparent + monospace via mark; visible when cursor in block.
     if (isFenced && (isFirstLine || isLastLine) && lineEnd > lineStart) {
-      decos.push(Decoration.mark({
-        attributes: {
-          style: MONO_MARK + (cursorOnCode
-            ? "color:var(--nexus-text-faint,#bbb);"
-            : "color:transparent;cursor:text;")
-        }
-      }).range(lineStart, lineEnd));
+      decos.push(
+        Decoration.mark({
+          attributes: {
+            style:
+              MONO_MARK +
+              (cursorOnCode
+                ? "color:var(--nexus-text-faint,#bbb);"
+                : "color:transparent;cursor:text;"),
+          },
+        }).range(lineStart, lineEnd),
+      );
     }
 
     // Content lines (non-fence): monospace via mark.
     if (!(isFenced && (isFirstLine || isLastLine)) && lineEnd > lineStart) {
-      decos.push(Decoration.mark({
-        attributes: { style: MONO_MARK }
-      }).range(lineStart, lineEnd));
+      decos.push(
+        Decoration.mark({
+          attributes: { style: MONO_MARK },
+        }).range(lineStart, lineEnd),
+      );
     }
 
     // Copy button: always present, absolute-positioned inside first fence line.
@@ -916,8 +1029,8 @@ function buildCodeBlockDecorations(
       decos.push(
         Decoration.widget({
           widget: new CodeCopyWidget(codeValue, lang ?? ""),
-          side: 1
-        }).range(lineEnd)
+          side: 1,
+        }).range(lineEnd),
       );
     }
 
@@ -939,9 +1052,7 @@ function buildCodeBlockDecorations(
       if (tok.from >= contentEnd) break;
       if (tok.to <= contentStart) continue;
       if (tok.from < range.from || tok.to > range.to) continue;
-      decos.push(
-        Decoration.mark({ class: tok.className }).range(tok.from, tok.to)
-      );
+      decos.push(Decoration.mark({ class: tok.className }).range(tok.from, tok.to));
     }
   }
 }
@@ -969,8 +1080,10 @@ function getInlineMarkerStyle(nodeType: string, source: string): InlineMarkerSty
       let ticks = 0;
       for (let i = 0; i < source.length && source[i] === "`"; i++) ticks++;
       return {
-        openLen: ticks, closeLen: ticks,
-        style: "font-family:monospace;background:var(--nexus-bg-muted);padding:1px 4px;border-radius:3px"
+        openLen: ticks,
+        closeLen: ticks,
+        style:
+          "font-family:monospace;background:var(--nexus-bg-muted);padding:1px 4px;border-radius:3px",
       };
     }
     case "link": {
@@ -979,25 +1092,27 @@ function getInlineMarkerStyle(nodeType: string, source: string): InlineMarkerSty
       if (bracketClose >= 0) {
         const url = source.slice(bracketClose + 2, source.length - 1);
         return {
-          openLen: 1,                            // hide [
+          openLen: 1, // hide [
           closeLen: source.length - bracketClose, // hide ](url)
           style: "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
-          attrs: { "data-link-url": url }
+          attrs: { "data-link-url": url },
         };
       }
       // Standard autolink: <URL> — hide angle brackets
       if (source.startsWith("<") && source.endsWith(">")) {
         return {
-          openLen: 1, closeLen: 1,
+          openLen: 1,
+          closeLen: 1,
           style: "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
-          attrs: { "data-link-url": source.slice(1, -1) }
+          attrs: { "data-link-url": source.slice(1, -1) },
         };
       }
       // GFM autolink literal: bare URL, no markers to hide
       return {
-        openLen: 0, closeLen: 0,
+        openLen: 0,
+        closeLen: 0,
         style: "color:var(--nexus-accent);text-decoration:underline;cursor:pointer",
-        attrs: { "data-link-url": source }
+        attrs: { "data-link-url": source },
       };
     }
     default:
@@ -1018,9 +1133,10 @@ function buildDecorations(
   selection: readonly SelectionRange[],
   config: NormalizedLivePreviewConfig,
   viewRef: { current: EditorView | null },
-  ctx: BuildContext
+  ctx: BuildContext,
 ): { decos: DecorationSet; ast: Root; codeTokens: CodeHighlightToken[] } {
-  if (!config.enabled) return { decos: Decoration.none, ast: ctx.ast ?? createEmptyAst(), codeTokens: [] };
+  if (!config.enabled)
+    return { decos: Decoration.none, ast: ctx.ast ?? createEmptyAst(), codeTokens: [] };
 
   const perfEnabled = (globalThis as { NEXUS_PERF?: boolean }).NEXUS_PERF !== false;
   const t0 = perfEnabled ? performance.now() : 0;
@@ -1034,7 +1150,6 @@ function buildDecorations(
   // Highlight tokens are computed ON DEMAND but cached: identical (lang, code)
   // pairs hit the LRU in highlightCodeBlock so cursor moves don't re-tokenize.
   const codeTokens = ctx.codeTokens ?? highlightAllCodeBlocks(ast, doc);
-  const t1b = perfEnabled ? performance.now() : 0;
   const ranges = collectLivePreviewRanges(ast, doc, selection);
   const t2 = perfEnabled ? performance.now() : 0;
   const astHit = !!ctx.ast;
@@ -1050,16 +1165,20 @@ function buildDecorations(
         doc,
         selection,
         decos,
-        ctx.compositionActive === true
+        ctx.compositionActive === true,
       );
     } else if (range.node.type === "table" && !config.renderers.table) {
       decos.push(
         Decoration.replace({
           widget: new EditableTableWidget(
-            range.node as Table, range.from, range.source, viewRef, config.labels
+            range.node as Table,
+            range.from,
+            range.source,
+            viewRef,
+            config.labels,
           ),
-          block: true
-        }).range(range.from, range.to)
+          block: true,
+        }).range(range.from, range.to),
       );
     } else if (range.node.type === "html") {
       buildHtmlDecorations(
@@ -1067,15 +1186,21 @@ function buildDecorations(
         selection,
         decos,
         config,
-        viewRef
+        viewRef,
       );
     } else if (range.node.type === "list") {
-      buildListDecorations(range as { from: number; to: number; node: List }, doc, selection, decos, viewRef);
+      buildListDecorations(
+        range as { from: number; to: number; node: List },
+        doc,
+        selection,
+        decos,
+        viewRef,
+      );
     } else if (range.node.type === "blockquote") {
       const alertInfo = buildBlockquoteDecorations(
         range as { from: number; to: number; source: string },
         selection,
-        decos
+        decos,
       );
       if (alertInfo) {
         // GFM Alert: suppress the inline link decoration that lezer emits for
@@ -1085,7 +1210,13 @@ function buildDecorations(
         parentSpans.push([range.from, alertInfo.alertHeadEnd]);
       }
     } else if (range.node.type === "code" && !config.renderers.code) {
-      buildCodeBlockDecorations(range as { from: number; to: number; node: Code; source: string }, selection, decos, viewRef, codeTokens);
+      buildCodeBlockDecorations(
+        range as { from: number; to: number; node: Code; source: string },
+        selection,
+        decos,
+        viewRef,
+        codeTokens,
+      );
     } else if (range.node.type === "image") {
       // Cursor-aware + preview-alongside:
       //   * cursor OUT  → replace widget (source hidden).
@@ -1106,8 +1237,8 @@ function buildDecorations(
       if (!cursorOnImage) {
         decos.push(
           Decoration.replace({
-            widget: createWidget(buildImg, true, undefined, imgKey)
-          }).range(range.from, range.to)
+            widget: createWidget(buildImg, true, undefined, imgKey),
+          }).range(range.from, range.to),
         );
       } else {
         // Edit mode: keep source text visible; also render the image below.
@@ -1116,7 +1247,7 @@ function buildDecorations(
             widget: createWidget(buildImg, true, undefined, imgKey),
             block: true,
             side: 1,
-          }).range(range.to)
+          }).range(range.to),
         );
       }
     } else if (range.node.type === "link" && !config.renderers.link) {
@@ -1132,9 +1263,13 @@ function buildDecorations(
         const linkText = range.source.slice(openLen, range.source.length - closeLen);
         const span = document.createElement("span");
         span.textContent = linkText;
-        span.style.cssText = style + ";transition:opacity .15s;";
-        span.addEventListener("mouseenter", () => { span.style.opacity = "0.7"; });
-        span.addEventListener("mouseleave", () => { span.style.opacity = "1"; });
+        span.style.cssText = `${style};transition:opacity .15s;`;
+        span.addEventListener("mouseenter", () => {
+          span.style.opacity = "0.7";
+        });
+        span.addEventListener("mouseleave", () => {
+          span.style.opacity = "1";
+        });
         if (attrs) {
           for (const [k, v] of Object.entries(attrs)) span.setAttribute(k, v);
         }
@@ -1142,7 +1277,7 @@ function buildDecorations(
         decos.push(
           Decoration.replace({
             widget: createWidget(span, false, undefined, linkKey),
-          }).range(range.from, range.to)
+          }).range(range.from, range.to),
         );
       }
     } else if (range.node.type === "definition") {
@@ -1151,39 +1286,45 @@ function buildDecorations(
       // was the single biggest click-drift source. Heights must stay constant regardless
       // of cursor to keep CM6's measurement cache and click-position resolution stable.
       decos.push(
-        Decoration.mark({ attributes: { style: "color:var(--nexus-text-faint)" } })
-          .range(range.from, range.to)
+        Decoration.mark({ attributes: { style: "color:var(--nexus-text-faint)" } }).range(
+          range.from,
+          range.to,
+        ),
       );
     } else if (range.node.type === "footnoteReference") {
       const ref = range.node as FootnoteReference;
       const sup = document.createElement("sup");
       sup.textContent = ref.identifier;
-      sup.style.cssText = "color:var(--nexus-accent);cursor:pointer;font-size:0.8em;vertical-align:super;";
+      sup.style.cssText =
+        "color:var(--nexus-accent);cursor:pointer;font-size:0.8em;vertical-align:super;";
       const fnRefKey = `fnref:${range.from}-${range.to}:${ref.identifier}`;
       decos.push(
         Decoration.replace({
           widget: createWidget(sup, false, undefined, fnRefKey),
-        }).range(range.from, range.to)
+        }).range(range.from, range.to),
       );
     } else if (range.node.type === "footnoteDefinition") {
       const def = range.node as FootnoteDefinition;
       const defText = range.source.replace(/^\[\^\w+\]:\s*/, "");
       const el = document.createElement("div");
-      el.style.cssText = "font-size:0.85em;color:var(--nexus-text-muted);border-top:1px solid var(--nexus-border);padding-top:8px;";
+      el.style.cssText =
+        "font-size:0.85em;color:var(--nexus-text-muted);border-top:1px solid var(--nexus-border);padding-top:8px;";
       const marker = document.createElement("sup");
       marker.textContent = def.identifier;
       marker.style.cssText = "color:var(--nexus-accent);margin-right:4px;";
       el.appendChild(marker);
       el.appendChild(document.createTextNode(defText));
       // Use line decoration + widget for stable viewport height
-      decos.push(Decoration.line({
-        attributes: { style: "padding:0;margin:0;min-height:0;" }
-      }).range(range.from));
+      decos.push(
+        Decoration.line({
+          attributes: { style: "padding:0;margin:0;min-height:0;" },
+        }).range(range.from),
+      );
       const fnDefKey = `fndef:${range.from}-${range.to}:${def.identifier}:${range.source}`;
       decos.push(
         Decoration.replace({
           widget: createWidget(el, false, undefined, fnDefKey),
-        }).range(range.from, range.to)
+        }).range(range.from, range.to),
       );
     } else {
       if (range.node.type === "heading" || range.node.type === "table") {
@@ -1233,13 +1374,20 @@ function buildDecorations(
         decos.push(
           Decoration.replace({
             widget: createWidget(
-              () => renderLivePreviewNode(range.node, range.source, config.renderers, range.from, range.to),
+              () =>
+                renderLivePreviewNode(
+                  range.node,
+                  range.source,
+                  config.renderers,
+                  range.from,
+                  range.to,
+                ),
               isBlock,
               heightHint,
               blockKey,
             ),
-            block: isBlock
-          }).range(range.from, range.to)
+            block: isBlock,
+          }).range(range.from, range.to),
         );
       }
     }
@@ -1257,7 +1405,8 @@ function buildDecorations(
     if (total > 5 || parseMs > 2) {
       // eslint-disable-next-line no-console
       console.log(
-        "%c[perf]", "color:#0aa;font-weight:bold",
+        "%c[perf]",
+        "color:#0aa;font-weight:bold",
         "buildDecorations",
         `total=${total.toFixed(1)}ms`,
         {
@@ -1277,7 +1426,7 @@ function buildDecorations(
 
 export function createLivePreviewExtension(
   config: boolean | LivePreviewConfig | undefined,
-  localeLabels?: LivePreviewLabels
+  localeLabels?: LivePreviewLabels,
 ): Extension[] {
   const normalized = normalizeConfig(config);
   if (!normalized.enabled) return [];
@@ -1297,11 +1446,16 @@ export function createLivePreviewExtension(
   const rebuildForCompositionStart = StateEffect.define<null>();
   const rebuildAfterComposition = StateEffect.define<null>();
 
-  function build(state: EditorState, selection: readonly SelectionRange[], reuseCache: boolean): DecorationSet {
+  function build(
+    state: EditorState,
+    selection: readonly SelectionRange[],
+    reuseCache: boolean,
+  ): DecorationSet {
     const docStr = state.doc.toString();
-    const ctx: BuildContext = reuseCache && lastBuilt && lastBuilt.doc === docStr
-      ? { ast: lastBuilt.ast, codeTokens: lastBuilt.codeTokens }
-      : {};
+    const ctx: BuildContext =
+      reuseCache && lastBuilt && lastBuilt.doc === docStr
+        ? { ast: lastBuilt.ast, codeTokens: lastBuilt.codeTokens }
+        : {};
     try {
       const out = buildDecorations(state, selection, normalized, viewRef, {
         ...ctx,
@@ -1314,7 +1468,10 @@ export function createLivePreviewExtension(
       // markdown"（仍可编辑），并缓存空 AST，避免后续 selection-only 重建反复抛同样的错。
       // 文档再次变更（docChanged，reuseCache=false）会重新尝试完整构建并自动恢复。
       // eslint-disable-next-line no-console
-      console.error("[NexusEditor] live-preview build failed; rendering raw markdown for this view", err);
+      console.error(
+        "[NexusEditor] live-preview build failed; rendering raw markdown for this view",
+        err,
+      );
       lastBuilt = { doc: docStr, ast: createEmptyAst(), codeTokens: [] };
       return Decoration.none;
     }
@@ -1358,7 +1515,7 @@ export function createLivePreviewExtension(
     },
     provide(field) {
       return EditorView.decorations.from(field);
-    }
+    },
   });
 
   const viewCapture = ViewPlugin.fromClass(
@@ -1374,7 +1531,7 @@ export function createLivePreviewExtension(
       destroy(): void {
         if (viewRef.current === this.view) viewRef.current = null;
       }
-    }
+    },
   );
 
   const compositionHandler = EditorView.domEventHandlers({
@@ -1420,8 +1577,10 @@ export function createLivePreviewExtension(
         const doc = view.state.doc.toString();
         const headingRe = /^(#{1,6})\s+(.+)$/gm;
         let m: RegExpExecArray | null;
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard RegExp loop idiom
         while ((m = headingRe.exec(doc)) !== null) {
-          const headingSlug = m[2].trim()
+          const headingSlug = m[2]
+            .trim()
             .toLowerCase()
             .replace(/[^\p{L}\p{N}\s-]/gu, "")
             .trim()
@@ -1431,7 +1590,7 @@ export function createLivePreviewExtension(
           if (headingSlug === targetSlug) {
             view.dispatch({
               selection: { anchor: m.index },
-              effects: EditorView.scrollIntoView(m.index, { y: "start", yMargin: 20 })
+              effects: EditorView.scrollIntoView(m.index, { y: "start", yMargin: 20 }),
             });
             view.focus();
             return true;
@@ -1443,7 +1602,7 @@ export function createLivePreviewExtension(
       // External links: open in new tab
       window.open(url, "_blank", "noopener");
       return true;
-    }
+    },
   });
 
   // 表格被渲染成 block replace widget（整段源码折叠成一个不可逐字进入的部件），
@@ -1467,5 +1626,12 @@ export function createLivePreviewExtension(
     return builder.finish();
   });
 
-  return [field, viewCapture, compositionHandler, linkHandler, tableAtomicRanges, createLivePreviewDiagnostics()];
+  return [
+    field,
+    viewCapture,
+    compositionHandler,
+    linkHandler,
+    tableAtomicRanges,
+    createLivePreviewDiagnostics(),
+  ];
 }

--- a/packages/core/src/markdown-autopair.ts
+++ b/packages/core/src/markdown-autopair.ts
@@ -3,7 +3,7 @@
  * When the user types **, *, ~~, or ` with a selection, it wraps the selection.
  * When typed without selection, it inserts a matching pair and places the cursor between.
  */
-import { type Extension } from "@codemirror/state";
+import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 
 const PAIRS: Array<{ trigger: string; open: string; close: string }> = [
@@ -31,7 +31,10 @@ export function markdownAutoPair(): Extension {
         const selected = view.state.sliceDoc(sel.from, sel.to);
         view.dispatch({
           changes: { from: sel.from, to: sel.to, insert: pair.open + selected + pair.close },
-          selection: { anchor: sel.from + pair.open.length, head: sel.from + pair.open.length + selected.length },
+          selection: {
+            anchor: sel.from + pair.open.length,
+            head: sel.from + pair.open.length + selected.length,
+          },
         });
         return true;
       }
@@ -58,7 +61,11 @@ export function markdownAutoPair(): Extension {
         view.dispatch({
           changes: [
             { from: from - 1, to: from, insert: "" }, // remove the first char
-            { from: sel.from, to: sel.to, insert: pair.open + view.state.sliceDoc(sel.from, sel.to) + pair.close },
+            {
+              from: sel.from,
+              to: sel.to,
+              insert: pair.open + view.state.sliceDoc(sel.from, sel.to) + pair.close,
+            },
           ],
         });
         return true;

--- a/packages/core/src/markdown-fold.ts
+++ b/packages/core/src/markdown-fold.ts
@@ -1,5 +1,5 @@
-import { type Extension } from "@codemirror/state";
 import { foldGutter, foldService } from "@codemirror/language";
+import type { Extension } from "@codemirror/state";
 
 const HEADING_RE = /^(#{1,6}) /;
 const FENCE_OPEN_RE = /^[ \t]*(`{3,}|~{3,})/;
@@ -13,7 +13,7 @@ const INDENT_RE = /^([ \t]*)/;
  * - Fenced code blocks fold from the opening fence to the closing fence.
  */
 export function markdownFoldService(): Extension {
-  return foldService.of((state, lineStart, lineEnd) => {
+  return foldService.of((state, lineStart, _lineEnd) => {
     const line = state.doc.lineAt(lineStart);
     const text = line.text;
 
@@ -47,7 +47,10 @@ export function markdownFoldService(): Extension {
       for (let i = line.number + 1; i <= state.doc.lines; i++) {
         const nextLine = state.doc.line(i);
         const trimmed = nextLine.text.trimStart();
-        if (trimmed.startsWith(fenceChar.repeat(fenceLen)) && trimmed.trim().length <= fenceLen + 1) {
+        if (
+          trimmed.startsWith(fenceChar.repeat(fenceLen)) &&
+          trimmed.trim().length <= fenceLen + 1
+        ) {
           return { from: line.to, to: nextLine.to };
         }
       }
@@ -83,8 +86,5 @@ export function markdownFoldService(): Extension {
 
 /** Fold gutter + fold service for markdown documents. */
 export function markdownFold(): Extension {
-  return [
-    markdownFoldService(),
-    foldGutter()
-  ];
+  return [markdownFoldService(), foldGutter()];
 }

--- a/packages/core/src/markdown-keymap.ts
+++ b/packages/core/src/markdown-keymap.ts
@@ -1,4 +1,4 @@
-import { Prec, type Extension } from "@codemirror/state";
+import { type Extension, Prec } from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 
 const LIST_RE = /^(\s*)([-*+]|\d+[.)]) /;
@@ -29,7 +29,7 @@ export function handleMarkdownEnter(view: EditorView): boolean {
     if (!content.trim()) {
       view.dispatch({
         changes: { from: line.from, to: line.to, insert: "" },
-        selection: { anchor: line.from }
+        selection: { anchor: line.from },
       });
       return true;
     }
@@ -38,16 +38,14 @@ export function handleMarkdownEnter(view: EditorView): boolean {
     let nextMarker = marker;
     const numMatch = marker.match(/^(\d+)([.)])/);
     if (numMatch) {
-      nextMarker = `${parseInt(numMatch[1]) + 1}${numMatch[2]}`;
+      nextMarker = `${Number.parseInt(numMatch[1]) + 1}${numMatch[2]}`;
     }
 
-    const newPrefix = cbMatch
-      ? `${indent}${nextMarker} [ ] `
-      : `${indent}${nextMarker} `;
+    const newPrefix = cbMatch ? `${indent}${nextMarker} [ ] ` : `${indent}${nextMarker} `;
 
     view.dispatch({
-      changes: { from: sel.head, insert: "\n" + newPrefix },
-      selection: { anchor: sel.head + 1 + newPrefix.length }
+      changes: { from: sel.head, insert: `\n${newPrefix}` },
+      selection: { anchor: sel.head + 1 + newPrefix.length },
     });
     return true;
   }
@@ -62,14 +60,14 @@ export function handleMarkdownEnter(view: EditorView): boolean {
     if (!content.trim()) {
       view.dispatch({
         changes: { from: line.from, to: line.to, insert: "" },
-        selection: { anchor: line.from }
+        selection: { anchor: line.from },
       });
       return true;
     }
 
     view.dispatch({
-      changes: { from: sel.head, insert: "\n" + prefix },
-      selection: { anchor: sel.head + 1 + prefix.length }
+      changes: { from: sel.head, insert: `\n${prefix}` },
+      selection: { anchor: sel.head + 1 + prefix.length },
     });
     return true;
   }

--- a/packages/core/src/slash-state.ts
+++ b/packages/core/src/slash-state.ts
@@ -29,7 +29,7 @@ const DEFAULT_LIMIT = 8;
 // Keep the gaps wide enough that the tiebreaker can never bridge two
 // adjacent tiers (max tiebreaker offset is bounded by title length, in
 // practice < 100, so a gap of 1000 is safe).
-const SCORE_EMPTY_PRESERVE_ORDER = 0;
+const _SCORE_EMPTY_PRESERVE_ORDER = 0;
 const SCORE_TITLE_EXACT = 6000;
 const SCORE_TITLE_PREFIX = 5000;
 const SCORE_KEYWORD_EXACT = 4000;
@@ -69,11 +69,7 @@ interface ScoredCommand {
   index: number;
 }
 
-function scoreCommand(
-  cmd: SlashCommandDef,
-  query: string,
-  index: number
-): ScoredCommand | null {
+function scoreCommand(cmd: SlashCommandDef, query: string, index: number): ScoredCommand | null {
   const title = cmd.title.toLowerCase();
 
   if (title === query) {
@@ -115,10 +111,7 @@ function scoreCommand(
   return null;
 }
 
-export function filterSlashCommands(
-  commands: SlashCommandDef[],
-  query: string
-): SlashCommandDef[] {
+export function filterSlashCommands(commands: SlashCommandDef[], query: string): SlashCommandDef[] {
   if (query === "") {
     // Empty query is the "menu just opened" case — keep the registration
     // order so the host can choose a "frequently used first" layout via
@@ -154,7 +147,7 @@ export function computeSlashState(
   doc: string,
   cursor: number,
   commands: SlashCommandDef[],
-  options?: SlashStateOptions
+  options?: SlashStateOptions,
 ): SlashStateResult {
   const match = getSlashMatch(doc, cursor);
   if (!match) {

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -105,9 +105,10 @@ function themeToEditorTheme(theme: NexusTheme): Extension {
     vars[cssVar] = theme[key as keyof NexusTheme] as string;
   }
 
-  const fontSize = (theme.fontSize ?? 15) + "px";
+  const fontSize = `${theme.fontSize ?? 15}px`;
   const fontFamily = theme.fontFamily ?? "system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
-  const fontFamilyMono = theme.fontFamilyMono ?? "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+  const fontFamilyMono =
+    theme.fontFamilyMono ?? "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
   const contentMaxWidth = theme.contentMaxWidth;
 
   const contentStyles: Record<string, string> = { padding: "16px 0" };
@@ -123,7 +124,7 @@ function themeToEditorTheme(theme: NexusTheme): Extension {
       color: "var(--nexus-text)",
       fontSize,
       fontFamily,
-      ...vars
+      ...vars,
     },
     ".cm-content": contentStyles,
     ".cm-line": { padding: "0 20px" },
@@ -160,6 +161,6 @@ export function createThemeExtension(theme: NexusTheme): {
     extension: ext,
     reconfigure(next: NexusTheme) {
       return { effects: themeCompartment.reconfigure(themeToEditorTheme(next)) };
-    }
+    },
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,23 @@
 import type { Extension } from "@codemirror/state";
-import type { Blockquote, Code, Definition, Delete, Emphasis, FootnoteDefinition, FootnoteReference, Heading, Html, Image, InlineCode, Link, List, Root, Strong, Table, ThematicBreak } from "mdast";
+import type {
+  Blockquote,
+  Code,
+  Definition,
+  Delete,
+  Emphasis,
+  FootnoteDefinition,
+  FootnoteReference,
+  Heading,
+  Html,
+  Image,
+  InlineCode,
+  Link,
+  List,
+  Root,
+  Strong,
+  Table,
+  ThematicBreak,
+} from "mdast";
 import type { Plugin } from "unified";
 
 export interface CodeHighlightToken {
@@ -203,7 +221,7 @@ export interface SlashCommandDef {
    * keep their own id-to-action registry can dispatch via the menu UI's
    * `onCommand` override instead.
    */
-  run?: (editor: EditorAPI) => boolean | void;
+  run?: (editor: EditorAPI) => boolean | undefined;
 }
 
 /**
@@ -257,7 +275,7 @@ export interface EditorCommand {
   /** 可读名称，供命令面板 / 菜单展示。 */
   label?: string;
   /** 执行体。返回 false 表示未消费（宿主可继续派发默认行为）。 */
-  run: (editor: EditorAPI) => boolean | void;
+  run: (editor: EditorAPI) => boolean | undefined;
   /** 可选 CodeMirror 快捷键绑定，如 "Mod-b"、"Ctrl-k"。 */
   hotkey?: string;
 }
@@ -278,7 +296,10 @@ export interface EditorEventContext {
  * 事件处理器：返回 `true` 表示已消费该事件——编辑器会阻止默认行为并停止把事件
  * 继续派发给后续处理器（含内置默认逻辑）。返回 `false`/`undefined` 表示放行。
  */
-export type EditorEventHandler<E extends Event> = (event: E, ctx: EditorEventContext) => boolean | void;
+export type EditorEventHandler<E extends Event> = (
+  event: E,
+  ctx: EditorEventContext,
+) => boolean | undefined;
 
 /**
  * 插件可注册的 DOM 事件钩子。内置的图片粘贴 / 拖拽资源上传会作为兜底，在所有

--- a/packages/core/src/widget-extension.ts
+++ b/packages/core/src/widget-extension.ts
@@ -6,7 +6,13 @@ import {
   StateField,
   type Transaction,
 } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView, ViewPlugin, WidgetType } from "@codemirror/view";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+} from "@codemirror/view";
 import type { Content, Parent, Root } from "mdast";
 
 import type { ParserLike, WidgetDefinition, WidgetRenderContext } from "./types";
@@ -28,7 +34,7 @@ function parseDocument(parser: ParserLike, markdown: string): Root {
 function selectionIntersects(
   from: number,
   to: number,
-  selection: readonly SelectionRange[]
+  selection: readonly SelectionRange[],
 ): boolean {
   return selection.some((range) => {
     const rangeFrom = Math.min(range.anchor, range.head);
@@ -59,7 +65,7 @@ function collectWidgetRanges(
   ast: Root,
   doc: string,
   selection: readonly SelectionRange[],
-  widgets: WidgetDefinition[]
+  widgets: WidgetDefinition[],
 ): WidgetRange[] {
   const ranges: WidgetRange[] = [];
 
@@ -70,7 +76,7 @@ function collectWidgetRanges(
 
       if (typeof from === "number" && typeof to === "number") {
         const matched = widgets.find(
-          (w) => w.nodeType === child.type && (!w.match || w.match(child))
+          (w) => w.nodeType === child.type && (!w.match || w.match(child)),
         );
 
         if (matched && !selectionIntersects(from, to, selection)) {
@@ -102,7 +108,7 @@ class NexusWidget extends WidgetType {
     private source: string,
     private from: number,
     private to: number,
-    private viewRef: { current: EditorView | null }
+    private viewRef: { current: EditorView | null },
   ) {
     super();
   }
@@ -124,9 +130,8 @@ class NexusWidget extends WidgetType {
         const v = this.viewRef.current;
         if (!v) return;
         const safeAnchor = Math.max(0, Math.min(anchor, v.state.doc.length));
-        const safeHead = head === undefined
-          ? safeAnchor
-          : Math.max(0, Math.min(head, v.state.doc.length));
+        const safeHead =
+          head === undefined ? safeAnchor : Math.max(0, Math.min(head, v.state.doc.length));
         v.dispatch({ selection: { anchor: safeAnchor, head: safeHead } });
       },
       focus: () => {
@@ -152,7 +157,7 @@ function buildWidgetDecorations(
   selection: readonly SelectionRange[],
   parser: ParserLike,
   widgets: WidgetDefinition[],
-  viewRef: { current: EditorView | null }
+  viewRef: { current: EditorView | null },
 ): DecorationSet {
   const ast = parseDocument(parser, doc);
   const ranges = collectWidgetRanges(ast, doc, selection, widgets);
@@ -168,10 +173,10 @@ function buildWidgetDecorations(
           range.source,
           range.from,
           range.to,
-          viewRef
+          viewRef,
         ),
         block: isBlock,
-      }).range(range.from, range.to)
+      }).range(range.from, range.to),
     );
   }
 
@@ -180,7 +185,7 @@ function buildWidgetDecorations(
 
 export function createWidgetExtension(
   parser: ParserLike,
-  widgets: WidgetDefinition[]
+  widgets: WidgetDefinition[],
 ): Extension[] {
   if (widgets.length === 0) return [];
 
@@ -194,7 +199,7 @@ export function createWidgetExtension(
         state.selection.ranges,
         parser,
         widgets,
-        viewRef
+        viewRef,
       );
     },
     update(decos: DecorationSet, tr: Transaction) {
@@ -204,7 +209,7 @@ export function createWidgetExtension(
           tr.state.selection.ranges,
           parser,
           widgets,
-          viewRef
+          viewRef,
         );
       }
       if (tr.isUserEvent("input.type.compose")) {
@@ -216,7 +221,7 @@ export function createWidgetExtension(
           tr.state.selection.ranges,
           parser,
           widgets,
-          viewRef
+          viewRef,
         );
       }
       return decos;
@@ -237,7 +242,7 @@ export function createWidgetExtension(
       destroy(): void {
         if (viewRef.current === this.view) viewRef.current = null;
       }
-    }
+    },
   );
 
   const compositionHandler = EditorView.domEventHandlers({

--- a/packages/core/src/wikilinks.ts
+++ b/packages/core/src/wikilinks.ts
@@ -1,10 +1,16 @@
 import {
-  autocompletion,
+  type Completion,
   type CompletionContext,
   type CompletionResult,
-  type Completion
+  autocompletion,
 } from "@codemirror/autocomplete";
-import { StateEffect, StateField, type Extension, type Range, type Transaction } from "@codemirror/state";
+import {
+  type Extension,
+  type Range,
+  StateEffect,
+  StateField,
+  type Transaction,
+} from "@codemirror/state";
 import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
 
 import type { NexusPlugin } from "./types";
@@ -79,6 +85,7 @@ export function scanWikiLinks(doc: string): WikiLinkMatch[] {
   const out: WikiLinkMatch[] = [];
   WIKILINK_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard RegExp loop idiom
   while ((match = WIKILINK_RE.exec(doc)) !== null) {
     const from = match.index;
     const source = match[0];
@@ -120,7 +127,7 @@ function selectionOnLine(
   doc: string,
   from: number,
   to: number,
-  selectionHeads: readonly number[]
+  selectionHeads: readonly number[],
 ): boolean {
   const nodeLineStart = doc.lastIndexOf("\n", from - 1) + 1;
   const nl = doc.indexOf("\n", to);
@@ -140,7 +147,7 @@ function buildWikiLinkDecorations(
   doc: string,
   selectionHeads: readonly number[],
   resolve: WikilinksOptions["resolve"],
-  ignore: WikilinksOptions["ignore"]
+  ignore: WikilinksOptions["ignore"],
 ): DecorationSet {
   const matches = scanWikiLinks(doc);
   if (matches.length === 0) return Decoration.none;
@@ -185,10 +192,7 @@ function buildWikiLinkDecorations(
   return Decoration.set(decos, true);
 }
 
-function findWikiContext(
-  doc: string,
-  pos: number
-): { openFrom: number; query: string } | null {
+function findWikiContext(doc: string, pos: number): { openFrom: number; query: string } | null {
   // Walk backwards on the current line to find the nearest unescaped `[[`
   // that has not yet been closed by `]]`.
   const { start, end: _end } = lineBoundaries(doc, pos);
@@ -207,9 +211,7 @@ function findWikiContext(
   return { openFrom: start + openIdx, query: queryPart };
 }
 
-function createAutocompleteSource(
-  suggest: NonNullable<WikilinksOptions["suggest"]>
-) {
+function createAutocompleteSource(suggest: NonNullable<WikilinksOptions["suggest"]>) {
   return async (ctx: CompletionContext): Promise<CompletionResult | null> => {
     const pos = ctx.pos;
     const doc = ctx.state.doc.toString();
@@ -322,7 +324,7 @@ export function createWikilinksExtension(options: WikilinksOptions = {}): Extens
       autocompletion({
         override: [createAutocompleteSource(options.suggest)],
         activateOnTyping: true,
-      })
+      }),
     );
   }
 

--- a/packages/core/test/accessibility.test.ts
+++ b/packages/core/test/accessibility.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { createEditor } from "../src/index";
 import { createGfmPreset } from "../../preset-gfm/src/index";
+import { createEditor } from "../src/index";
 
 describe("accessibility", () => {
   it("headings have role=heading and aria-level", () => {
@@ -9,7 +9,7 @@ describe("accessibility", () => {
     const editor = createEditor({
       container,
       initialValue: "Intro\n\n# Title\n\n## Sub",
-      livePreview: true
+      livePreview: true,
     });
 
     const h1 = container.querySelector("[role='heading'][aria-level='1']");
@@ -27,7 +27,7 @@ describe("accessibility", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconsole.log(1)\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     // Move cursor into the code block to see editing mode (role=code on first line)
@@ -44,7 +44,7 @@ describe("accessibility", () => {
       container,
       initialValue: "Text\n\n| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const table = container.querySelector("table[role='grid']");

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -1,5 +1,5 @@
-import type { Root } from "mdast";
 import { EditorView, ViewPlugin } from "@codemirror/view";
+import type { Root } from "mdast";
 import type { Plugin } from "unified";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEditor } from "../src/index";
@@ -59,7 +59,7 @@ describe("createEditor", () => {
       },
       onBlur() {
         events.push("blur");
-      }
+      },
     });
 
     editor.focus();
@@ -80,7 +80,7 @@ describe("createEditor", () => {
       onChange(_doc, ast) {
         nodeTypes.push(ast.type);
         nodeTypes.push(ast.children[0]?.type ?? "missing");
-      }
+      },
     });
 
     editor.setDocument("# Heading");
@@ -98,11 +98,11 @@ describe("createEditor", () => {
       parser: {
         parse() {
           throw new Error("boom");
-        }
+        },
       },
       onChange(doc) {
         docs.push(doc);
-      }
+      },
     });
 
     editor.setDocument("after failure");
@@ -116,20 +116,18 @@ describe("createEditor", () => {
     const container = document.createElement("div");
     let nodeTypes: string[] = [];
     let shortcutResult = false;
-    const appendParagraph: Plugin<[], Root, Root> = function () {
-      return (tree) => {
-        tree.children.push({
-          type: "paragraph",
-          children: [{ type: "text", value: "plugin" }]
-        });
-      };
+    const appendParagraph: Plugin<[], Root, Root> = () => (tree) => {
+      tree.children.push({
+        type: "paragraph",
+        children: [{ type: "text", value: "plugin" }],
+      });
     };
     const editor = createEditor({
       container,
       plugins: [
         {
           name: "remark-transform",
-          remarkPlugins: [appendParagraph]
+          remarkPlugins: [appendParagraph],
         },
         {
           name: "shortcut",
@@ -140,14 +138,14 @@ describe("createEditor", () => {
                 api.setDocument("shortcut-ran");
                 shortcutResult = true;
                 return true;
-              }
-            }
-          ]
-        }
+              },
+            },
+          ],
+        },
       ],
       onChange(_doc, ast) {
         nodeTypes = ast.children.map((child: { type: string }) => child.type);
-      }
+      },
     });
 
     editor.setDocument("# Heading");
@@ -168,9 +166,9 @@ describe("createEditor", () => {
       parse(markdown: string): Root {
         return {
           type: "root",
-          children: [{ type: "paragraph", children: [{ type: "text", value: markdown }] }]
+          children: [{ type: "paragraph", children: [{ type: "text", value: markdown }] }],
         };
-      }
+      },
     };
     const editor = createEditor({
       container,
@@ -178,7 +176,7 @@ describe("createEditor", () => {
       parseDelayMs: 20,
       onChange(doc) {
         docs.push(doc);
-      }
+      },
     });
 
     editor.setDocument("first");
@@ -201,14 +199,14 @@ describe("createEditor", () => {
         constructor(readonly view: EditorView) {
           capturedView = view;
         }
-      }
+      },
     );
     const editor = createEditor({
       container,
       plugins: [{ name: "capture-view", cmExtensions: [captureView] }],
       onChange(doc) {
         docs.push(doc);
-      }
+      },
     });
 
     expect(capturedView).not.toBeNull();
@@ -239,7 +237,7 @@ describe("createEditor", () => {
       parseDelayMs: 20,
       onChange(doc) {
         docs.push(doc);
-      }
+      },
     });
 
     editor.setDocument("queued");
@@ -260,7 +258,7 @@ describe("createEditor", () => {
       },
       onBlur() {
         events.push("blur");
-      }
+      },
     });
 
     const content = container.querySelector("[contenteditable='true']");
@@ -287,11 +285,11 @@ describe("createEditor", () => {
               run(api) {
                 api.setDocument("shortcut-keyboard");
                 return true;
-              }
-            }
-          ]
-        }
-      ]
+              },
+            },
+          ],
+        },
+      ],
     });
 
     const content = container.querySelector("[contenteditable='true']");
@@ -303,8 +301,8 @@ describe("createEditor", () => {
         key: "k",
         ctrlKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
 
     expect(editor.getDocument()).toBe("shortcut-keyboard");
@@ -318,13 +316,13 @@ describe("createEditor", () => {
       plugins: [
         {
           name: "slash-a",
-          slashCommands: [{ id: "heading", title: "Heading" }]
+          slashCommands: [{ id: "heading", title: "Heading" }],
         },
         {
           name: "slash-b",
-          slashCommands: [{ id: "table", title: "Table" }]
-        }
-      ]
+          slashCommands: [{ id: "table", title: "Table" }],
+        },
+      ],
     });
 
     expect(editor.getSlashCommands().map((command) => command.id)).toEqual(["heading", "table"]);
@@ -339,7 +337,7 @@ describe("createEditor", () => {
       onAssetUpload(uploadedFile) {
         expect(uploadedFile).toBe(file);
         return Promise.resolve("https://cdn.example.com/image.png");
-      }
+      },
     });
 
     await expect(editor.uploadAsset(file)).resolves.toBe("https://cdn.example.com/image.png");
@@ -360,7 +358,7 @@ describe("createEditor", () => {
       },
       onBlur() {
         events.push("blur");
-      }
+      },
     });
 
     editor.destroy();
@@ -381,7 +379,7 @@ describe("createEditor", () => {
       plugins: [
         {
           name: "editor-attributes",
-          cmExtensions: [EditorView.editorAttributes.of({ "data-plugin": "yes" })]
+          cmExtensions: [EditorView.editorAttributes.of({ "data-plugin": "yes" })],
         },
         {
           name: "update-listener",
@@ -390,10 +388,10 @@ describe("createEditor", () => {
               if (update.docChanged) {
                 seenDocs.push(update.state.doc.toString());
               }
-            })
-          ]
-        }
-      ]
+            }),
+          ],
+        },
+      ],
     });
 
     editor.setDocument("from-extension");
@@ -410,7 +408,7 @@ describe("createEditor", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "# Title\n\nIntro\n\n## Section A\n\n### Sub\n\n## Section B"
+      initialValue: "# Title\n\nIntro\n\n## Section A\n\n### Sub\n\n## Section B",
     });
 
     const toc = editor.getTableOfContents();
@@ -439,7 +437,7 @@ describe("createEditor", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "# Hello\n\n**bold** text\n\n```js\nconsole.log(1)\n```"
+      initialValue: "# Hello\n\n**bold** text\n\n```js\nconsole.log(1)\n```",
     });
 
     const html = editor.exportHTML();
@@ -457,7 +455,7 @@ function captureViewPlugin(onView: (view: EditorView) => void) {
       constructor(readonly view: EditorView) {
         onView(view);
       }
-    }
+    },
   );
 }
 
@@ -478,7 +476,9 @@ describe("createEditor — composition-safe setDocument", () => {
     const editor = createEditor({
       container,
       initialValue: "base",
-      plugins: [{ name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] }],
+      plugins: [
+        { name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] },
+      ],
     });
     const view = requireEditorView(capturedView);
 
@@ -496,7 +496,9 @@ describe("createEditor — composition-safe setDocument", () => {
     const editor = createEditor({
       container,
       initialValue: "base",
-      plugins: [{ name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] }],
+      plugins: [
+        { name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] },
+      ],
     });
     const view = requireEditorView(capturedView);
 
@@ -521,7 +523,9 @@ describe("createEditor — composition-safe setDocument", () => {
       onChange(doc) {
         docs.push(doc);
       },
-      plugins: [{ name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] }],
+      plugins: [
+        { name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] },
+      ],
     });
     const view = requireEditorView(capturedView);
 
@@ -579,7 +583,7 @@ describe("createEditor — command registry", () => {
 
     const content = container.querySelector("[contenteditable='true']");
     content?.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "j", ctrlKey: true, bubbles: true, cancelable: true })
+      new KeyboardEvent("keydown", { key: "j", ctrlKey: true, bubbles: true, cancelable: true }),
     );
 
     expect(editor.getDocument()).toBe("X");
@@ -690,7 +694,11 @@ describe("createEditor — DOM event hook layer", () => {
     expect(keys).toContain("F2");
     expect(handled.defaultPrevented).toBe(true);
 
-    const passthrough = new KeyboardEvent("keydown", { key: "F3", bubbles: true, cancelable: true });
+    const passthrough = new KeyboardEvent("keydown", {
+      key: "F3",
+      bubbles: true,
+      cancelable: true,
+    });
     content.dispatchEvent(passthrough);
     expect(passthrough.defaultPrevented).toBe(false);
     editor.destroy();

--- a/packages/core/test/live-preview-ranges.test.ts
+++ b/packages/core/test/live-preview-ranges.test.ts
@@ -14,11 +14,7 @@ function parse(markdown: string): Root {
 describe("live preview ranges", () => {
   it("collects stable ranges for block and image previews", () => {
     const doc = "Intro\n\n# Heading\n\n> Quote\n\n![Alt](https://example.com/image.png)";
-    const ranges = collectLivePreviewRanges(
-      parse(doc),
-      doc,
-      [EditorSelection.cursor(0)]
-    );
+    const ranges = collectLivePreviewRanges(parse(doc), doc, [EditorSelection.cursor(0)]);
 
     expect(ranges.map((range) => range.node.type)).toEqual(["heading", "blockquote", "image"]);
     expect(ranges.at(-1)?.source).toBe("![Alt](https://example.com/image.png)");
@@ -27,18 +23,12 @@ describe("live preview ranges", () => {
   it("always emits inline ranges regardless of cursor position", () => {
     const doc = "Text **bold** *italic*\n\nother line";
     // Inline ranges are always emitted; buildDecorations decides styling
-    const rangesSameLine = collectLivePreviewRanges(
-      parse(doc),
-      doc,
-      [EditorSelection.cursor(8)]
-    );
+    const rangesSameLine = collectLivePreviewRanges(parse(doc), doc, [EditorSelection.cursor(8)]);
     expect(rangesSameLine.map((r) => r.node.type)).toEqual(["strong", "emphasis"]);
 
-    const rangesDiffLine = collectLivePreviewRanges(
-      parse(doc),
-      doc,
-      [EditorSelection.cursor(doc.length)]
-    );
+    const rangesDiffLine = collectLivePreviewRanges(parse(doc), doc, [
+      EditorSelection.cursor(doc.length),
+    ]);
     expect(rangesDiffLine.map((r) => r.node.type)).toEqual(["strong", "emphasis"]);
   });
 
@@ -51,11 +41,9 @@ describe("live preview ranges", () => {
       "## After",
     ].join("\n");
 
-    const ranges = collectLivePreviewRanges(
-      lezerStringToMdast(doc),
-      doc,
-      [EditorSelection.cursor(doc.length)]
-    );
+    const ranges = collectLivePreviewRanges(lezerStringToMdast(doc), doc, [
+      EditorSelection.cursor(doc.length),
+    ]);
 
     expect(ranges.map((range) => range.node.type)).toEqual(["table", "heading"]);
   });

--- a/packages/core/test/live-preview-regressions.test.ts
+++ b/packages/core/test/live-preview-regressions.test.ts
@@ -10,7 +10,7 @@ describe("live preview regressions", () => {
       container,
       initialValue: "Text **bold**\n\nend",
       livePreview: true,
-      plugins: [createHistoryPlugin()]
+      plugins: [createHistoryPlugin()],
     });
 
     const content = container.querySelector("[contenteditable='true']");
@@ -26,8 +26,8 @@ describe("live preview regressions", () => {
         key: "z",
         ctrlKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
 
     // Cursor on different line → markers hidden
@@ -44,7 +44,7 @@ describe("live preview regressions", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold** end\n\nother line",
-      livePreview: true
+      livePreview: true,
     });
 
     // Cursor on bold line: raw markdown visible
@@ -68,12 +68,12 @@ describe("live preview regressions", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconst a = 1;\nconst b = 2;\n```\n\nmore",
-      livePreview: true
+      livePreview: true,
     });
 
     // Code lines have background on the line element (Decoration.line)
-    const bgLines = Array.from(container.querySelectorAll(".cm-line")).filter(
-      (line) => (line as HTMLElement).getAttribute("style")?.includes("background")
+    const bgLines = Array.from(container.querySelectorAll(".cm-line")).filter((line) =>
+      (line as HTMLElement).getAttribute("style")?.includes("background"),
     );
     expect(bgLines.length).toBeGreaterThanOrEqual(2);
     for (const line of bgLines) {
@@ -83,9 +83,9 @@ describe("live preview regressions", () => {
     }
     // Monospace is on child mark spans, not the line itself
     const monoSpans = bgLines.flatMap((line) =>
-      Array.from(line.querySelectorAll("span")).filter(
-        (span) => span.getAttribute("style")?.includes("monospace")
-      )
+      Array.from(line.querySelectorAll("span")).filter((span) =>
+        span.getAttribute("style")?.includes("monospace"),
+      ),
     );
     expect(monoSpans.length).toBeGreaterThan(0);
     editor.destroy();
@@ -99,7 +99,7 @@ describe("live preview regressions", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n[ref]: https://example.com\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(0);
@@ -118,7 +118,7 @@ describe("live preview regressions", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n> Editable quote\n> second line\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -144,18 +144,20 @@ describe("live preview regressions", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconst a = 1;\n```\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(0);
-    const btnOff = Array.from(container.querySelectorAll("button"))
-      .find((b) => b.getAttribute("aria-label") === "Copy code");
+    const btnOff = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Copy code",
+    );
     expect(btnOff).toBeDefined();
 
     // Cursor inside code block — button still there
     editor.setSelection(10);
-    const btnOn = Array.from(container.querySelectorAll("button"))
-      .find((b) => b.getAttribute("aria-label") === "Copy code");
+    const btnOn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Copy code",
+    );
     expect(btnOn).toBeDefined();
     editor.destroy();
   });
@@ -166,10 +168,11 @@ describe("live preview regressions", () => {
     const editorA = createEditor({
       container: withLang,
       initialValue: "```python\nprint(1)\n```",
-      livePreview: true
+      livePreview: true,
     });
-    const btnA = Array.from(withLang.querySelectorAll("button"))
-      .find((b) => b.getAttribute("aria-label") === "Copy code");
+    const btnA = Array.from(withLang.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Copy code",
+    );
     expect(btnA?.textContent).toBe("python");
     editorA.destroy();
 
@@ -177,10 +180,11 @@ describe("live preview regressions", () => {
     const editorB = createEditor({
       container: noLang,
       initialValue: "```\njust text\n```",
-      livePreview: true
+      livePreview: true,
     });
-    const btnB = Array.from(noLang.querySelectorAll("button"))
-      .find((b) => b.getAttribute("aria-label") === "Copy code");
+    const btnB = Array.from(noLang.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Copy code",
+    );
     expect(btnB?.textContent).toBe("Copy");
     editorB.destroy();
   });
@@ -195,7 +199,7 @@ describe("live preview regressions", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n![alt](https://example.com/img.png)\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(0);

--- a/packages/core/test/live-preview.test.ts
+++ b/packages/core/test/live-preview.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { EditorView, ViewPlugin, type ViewUpdate } from "@codemirror/view";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { createGfmPreset } from "../../preset-gfm/src/index";
 import { createEditor } from "../src/index";
@@ -38,7 +38,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold** *italic* `code` [link](https://example.com)\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     // Move cursor to a different line
@@ -60,7 +60,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold**\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     // Cursor on different line → markers hidden
@@ -79,7 +79,7 @@ describe("live preview", () => {
       container,
       initialValue: "Text ~~deleted~~\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -95,7 +95,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold**\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setDocument("Text **changed**\n\nend");
@@ -116,7 +116,7 @@ describe("live preview", () => {
         constructor(readonly view: EditorView) {
           capturedView = view;
         }
-      }
+      },
     );
     const editor = createEditor({
       container,
@@ -155,7 +155,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text ***bold italic***\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -172,7 +172,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **_mixed_**\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -191,7 +191,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Click [here](https://example.com)\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -206,8 +206,9 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "## 目录\n\n1. [项目概述](#项目概述)\n2. [快速开始](#快速开始)\n3. [主要功能](#主要功能)\n\nend",
-      livePreview: true
+      initialValue:
+        "## 目录\n\n1. [项目概述](#项目概述)\n2. [快速开始](#快速开始)\n3. [主要功能](#主要功能)\n\nend",
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -225,7 +226,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Click [here](https://example.com) now\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -243,7 +244,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: source,
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(source.indexOf(") now") + 1);
@@ -259,7 +260,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: source,
-      livePreview: true
+      livePreview: true,
     });
 
     editor.setSelection(source.indexOf("\n2."));
@@ -276,7 +277,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Intro\n\n# Heading",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.querySelector("[data-heading-level='1']")?.textContent).toBe("Heading");
@@ -292,7 +293,7 @@ describe("live preview", () => {
         constructor(readonly view: EditorView) {
           capturedView = view;
         }
-      }
+      },
     );
     const editor = createEditor({
       container,
@@ -332,11 +333,7 @@ describe("live preview", () => {
 
   it("keeps empty ATX heading input on the same line during composition", async () => {
     const container = document.createElement("div");
-    const lines = [
-      ...Array.from({ length: 22 }, (_, index) => `line ${index + 1}`),
-      "### ",
-      "end",
-    ];
+    const lines = [...Array.from({ length: 22 }, (_, index) => `line ${index + 1}`), "### ", "end"];
     const source = lines.join("\n");
     let capturedView: EditorView | null = null;
     let effectOnlyUpdates = 0;
@@ -351,7 +348,7 @@ describe("live preview", () => {
             effectOnlyUpdates++;
           }
         }
-      }
+      },
     );
     const editor = createEditor({
       container,
@@ -395,15 +392,15 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Intro\n\n> Quote\n\n![Alt](https://example.com/image.png)",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.querySelector("blockquote")).toBeNull();
     expect(container.textContent).toContain("Quote");
     expect(container.textContent).not.toContain("> Quote");
-    expect(container.querySelector("[data-live-preview-image]")?.getAttribute("data-live-preview-image")).toBe(
-      "https://example.com/image.png"
-    );
+    expect(
+      container.querySelector("[data-live-preview-image]")?.getAttribute("data-live-preview-image"),
+    ).toBe("https://example.com/image.png");
 
     editor.setSelection(9);
     expect(container.textContent).toContain("> Quote");
@@ -415,7 +412,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n---\n\nMore",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.querySelector("hr")).not.toBeNull();
@@ -429,7 +426,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconsole.log(1)\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     expect(container.textContent).toContain("console.log(1)");
@@ -444,7 +441,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```js\nconsole.log(1)\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     const textBefore = container.textContent ?? "";
@@ -463,12 +460,13 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n```py\nx = 1\ny = 2\n```",
-      livePreview: true
+      livePreview: true,
     });
 
     const codeLines = Array.from(container.querySelectorAll(".cm-line")).filter(
-      (line) => (line as HTMLElement).style.background === "rgb(246, 248, 250)"
-        || (line as HTMLElement).getAttribute("style")?.includes("background")
+      (line) =>
+        (line as HTMLElement).style.background === "rgb(246, 248, 250)" ||
+        (line as HTMLElement).getAttribute("style")?.includes("background"),
     );
     expect(codeLines.length).toBeGreaterThanOrEqual(2);
     editor.destroy();
@@ -481,15 +479,16 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text\n\n    indented code\n    second line",
-      livePreview: true
+      livePreview: true,
     });
 
     const text = container.textContent ?? "";
     expect(text).toContain("indented code");
     expect(text).toContain("second line");
     const codeLines = Array.from(container.querySelectorAll(".cm-line")).filter(
-      (line) => (line as HTMLElement).getAttribute("style")?.includes("background") ||
-        (line as HTMLElement).innerHTML.includes("monospace")
+      (line) =>
+        (line as HTMLElement).getAttribute("style")?.includes("background") ||
+        (line as HTMLElement).innerHTML.includes("monospace"),
     );
     expect(codeLines.length).toBeGreaterThanOrEqual(2);
     editor.destroy();
@@ -503,7 +502,7 @@ describe("live preview", () => {
       container,
       initialValue: "Text with footnote[^1]\n\n[^1]: Definition text",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const sup = container.querySelector("sup");
@@ -520,7 +519,7 @@ describe("live preview", () => {
       container,
       initialValue: "Visit https://example.com today\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -539,15 +538,15 @@ describe("live preview", () => {
       container,
       initialValue: "Text\n\n| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const table = container.querySelector("table");
     expect(table).not.toBeNull();
     const ths = table?.querySelectorAll("th");
-    expect(ths!.length).toBeGreaterThanOrEqual(3);
-    expect(ths![1]?.textContent).toBe("A");
-    expect(ths![1]?.classList.contains("nexus-cell")).toBe(true);
+    expect(ths?.length).toBeGreaterThanOrEqual(3);
+    expect(ths?.[1]?.textContent).toBe("A");
+    expect(ths?.[1]?.classList.contains("nexus-cell")).toBe(true);
     editor.destroy();
   });
 
@@ -559,13 +558,13 @@ describe("live preview", () => {
         constructor(readonly view: EditorView) {
           capturedView = view;
         }
-      }
+      },
     );
     const editor = createEditor({
       container,
       initialValue: "before\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n\nafter",
       livePreview: true,
-      plugins: [createGfmPreset(), { name: "capture", cmExtensions: [captureView] }]
+      plugins: [createGfmPreset(), { name: "capture", cmExtensions: [captureView] }],
     });
     const view = requireEditorView(capturedView);
     // 光标离开表格，使其渲染为不可逐字进入的 block widget。
@@ -594,29 +593,35 @@ describe("live preview", () => {
       container,
       initialValue: "| A | B |\n| --- | --- |\n| 1 | 222 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
-    const cell = container.querySelectorAll<HTMLElement>("tr")[2]?.querySelectorAll<HTMLElement>(".nexus-cell")[1];
+    const cell = container
+      .querySelectorAll<HTMLElement>("tr")[2]
+      ?.querySelectorAll<HTMLElement>(".nexus-cell")[1];
     expect(cell).not.toBeUndefined();
     expect(cell?.contentEditable).not.toBe("true");
 
-    cell?.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      button: 0,
-      clientX: 80,
-      clientY: 40
-    }));
+    cell?.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 80,
+        clientY: 40,
+      }),
+    );
 
     expect(cell?.contentEditable).not.toBe("true");
 
-    document.dispatchEvent(new MouseEvent("mouseup", {
-      bubbles: true,
-      button: 0,
-      clientX: 80,
-      clientY: 40
-    }));
+    document.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        button: 0,
+        clientX: 80,
+        clientY: 40,
+      }),
+    );
 
     expect(cell?.contentEditable).toBe("true");
     editor.destroy();
@@ -630,11 +635,11 @@ describe("live preview", () => {
       container,
       initialValue: "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const dataRows = Array.from(container.querySelectorAll<HTMLElement>("tr")).filter((row) =>
-      row.querySelector(".nexus-cell")
+      row.querySelector(".nexus-cell"),
     );
     const cellOf = (rowIndex: number, colIndex: number): HTMLElement =>
       dataRows[rowIndex].querySelectorAll<HTMLElement>(".nexus-cell")[colIndex];
@@ -644,24 +649,46 @@ describe("live preview", () => {
     // 因此这里用「事件是否被消费 + 目标单元格是否被激活为可编辑」来判定导航，
     // focus 的真实落点由 E2E 在真实 Chromium 中覆盖。
     const start = cellOf(1, 0);
-    start.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, button: 0, clientX: 80, clientY: 40 }));
-    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, clientX: 80, clientY: 40 }));
+    start.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 80,
+        clientY: 40,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mouseup", { bubbles: true, button: 0, clientX: 80, clientY: 40 }),
+    );
     expect(start.contentEditable).toBe("true");
 
     // ↓ 激活第 3 行第 1 列（"3"），并消费事件。
-    const downEvent = new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true });
+    const downEvent = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
     start.dispatchEvent(downEvent);
     expect(downEvent.defaultPrevented).toBe(true);
     const bottom = cellOf(2, 0);
     expect(bottom.contentEditable).toBe("true");
 
     // ↓ 在最后一行到达边界，不消费（交回默认）。
-    const downAtBottom = new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true });
+    const downAtBottom = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
     bottom.dispatchEvent(downAtBottom);
     expect(downAtBottom.defaultPrevented).toBe(false);
 
     // ↑ 从底行回到第 2 行第 1 列（"1"）。
-    const upEvent = new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true, cancelable: true });
+    const upEvent = new KeyboardEvent("keydown", {
+      key: "ArrowUp",
+      bubbles: true,
+      cancelable: true,
+    });
     bottom.dispatchEvent(upEvent);
     expect(upEvent.defaultPrevented).toBe(true);
     expect(start.contentEditable).toBe("true");
@@ -677,10 +704,12 @@ describe("live preview", () => {
       container,
       initialValue: "| A | B |\n| --- | --- |\n| 1 | **加粗** |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
-    const cell = container.querySelectorAll<HTMLElement>("tr")[2]?.querySelectorAll<HTMLElement>(".nexus-cell")[1];
+    const cell = container
+      .querySelectorAll<HTMLElement>("tr")[2]
+      ?.querySelectorAll<HTMLElement>(".nexus-cell")[1];
     const textNode = cell?.querySelector("strong")?.firstChild;
     expect(cell).not.toBeUndefined();
     expect(textNode?.textContent).toBe("加粗");
@@ -694,19 +723,23 @@ describe("live preview", () => {
       value: () => range,
     });
 
-    cell?.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      button: 0,
-      clientX: 80,
-      clientY: 40
-    }));
-    document.dispatchEvent(new MouseEvent("mouseup", {
-      bubbles: true,
-      button: 0,
-      clientX: 80,
-      clientY: 40
-    }));
+    cell?.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 80,
+        clientY: 40,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        button: 0,
+        clientX: 80,
+        clientY: 40,
+      }),
+    );
 
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
@@ -729,10 +762,12 @@ describe("live preview", () => {
       container,
       initialValue: "| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
-    const cells = container.querySelectorAll<HTMLElement>("tr")[2]?.querySelectorAll<HTMLElement>(".nexus-cell");
+    const cells = container
+      .querySelectorAll<HTMLElement>("tr")[2]
+      ?.querySelectorAll<HTMLElement>(".nexus-cell");
     const firstCell = cells?.[0];
     const secondCell = cells?.[1];
     expect(firstCell).not.toBeUndefined();
@@ -747,7 +782,7 @@ describe("live preview", () => {
       bottom: 30,
       width: 50,
       height: 30,
-      toJSON: () => ({})
+      toJSON: () => ({}),
     });
     secondCell!.getBoundingClientRect = () => ({
       x: 50,
@@ -758,28 +793,34 @@ describe("live preview", () => {
       bottom: 30,
       width: 50,
       height: 30,
-      toJSON: () => ({})
+      toJSON: () => ({}),
     });
 
-    firstCell?.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      button: 0,
-      clientX: 25,
-      clientY: 15
-    }));
-    document.dispatchEvent(new MouseEvent("mousemove", {
-      bubbles: true,
-      button: 0,
-      clientX: 75,
-      clientY: 15
-    }));
-    document.dispatchEvent(new MouseEvent("mouseup", {
-      bubbles: true,
-      button: 0,
-      clientX: 75,
-      clientY: 15
-    }));
+    firstCell?.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 25,
+        clientY: 15,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        button: 0,
+        clientX: 75,
+        clientY: 15,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        button: 0,
+        clientX: 75,
+        clientY: 15,
+      }),
+    );
 
     expect(firstCell?.contentEditable).not.toBe("true");
     expect(firstCell?.style.background).toContain("124, 108, 250");
@@ -822,7 +863,9 @@ describe("live preview", () => {
 
     // First row, first column: media-only standalone image — width:100%
     // so it grows with the column.
-    const mediaOnlyStandalone = imgs.find((i) => i.getAttribute("src") === "https://example.com/a.png");
+    const mediaOnlyStandalone = imgs.find(
+      (i) => i.getAttribute("src") === "https://example.com/a.png",
+    );
     expect(mediaOnlyStandalone?.style.width).toBe("100%");
     expect(mediaOnlyStandalone?.style.maxHeight).toBe("240px");
 
@@ -917,12 +960,20 @@ describe("live preview", () => {
     // mouseup to commit. The DOM should pick up a <colgroup> + the
     // table should switch to fixed layout afterwards.
     const startX = 200;
-    handle?.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true, cancelable: true, button: 0, clientX: startX,
-    }));
-    document.dispatchEvent(new MouseEvent("mousemove", {
-      bubbles: true, clientX: startX + 60,
-    }));
+    handle?.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: startX,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: startX + 60,
+      }),
+    );
     document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
     const table = container.querySelector("table") as HTMLTableElement | null;
@@ -945,7 +996,7 @@ describe("live preview", () => {
     });
 
     const rows = Array.from(container.querySelectorAll("tr")).map((row) =>
-      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent)
+      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent),
     );
     // Every body row should have the same cell count as the widest row (4).
     // Header padded with one empty extra column; the short row padded too.
@@ -961,11 +1012,11 @@ describe("live preview", () => {
       container,
       initialValue: "| A |  | C |\n| --- | --- | --- |\n| 1 |  | 3 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const rows = Array.from(container.querySelectorAll("tr")).map((row) =>
-      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent)
+      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent),
     );
     expect(rows[1]).toEqual(["A", "", "C"]);
     expect(rows[2]).toEqual(["1", "", "3"]);
@@ -978,17 +1029,17 @@ describe("live preview", () => {
       container,
       initialValue: "| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const addColumn = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.title === "Add column"
+      (button) => button.title === "Add column",
     );
     expect(addColumn).not.toBeUndefined();
     addColumn?.click();
 
     const rows = Array.from(container.querySelectorAll("tr")).map((row) =>
-      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent)
+      Array.from(row.querySelectorAll(".nexus-cell")).map((cell) => cell.textContent),
     );
     expect(rows[1]).toEqual(["A", "B", ""]);
     expect(rows[2]).toEqual(["1", "2", ""]);
@@ -1006,9 +1057,9 @@ describe("live preview", () => {
         deleteRow: "删除行",
         deleteColumn: "删除列",
         insertRowBelow: "在下方插入行",
-        insertColumnAfter: "在右侧插入列"
+        insertColumnAfter: "在右侧插入列",
       },
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const dataCell = container.querySelectorAll("tr")[2]?.querySelector(".nexus-cell");
@@ -1017,7 +1068,7 @@ describe("live preview", () => {
       bubbles: true,
       cancelable: true,
       clientX: 32,
-      clientY: 40
+      clientY: 40,
     });
     dataCell?.dispatchEvent(event);
 
@@ -1049,9 +1100,9 @@ describe("live preview", () => {
             element.setAttribute("data-heading", "custom");
             element.textContent = text.toUpperCase();
             return element;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
     expect(container.querySelector("[data-heading='custom']")?.textContent).toBe("HEADING");
@@ -1069,9 +1120,9 @@ describe("live preview", () => {
             const element = document.createElement("span");
             element.setAttribute("data-source", source);
             return element;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
     // Cursor on first line, away from the bold
@@ -1258,7 +1309,7 @@ describe("live preview", () => {
   it("clicking <summary> or <a href> inside an HTML block preserves native behaviour (no edit-mode trigger)", () => {
     const container = document.createElement("div");
     const html =
-      '<details><summary>Toggle</summary><p>Hidden text</p></details>' +
+      "<details><summary>Toggle</summary><p>Hidden text</p></details>" +
       '<p><a href="https://example.com" data-test="link">Link</a></p>';
     const editor = createEditor({
       container,
@@ -1293,7 +1344,7 @@ describe("live preview", () => {
     const container = document.createElement("div");
     const html =
       '<div class="hostile" onclick="alert(1)">' +
-      '<script>window.evil=true;</script>safe content</div>';
+      "<script>window.evil=true;</script>safe content</div>";
     const editor = createEditor({
       container,
       initialValue: `Intro\n\n${html}\n\nend`,
@@ -1320,7 +1371,7 @@ describe("live preview", () => {
       container,
       initialValue: "Intro\n\n1. first\n   - nested a\n   - nested b\n2. second\n3. third\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -1342,7 +1393,7 @@ describe("live preview", () => {
       container,
       initialValue: "Intro\n\n- [x] done item\n- [ ] open item\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     editor.setSelection(editor.getDocument().length);
@@ -1359,7 +1410,7 @@ describe("live preview", () => {
       container,
       initialValue: "intro\n\n- [ ] open item\n- [x] done item\n\nend",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     // 光标放在文末 end 行（不在任一任务行）→ 两个复选框都渲染。
@@ -1379,7 +1430,7 @@ describe("live preview", () => {
       container,
       initialValue: "- [ ] alpha\n- [ ] beta",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     // 光标落在第一行（alpha 项）→ 该行露出 `- [ ] ` 原文，复选框消失；
@@ -1398,7 +1449,7 @@ describe("live preview", () => {
       container,
       initialValue: "1. one\n2. two\n3. three",
       livePreview: true,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     // 光标落在第二项 → 该行露出 `2. ` 原文，但第三项仍须渲染为 `3. `
@@ -1418,7 +1469,7 @@ describe("live preview", () => {
     const editor = createEditor({
       container,
       initialValue: "Text **bold** here\n\nend",
-      livePreview: true
+      livePreview: true,
     });
 
     // Cursor on the line with bold — markers should remain visible but
@@ -1427,7 +1478,8 @@ describe("live preview", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("**bold**");
     const boldSpan = Array.from(container.querySelectorAll<HTMLElement>("span")).find(
-      (el) => el.textContent === "bold" && /font-weight\s*:\s*bold/i.test(el.getAttribute("style") ?? "")
+      (el) =>
+        el.textContent === "bold" && /font-weight\s*:\s*bold/i.test(el.getAttribute("style") ?? ""),
     );
     expect(boldSpan).not.toBeUndefined();
     editor.destroy();
@@ -1444,9 +1496,9 @@ describe("live preview", () => {
             const element = document.createElement("span");
             element.textContent = text.toUpperCase();
             return element;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
     editor.setSelection(0);

--- a/packages/core/test/locale.test.ts
+++ b/packages/core/test/locale.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { createEditor, enLocale, zhLocale, resolveLocale } from "../src/index";
 import { createGfmPreset } from "../../preset-gfm/src/index";
+import { createEditor, enLocale, resolveLocale, zhLocale } from "../src/index";
 
 describe("internationalization", () => {
   it("resolveLocale returns English by default", () => {
@@ -31,7 +31,7 @@ describe("internationalization", () => {
       initialValue: "| A | B |\n| --- | --- |\n| 1 | 2 |",
       livePreview: true,
       locale: zhLocale,
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     // The add-column button should have Chinese title
@@ -42,12 +42,23 @@ describe("internationalization", () => {
 
   it("enLocale has all required keys", () => {
     const keys: (keyof typeof enLocale)[] = [
-      "addColumn", "addRow", "deleteColumn", "deleteRow",
-      "insertColumnBefore", "insertColumnAfter",
-      "insertRowAbove", "insertRowBelow",
-      "alignLeft", "alignCenter", "alignRight",
-      "foldCode", "unfoldCode", "foldHeading", "unfoldHeading",
-      "openLink", "codeBlockLabel"
+      "addColumn",
+      "addRow",
+      "deleteColumn",
+      "deleteRow",
+      "insertColumnBefore",
+      "insertColumnAfter",
+      "insertRowAbove",
+      "insertRowBelow",
+      "alignLeft",
+      "alignCenter",
+      "alignRight",
+      "foldCode",
+      "unfoldCode",
+      "foldHeading",
+      "unfoldHeading",
+      "openLink",
+      "codeBlockLabel",
     ];
     for (const key of keys) {
       expect(typeof enLocale[key]).toBe("string");

--- a/packages/core/test/markdown-fold.test.ts
+++ b/packages/core/test/markdown-fold.test.ts
@@ -1,5 +1,5 @@
-import { EditorState } from "@codemirror/state";
 import { foldable } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
 
@@ -9,8 +9,8 @@ function createView(doc: string): EditorView {
   return new EditorView({
     state: EditorState.create({
       doc,
-      extensions: [markdownFoldService()]
-    })
+      extensions: [markdownFoldService()],
+    }),
   });
 }
 
@@ -24,8 +24,8 @@ describe("markdown fold", () => {
     const range = foldable(view.state, line.from, line.to);
 
     expect(range).not.toBeNull();
-    expect(range!.from).toBe(line.to); // fold starts after heading
-    expect(range!.to).toBe(view.state.doc.line(2).to); // fold ends before "# Second"
+    expect(range?.from).toBe(line.to); // fold starts after heading
+    expect(range?.to).toBe(view.state.doc.line(2).to); // fold ends before "# Second"
     view.destroy();
   });
 
@@ -36,7 +36,7 @@ describe("markdown fold", () => {
     const range = foldable(view.state, line.from, line.to);
 
     expect(range).not.toBeNull();
-    expect(range!.to).toBe(doc.length);
+    expect(range?.to).toBe(doc.length);
     view.destroy();
   });
 
@@ -48,7 +48,7 @@ describe("markdown fold", () => {
 
     expect(range).not.toBeNull();
     // Should fold only "Content" line, stopping before "# Top"
-    expect(range!.to).toBe(view.state.doc.line(2).to);
+    expect(range?.to).toBe(view.state.doc.line(2).to);
     view.destroy();
   });
 
@@ -71,10 +71,10 @@ describe("markdown fold", () => {
     const range = foldable(view.state, line.from, line.to);
 
     expect(range).not.toBeNull();
-    expect(range!.from).toBe(line.to);
+    expect(range?.from).toBe(line.to);
     // Should fold to end of closing fence
     const lastLine = view.state.doc.line(4); // "```"
-    expect(range!.to).toBe(lastLine.to);
+    expect(range?.to).toBe(lastLine.to);
     view.destroy();
   });
 

--- a/packages/core/test/markdown-keymap.test.ts
+++ b/packages/core/test/markdown-keymap.test.ts
@@ -8,8 +8,8 @@ function createView(doc: string, cursor?: number): EditorView {
   const view = new EditorView({
     state: EditorState.create({
       doc,
-      selection: { anchor: cursor ?? doc.length }
-    })
+      selection: { anchor: cursor ?? doc.length },
+    }),
   });
   return view;
 }
@@ -106,8 +106,8 @@ describe("markdown keymap", () => {
     const view = new EditorView({
       state: EditorState.create({
         doc: "- item",
-        selection: { anchor: 2, head: 6 }
-      })
+        selection: { anchor: 2, head: 6 },
+      }),
     });
     const handled = handleMarkdownEnter(view);
 

--- a/packages/core/test/mermaid.test.ts
+++ b/packages/core/test/mermaid.test.ts
@@ -25,16 +25,7 @@ function makeContainer(): HTMLElement {
 describe("mermaid live preview", () => {
   it("replaces ```mermaid blocks with a diagram widget when cursor is outside", () => {
     const container = makeContainer();
-    const md = [
-      "before",
-      "",
-      "```mermaid",
-      "graph TD",
-      "  A --> B",
-      "```",
-      "",
-      "after",
-    ].join("\n");
+    const md = ["before", "", "```mermaid", "graph TD", "  A --> B", "```", "", "after"].join("\n");
 
     const editor = createEditor({
       container,
@@ -118,7 +109,7 @@ describe("mermaid live preview", () => {
     const editBtn = container.querySelector(".nexus-mermaid button") as HTMLButtonElement | null;
     expect(editBtn).not.toBeNull();
 
-    editBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    editBtn?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
 
     const { anchor } = editor.getSelection();
     const blockStart = md.indexOf("```mermaid");

--- a/packages/core/test/slash-state.test.ts
+++ b/packages/core/test/slash-state.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  computeSlashState,
-  filterSlashCommands,
-  getSlashMatch,
-} from "../src/slash-state";
+import { computeSlashState, filterSlashCommands, getSlashMatch } from "../src/slash-state";
 import type { SlashCommandDef } from "../src/types";
 
-function cmds(...defs: Array<Partial<SlashCommandDef> & { id: string; title: string }>): SlashCommandDef[] {
-  return defs.map((d) => ({ ...d } as SlashCommandDef));
+function cmds(
+  ...defs: Array<Partial<SlashCommandDef> & { id: string; title: string }>
+): SlashCommandDef[] {
+  return defs.map((d) => ({ ...d }) as SlashCommandDef);
 }
 
 describe("getSlashMatch", () => {
@@ -43,11 +41,7 @@ describe("filterSlashCommands ranking", () => {
       { id: "h1", title: "Heading 1" },
       { id: "bold", title: "Bold" },
     );
-    expect(filterSlashCommands(list, "").map((c) => c.id)).toEqual([
-      "table",
-      "h1",
-      "bold",
-    ]);
+    expect(filterSlashCommands(list, "").map((c) => c.id)).toEqual(["table", "h1", "bold"]);
   });
 
   it("ranks exact title match above prefix match", () => {
@@ -68,10 +62,7 @@ describe("filterSlashCommands ranking", () => {
     );
     // Query "h": both Title prefix → tiebreaker is title.length (Heading=7, Highlight=9),
     // so Heading wins.
-    expect(filterSlashCommands(list, "h").map((c) => c.id)).toEqual([
-      "heading",
-      "highlight",
-    ]);
+    expect(filterSlashCommands(list, "h").map((c) => c.id)).toEqual(["heading", "highlight"]);
   });
 
   it("ranks title-prefix above keyword-prefix when only one is a title hit", () => {
@@ -79,10 +70,7 @@ describe("filterSlashCommands ranking", () => {
       { id: "alpha", title: "Alpha", keywords: ["zeta"] },
       { id: "bravo", title: "Other", keywords: ["alphabet"] },
     );
-    expect(filterSlashCommands(list, "alpha").map((c) => c.id)).toEqual([
-      "alpha",
-      "bravo",
-    ]);
+    expect(filterSlashCommands(list, "alpha").map((c) => c.id)).toEqual(["alpha", "bravo"]);
   });
 
   it("filters out non-matches entirely", () => {
@@ -99,33 +87,22 @@ describe("filterSlashCommands ranking", () => {
       { id: "hr", title: "Page rule line", keywords: ["divider"] },
       { id: "rule-cmd", title: "Other", keywords: ["rule"] },
     );
-    expect(filterSlashCommands(list, "rule").map((c) => c.id)).toEqual([
-      "rule-cmd",
-      "hr",
-    ]);
+    expect(filterSlashCommands(list, "rule").map((c) => c.id)).toEqual(["rule-cmd", "hr"]);
   });
 
   it("is case-insensitive on both title and keywords", () => {
-    const list = cmds(
-      { id: "h1", title: "HEADING", keywords: ["TITLE"] },
-    );
+    const list = cmds({ id: "h1", title: "HEADING", keywords: ["TITLE"] });
     expect(filterSlashCommands(list, "tit").map((c) => c.id)).toEqual(["h1"]);
     expect(filterSlashCommands(list, "head").map((c) => c.id)).toEqual(["h1"]);
   });
 
   it("returns deterministic order on identical scores", () => {
-    const list = cmds(
-      { id: "z", title: "Zeta" },
-      { id: "a", title: "Alpha" },
-    );
+    const list = cmds({ id: "z", title: "Zeta" }, { id: "a", title: "Alpha" });
     // Empty query preserves input order.
     expect(filterSlashCommands(list, "").map((c) => c.id)).toEqual(["z", "a"]);
     // A query matching both via title-substring with identical
     // tiebreakers (offset 1) sorts alphabetically.
-    const list2 = cmds(
-      { id: "z", title: "Zoo" },
-      { id: "a", title: "Aoo" },
-    );
+    const list2 = cmds({ id: "z", title: "Zoo" }, { id: "a", title: "Aoo" });
     expect(filterSlashCommands(list2, "oo").map((c) => c.id)).toEqual(["a", "z"]);
   });
 });

--- a/packages/core/test/theme.test.ts
+++ b/packages/core/test/theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createEditor, lightTheme, darkTheme } from "../src/index";
+import { createEditor, darkTheme, lightTheme } from "../src/index";
 
 describe("theme system", () => {
   it("applies light theme CSS variables by default", () => {
@@ -10,7 +10,7 @@ describe("theme system", () => {
     const cmEditor = container.querySelector(".cm-editor") as HTMLElement;
     expect(cmEditor).not.toBeNull();
     // The CM6 theme extension sets CSS variables on the editor root
-    const style = cmEditor.style;
+    const _style = cmEditor.style;
     // Variables are set via CM6's theme mechanism on the & selector
     expect(cmEditor.className).toContain("cm-editor");
     editor.destroy();
@@ -21,7 +21,7 @@ describe("theme system", () => {
     const editor = createEditor({
       container,
       initialValue: "hello",
-      theme: darkTheme
+      theme: darkTheme,
     });
 
     // Should create without error
@@ -33,7 +33,7 @@ describe("theme system", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
-      initialValue: "preserve me"
+      initialValue: "preserve me",
     });
 
     editor.setTheme(darkTheme);
@@ -52,7 +52,7 @@ describe("theme system", () => {
     const editor = createEditor({
       container,
       initialValue: "custom theme",
-      theme: custom
+      theme: custom,
     });
 
     expect(editor.getDocument()).toBe("custom theme");

--- a/packages/core/test/widgets.test.ts
+++ b/packages/core/test/widgets.test.ts
@@ -14,7 +14,7 @@ describe("widget extension", () => {
           widgets: [
             {
               nodeType: "code",
-              render(node, source) {
+              render(_node, source) {
                 const el = document.createElement("div");
                 el.setAttribute("data-widget", "code");
                 el.textContent = source;
@@ -26,9 +26,7 @@ describe("widget extension", () => {
       ],
     });
 
-    expect(
-      container.querySelector("[data-widget='code']")
-    ).not.toBeNull();
+    expect(container.querySelector("[data-widget='code']")).not.toBeNull();
     editor.destroy();
   });
 
@@ -69,8 +67,7 @@ describe("widget extension", () => {
     // Prefix with "Text\n\n" so cursor at 0 doesn't intersect the code blocks
     const editor = createEditor({
       container,
-      initialValue:
-        "Text\n\n```mermaid\ngraph LR\n```\n\n```js\nconsole.log(1)\n```",
+      initialValue: "Text\n\n```mermaid\ngraph LR\n```\n\n```js\nconsole.log(1)\n```",
       plugins: [
         {
           name: "mermaid-widget",

--- a/packages/core/test/wikilinks.test.ts
+++ b/packages/core/test/wikilinks.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
-import { EditorState, EditorSelection } from "@codemirror/state";
+import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
 
 import {
-  scanWikiLinks,
+  createEditor,
   createWikilinksExtension,
   createWikilinksPlugin,
-  createEditor,
+  scanWikiLinks,
 } from "../src/index";
 
 describe("scanWikiLinks", () => {
@@ -79,7 +79,7 @@ describe("wikilinks decorations (rendered output)", () => {
 
     const span = container.querySelector("[data-wikilink-target]");
     expect(span).not.toBeNull();
-    expect(span!.getAttribute("data-wikilink-target")).toBe("MyNote");
+    expect(span?.getAttribute("data-wikilink-target")).toBe("MyNote");
     editor.destroy();
   });
 
@@ -98,7 +98,7 @@ describe("wikilinks decorations (rendered output)", () => {
     expect(text).toContain("visible alias");
     expect(text).not.toContain("A Real Target");
     const span = container.querySelector("[data-wikilink-target]");
-    expect(span!.getAttribute("data-wikilink-target")).toBe("A Real Target");
+    expect(span?.getAttribute("data-wikilink-target")).toBe("A Real Target");
     editor.destroy();
   });
 

--- a/packages/plugin-history/package.json
+++ b/packages/plugin-history/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/plugin-history/src/index.ts
+++ b/packages/plugin-history/src/index.ts
@@ -6,6 +6,6 @@ import type { NexusPlugin } from "@floatboat/nexus-core";
 export function createHistoryPlugin(): NexusPlugin {
   return {
     name: "plugin-history",
-    cmExtensions: [history(), keymap.of(historyKeymap)]
+    cmExtensions: [history(), keymap.of(historyKeymap)],
   };
 }

--- a/packages/plugin-history/test/plugin-history.test.ts
+++ b/packages/plugin-history/test/plugin-history.test.ts
@@ -8,7 +8,7 @@ describe("@floatboat/nexus-plugin-history", () => {
     const editor = createEditor({
       container,
       initialValue: "start",
-      plugins: [createHistoryPlugin()]
+      plugins: [createHistoryPlugin()],
     });
 
     const content = container.querySelector("[contenteditable='true']");
@@ -20,8 +20,8 @@ describe("@floatboat/nexus-plugin-history", () => {
         key: "z",
         ctrlKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
 
     expect(editor.getDocument()).toBe("start");
@@ -33,7 +33,7 @@ describe("@floatboat/nexus-plugin-history", () => {
     const editor = createEditor({
       container,
       initialValue: "start",
-      plugins: [createHistoryPlugin()]
+      plugins: [createHistoryPlugin()],
     });
 
     const content = container.querySelector("[contenteditable='true']");
@@ -45,8 +45,8 @@ describe("@floatboat/nexus-plugin-history", () => {
         key: "z",
         ctrlKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
 
     content?.dispatchEvent(
@@ -54,8 +54,8 @@ describe("@floatboat/nexus-plugin-history", () => {
         key: "y",
         ctrlKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
 
     expect(editor.getDocument()).toBe("next");

--- a/packages/plugin-math/package.json
+++ b/packages/plugin-math/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/plugin-math/src/index.ts
+++ b/packages/plugin-math/src/index.ts
@@ -13,10 +13,7 @@ import remarkMath from "remark-math";
  * widget-extension) — clicking on an inline formula already drops the
  * caret adjacent to it and toggles into edit mode automatically.
  */
-function attachBlockEditButton(
-  host: HTMLElement,
-  ctx: WidgetRenderContext | undefined
-): void {
+function attachBlockEditButton(host: HTMLElement, ctx: WidgetRenderContext | undefined): void {
   if (!ctx) return;
 
   const btn = document.createElement("button");
@@ -24,7 +21,7 @@ function attachBlockEditButton(
   btn.textContent = "✎";
   btn.title = "Edit formula";
   btn.setAttribute("aria-label", "Edit formula");
-  btn.style.cssText = [
+  btn.style.cssText = `${[
     "position:absolute",
     "top:4px",
     "right:8px",
@@ -42,16 +39,25 @@ function attachBlockEditButton(
     "user-select:none",
     "transition:opacity .15s",
     "pointer-events:auto",
-  ].join(";") + ";";
+  ].join(";")};`;
 
-  host.addEventListener("mouseenter", () => { btn.style.opacity = "1"; });
-  host.addEventListener("mouseleave", () => { btn.style.opacity = "0"; });
-  btn.addEventListener("mouseenter", () => { btn.style.opacity = "1"; });
+  host.addEventListener("mouseenter", () => {
+    btn.style.opacity = "1";
+  });
+  host.addEventListener("mouseleave", () => {
+    btn.style.opacity = "0";
+  });
+  btn.addEventListener("mouseenter", () => {
+    btn.style.opacity = "1";
+  });
 
   // Button events must escape the widget body's `ignoreEvents: true`
   // swallow. The button preventDefaults + stopPropagation so CM6 doesn't
   // see the click at all.
-  btn.addEventListener("mousedown", (e) => { e.preventDefault(); e.stopPropagation(); });
+  btn.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
   btn.addEventListener("click", (e) => {
     e.preventDefault();
     e.stopPropagation();

--- a/packages/plugin-search/package.json
+++ b/packages/plugin-search/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -1,19 +1,24 @@
 import {
+  SearchQuery,
   closeSearchPanel,
   findNext,
   findPrevious,
   getSearchQuery,
   highlightSelectionMatches,
-  openSearchPanel,
   replaceAll,
   replaceNext,
   search,
   searchKeymap,
-  SearchQuery,
   selectMatches,
-  setSearchQuery
+  setSearchQuery,
 } from "@codemirror/search";
-import { keymap, runScopeHandlers, type EditorView, type Panel, type ViewUpdate } from "@codemirror/view";
+import {
+  type EditorView,
+  type Panel,
+  type ViewUpdate,
+  keymap,
+  runScopeHandlers,
+} from "@codemirror/view";
 
 import type { NexusPlugin } from "@floatboat/nexus-core";
 
@@ -72,7 +77,7 @@ const DEFAULT_LABELS: SearchPluginLabels = {
   byWord: "By word",
   replaceNext: "Replace",
   replaceAll: "Replace all",
-  close: "Close"
+  close: "Close",
 };
 
 function escapeRegExp(value: string): string {
@@ -82,7 +87,7 @@ function escapeRegExp(value: string): string {
 export function findSearchMatches(
   doc: string,
   query: string,
-  options: SearchOptions = {}
+  options: SearchOptions = {},
 ): SearchMatch[] {
   if (!query) {
     return [];
@@ -99,7 +104,7 @@ export function findSearchMatches(
     matches.push({
       from,
       to: from + text.length,
-      text
+      text,
     });
   }
 
@@ -110,7 +115,7 @@ export function replaceAllMatches(
   doc: string,
   query: string,
   replacement: string,
-  options: SearchOptions = {}
+  options: SearchOptions = {},
 ): string {
   if (!query) {
     return doc;
@@ -124,7 +129,7 @@ function resolveLabel(
   view: EditorView,
   labels: Partial<SearchPluginLabels> | undefined,
   key: keyof SearchPluginLabels,
-  fallback: string
+  fallback: string,
 ): string {
   const candidate = labels?.[key]?.trim();
   if (candidate) return candidate;
@@ -133,7 +138,10 @@ function resolveLabel(
   return phrase || fallback;
 }
 
-function resolveLabels(view: EditorView, labels: Partial<SearchPluginLabels> | undefined): SearchPluginLabels {
+function resolveLabels(
+  view: EditorView,
+  labels: Partial<SearchPluginLabels> | undefined,
+): SearchPluginLabels {
   return {
     find: resolveLabel(view, labels, "find", DEFAULT_LABELS.find),
     replace: resolveLabel(view, labels, "replace", DEFAULT_LABELS.replace),
@@ -147,7 +155,7 @@ function resolveLabels(view: EditorView, labels: Partial<SearchPluginLabels> | u
     byWord: resolveLabel(view, labels, "byWord", DEFAULT_LABELS.byWord),
     replaceNext: resolveLabel(view, labels, "replaceNext", DEFAULT_LABELS.replaceNext),
     replaceAll: resolveLabel(view, labels, "replaceAll", DEFAULT_LABELS.replaceAll),
-    close: resolveLabel(view, labels, "close", DEFAULT_LABELS.close)
+    close: resolveLabel(view, labels, "close", DEFAULT_LABELS.close),
   };
 }
 
@@ -155,7 +163,7 @@ function createButton(
   testId: string,
   name: string,
   label: string,
-  onClick: () => void
+  onClick: () => void,
 ): HTMLButtonElement {
   const button = document.createElement("button");
   button.className = "cm-button";
@@ -272,7 +280,7 @@ function createIconButtonElements(
   name: string,
   label: string,
   icon: SearchIconName,
-  onClick: () => void
+  onClick: () => void,
 ): IconButtonElements {
   const wrapper = document.createElement("span");
   wrapper.className = "nexus-search-tooltip-wrap";
@@ -296,7 +304,7 @@ function createIconButton(
   name: string,
   label: string,
   icon: SearchIconName,
-  onClick: () => void
+  onClick: () => void,
 ): HTMLSpanElement {
   const { wrapper } = createIconButtonElements(testId, name, label, icon, onClick);
   return wrapper;
@@ -332,7 +340,7 @@ class NexusSearchPanel implements Panel {
   constructor(
     private readonly view: EditorView,
     readonly top: boolean,
-    labels: Partial<SearchPluginLabels> | undefined
+    labels: Partial<SearchPluginLabels> | undefined,
   ) {
     this.query = getSearchQuery(view.state);
     const resolvedLabels = resolveLabels(view, labels);
@@ -343,18 +351,30 @@ class NexusSearchPanel implements Panel {
       "search",
       resolvedLabels.find,
       this.query.search,
-      true
+      true,
     );
     this.replaceField = this.createTextField(
       "markdown-search-replace-input",
       "replace",
       resolvedLabels.replace,
       this.query.replace,
-      false
+      false,
     );
-    this.caseField = this.createCheckbox("markdown-search-case-toggle", "case", this.query.caseSensitive);
-    this.regexpField = this.createCheckbox("markdown-search-regexp-toggle", "re", this.query.regexp);
-    this.wholeWordField = this.createCheckbox("markdown-search-word-toggle", "word", this.query.wholeWord);
+    this.caseField = this.createCheckbox(
+      "markdown-search-case-toggle",
+      "case",
+      this.query.caseSensitive,
+    );
+    this.regexpField = this.createCheckbox(
+      "markdown-search-regexp-toggle",
+      "re",
+      this.query.regexp,
+    );
+    this.wholeWordField = this.createCheckbox(
+      "markdown-search-word-toggle",
+      "word",
+      this.query.wholeWord,
+    );
 
     this.dom = document.createElement("div");
     this.dom.className = "cm-search nexus-search-panel";
@@ -369,17 +389,21 @@ class NexusSearchPanel implements Panel {
         "toggleReplace",
         resolvedLabels.showReplace,
         "toggleReplace",
-        () => this.setReplaceExpanded(!this.replaceExpanded, true)
+        () => this.setReplaceExpanded(!this.replaceExpanded, true),
       );
     }
     const navigationGroup = document.createElement("div");
     navigationGroup.className = "nexus-search-button-group";
     navigationGroup.append(
       createIconButton("markdown-search-prev", "prev", resolvedLabels.previous, "previous", () =>
-        findPrevious(view)
+        findPrevious(view),
       ),
-      createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () => findNext(view)),
-      createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () => selectMatches(view))
+      createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () =>
+        findNext(view),
+      ),
+      createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () =>
+        selectMatches(view),
+      ),
     );
 
     const searchRowChildren: HTMLElement[] = [
@@ -387,7 +411,7 @@ class NexusSearchPanel implements Panel {
       createLabel(this.caseField, resolvedLabels.matchCase),
       createLabel(this.regexpField, resolvedLabels.regexp),
       createLabel(this.wholeWordField, resolvedLabels.byWord),
-      navigationGroup
+      navigationGroup,
     ];
     if (this.replaceToggle) {
       searchRowChildren.unshift(this.replaceToggle.wrapper);
@@ -404,22 +428,28 @@ class NexusSearchPanel implements Panel {
       this.replaceToggle?.button.setAttribute("aria-expanded", "false");
       replaceRow.append(
         this.replaceField,
-        createIconButton("markdown-search-replace", "replace", resolvedLabels.replaceNext, "replace", () =>
-          replaceNext(view)
+        createIconButton(
+          "markdown-search-replace",
+          "replace",
+          resolvedLabels.replaceNext,
+          "replace",
+          () => replaceNext(view),
         ),
         createIconButton(
           "markdown-search-replace-all",
           "replaceAll",
           resolvedLabels.replaceAll,
           "replaceAll",
-          () => replaceAll(view)
-        )
+          () => replaceAll(view),
+        ),
       );
       this.setReplaceExpanded(false);
       this.dom.append(replaceRow);
     }
 
-    const closeButton = createButton("markdown-search-close", "close", "×", () => closeSearchPanel(view));
+    const closeButton = createButton("markdown-search-close", "close", "×", () =>
+      closeSearchPanel(view),
+    );
     closeButton.setAttribute("aria-label", resolvedLabels.close);
     closeButton.title = resolvedLabels.close;
     this.dom.append(closeButton);
@@ -444,7 +474,7 @@ class NexusSearchPanel implements Panel {
     name: string,
     placeholder: string,
     value: string,
-    mainField: boolean
+    mainField: boolean,
   ): HTMLInputElement {
     const input = document.createElement("input");
     input.className = "cm-textfield";
@@ -480,7 +510,7 @@ class NexusSearchPanel implements Panel {
       caseSensitive: this.caseField.checked,
       regexp: this.regexpField.checked,
       wholeWord: this.wholeWordField.checked,
-      replace: this.replaceField.value
+      replace: this.replaceField.value,
     });
 
     if (!query.eq(this.query)) {
@@ -496,7 +526,10 @@ class NexusSearchPanel implements Panel {
     this.replaceRow.hidden = !expanded;
     this.replaceRow.setAttribute("aria-hidden", String(!expanded));
     this.replaceToggle.button.setAttribute("aria-expanded", String(expanded));
-    setIconButtonLabel(this.replaceToggle, expanded ? this.labels.hideReplace : this.labels.showReplace);
+    setIconButtonLabel(
+      this.replaceToggle,
+      expanded ? this.labels.hideReplace : this.labels.showReplace,
+    );
 
     if (expanded && focusReplace) {
       this.replaceField.focus();
@@ -540,9 +573,9 @@ export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlug
       top: options.top ?? true,
       caseSensitive: options.caseSensitive ?? false,
       literal: true,
-      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels)
+      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels),
     }),
-    keymap.of(searchKeymap)
+    keymap.of(searchKeymap),
   ];
 
   if (options.highlightSelectionMatches ?? true) {
@@ -551,6 +584,6 @@ export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlug
 
   return {
     name: "plugin-search",
-    cmExtensions
+    cmExtensions,
   };
 }

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -1,23 +1,19 @@
-import { describe, expect, it } from "vitest";
 import { createEditor } from "@floatboat/nexus-core";
-import {
-  createSearchPlugin,
-  findSearchMatches,
-  replaceAllMatches
-} from "../src/index";
+import { describe, expect, it } from "vitest";
+import { createSearchPlugin, findSearchMatches, replaceAllMatches } from "../src/index";
 
 describe("@floatboat/nexus-plugin-search", () => {
   it("finds all case-insensitive matches in a document", () => {
     expect(findSearchMatches("Hello hello HELLO", "hello")).toEqual([
       { from: 0, to: 5, text: "Hello" },
       { from: 6, to: 11, text: "hello" },
-      { from: 12, to: 17, text: "HELLO" }
+      { from: 12, to: 17, text: "HELLO" },
     ]);
   });
 
   it("supports case-sensitive search", () => {
     expect(findSearchMatches("Hello hello HELLO", "hello", { caseSensitive: true })).toEqual([
-      { from: 6, to: 11, text: "hello" }
+      { from: 6, to: 11, text: "hello" },
     ]);
   });
 
@@ -42,10 +38,10 @@ describe("@floatboat/nexus-plugin-search", () => {
         createSearchPlugin({
           labels: {
             find: "查找",
-            next: "下一个"
-          }
-        })
-      ]
+            next: "下一个",
+          },
+        }),
+      ],
     });
 
     const content = container.querySelector<HTMLElement>(".cm-content");
@@ -56,8 +52,8 @@ describe("@floatboat/nexus-plugin-search", () => {
         code: "KeyF",
         metaKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
     if (!container.querySelector('[data-test-id="markdown-search-bar"]')) {
       content?.dispatchEvent(
@@ -66,25 +62,33 @@ describe("@floatboat/nexus-plugin-search", () => {
           code: "KeyF",
           ctrlKey: true,
           bubbles: true,
-          cancelable: true
-        })
+          cancelable: true,
+        }),
       );
     }
 
     const panel = container.querySelector<HTMLElement>('[data-test-id="markdown-search-bar"]');
-    const input = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-input"]');
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-test-id="markdown-search-input"]',
+    );
     expect(panel).not.toBeNull();
     expect(input).not.toBeNull();
     expect(input?.placeholder).toBe("查找");
-    const nextButton = container.querySelector<HTMLButtonElement>('[data-test-id="markdown-search-next"]');
-    const nextTooltip = container.querySelector<HTMLElement>('[data-test-id="markdown-search-next-tooltip"]');
+    const nextButton = container.querySelector<HTMLButtonElement>(
+      '[data-test-id="markdown-search-next"]',
+    );
+    const nextTooltip = container.querySelector<HTMLElement>(
+      '[data-test-id="markdown-search-next-tooltip"]',
+    );
     const replaceToggle = container.querySelector<HTMLButtonElement>(
-      '[data-test-id="markdown-search-toggle-replace"]'
+      '[data-test-id="markdown-search-toggle-replace"]',
     );
     const replaceToggleTooltip = container.querySelector<HTMLElement>(
-      '[data-test-id="markdown-search-toggle-replace-tooltip"]'
+      '[data-test-id="markdown-search-toggle-replace-tooltip"]',
     );
-    const replaceRow = container.querySelector<HTMLDivElement>('[data-test-id="markdown-search-replace-row"]');
+    const replaceRow = container.querySelector<HTMLDivElement>(
+      '[data-test-id="markdown-search-replace-row"]',
+    );
     expect(nextButton?.textContent).toBe("");
     expect(nextButton?.title).toBe("");
     expect(nextButton?.getAttribute("aria-label")).toBe("下一个");
@@ -122,7 +126,7 @@ describe("@floatboat/nexus-plugin-search", () => {
     const editor = createEditor({
       container,
       initialValue: "alpha beta alpha",
-      plugins: [createSearchPlugin()]
+      plugins: [createSearchPlugin()],
     });
 
     const content = container.querySelector<HTMLElement>(".cm-content");
@@ -132,8 +136,8 @@ describe("@floatboat/nexus-plugin-search", () => {
         code: "KeyF",
         metaKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
     if (!container.querySelector('[data-test-id="markdown-search-bar"]')) {
       content?.dispatchEvent(
@@ -142,22 +146,24 @@ describe("@floatboat/nexus-plugin-search", () => {
           code: "KeyF",
           ctrlKey: true,
           bubbles: true,
-          cancelable: true
-        })
+          cancelable: true,
+        }),
       );
     }
 
-    const input = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-input"]');
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-test-id="markdown-search-input"]',
+    );
     expect(input).not.toBeNull();
     input!.value = "beta";
-    input!.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
-    input!.dispatchEvent(
+    input?.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+    input?.dispatchEvent(
       new KeyboardEvent("keydown", {
         key: "Enter",
         code: "Enter",
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
 
     const selection = editor.getSelection();
@@ -178,10 +184,10 @@ describe("@floatboat/nexus-plugin-search", () => {
         createSearchPlugin({
           labels: {
             replaceNext: "",
-            replaceAll: " "
-          }
-        })
-      ]
+            replaceAll: " ",
+          },
+        }),
+      ],
     });
 
     const content = container.querySelector<HTMLElement>(".cm-content");
@@ -191,8 +197,8 @@ describe("@floatboat/nexus-plugin-search", () => {
         code: "KeyF",
         metaKey: true,
         bubbles: true,
-        cancelable: true
-      })
+        cancelable: true,
+      }),
     );
     if (!container.querySelector('[data-test-id="markdown-search-bar"]')) {
       content?.dispatchEvent(
@@ -201,16 +207,22 @@ describe("@floatboat/nexus-plugin-search", () => {
           code: "KeyF",
           ctrlKey: true,
           bubbles: true,
-          cancelable: true
-        })
+          cancelable: true,
+        }),
       );
     }
 
-    const replaceButton = container.querySelector<HTMLButtonElement>('[data-test-id="markdown-search-replace"]');
-    const replaceTooltip = container.querySelector<HTMLElement>('[data-test-id="markdown-search-replace-tooltip"]');
-    const replaceAllButton = container.querySelector<HTMLButtonElement>('[data-test-id="markdown-search-replace-all"]');
+    const replaceButton = container.querySelector<HTMLButtonElement>(
+      '[data-test-id="markdown-search-replace"]',
+    );
+    const replaceTooltip = container.querySelector<HTMLElement>(
+      '[data-test-id="markdown-search-replace-tooltip"]',
+    );
+    const replaceAllButton = container.querySelector<HTMLButtonElement>(
+      '[data-test-id="markdown-search-replace-all"]',
+    );
     const replaceAllTooltip = container.querySelector<HTMLElement>(
-      '[data-test-id="markdown-search-replace-all-tooltip"]'
+      '[data-test-id="markdown-search-replace-all-tooltip"]',
     );
     expect(replaceButton?.getAttribute("aria-label")).toBe("Replace");
     expect(replaceTooltip?.textContent).toBe("Replace");

--- a/packages/plugin-slash/package.json
+++ b/packages/plugin-slash/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/plugin-slash/src/index.ts
+++ b/packages/plugin-slash/src/index.ts
@@ -1,10 +1,10 @@
 import {
-  computeSlashState,
-  filterSlashCommands,
-  getSlashMatch,
   type SlashMatch,
   type SlashStateOptions,
   type SlashStateResult,
+  computeSlashState,
+  filterSlashCommands,
+  getSlashMatch,
 } from "@floatboat/nexus-core";
 import type { NexusPlugin, SlashCommandDef } from "@floatboat/nexus-core";
 
@@ -21,7 +21,7 @@ export function getSlashState(
   doc: string,
   cursor: number,
   commands: SlashCommandDef[],
-  options?: SlashStateOptions
+  options?: SlashStateOptions,
 ): SlashStateResult {
   return computeSlashState(doc, cursor, commands, options);
 }

--- a/packages/plugin-slash/src/menu-ui.ts
+++ b/packages/plugin-slash/src/menu-ui.ts
@@ -13,7 +13,7 @@ export interface SlashMenuCommandContext {
 
 export type SlashMenuCommandHandler = (
   command: SlashCommandDef,
-  context: SlashMenuCommandContext
+  context: SlashMenuCommandContext,
 ) => void;
 
 export interface SlashMenuUIOptions {
@@ -67,7 +67,7 @@ function generateId(prefix: string): string {
 
 export function createSlashMenuUI(
   editor: EditorAPI,
-  options: SlashMenuUIOptions = {}
+  options: SlashMenuUIOptions = {},
 ): SlashMenuUI {
   const prefix = options.classPrefix ?? DEFAULT_PREFIX;
   const offset = options.offset ?? DEFAULT_OFFSET;

--- a/packages/plugin-slash/test/menu-ui.test.ts
+++ b/packages/plugin-slash/test/menu-ui.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createEditor, type EditorAPI, type SlashCommandDef } from "@floatboat/nexus-core";
-import { createSlashMenuUI, type SlashMenuUI } from "../src/menu-ui";
+import { type EditorAPI, type SlashCommandDef, createEditor } from "@floatboat/nexus-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type SlashMenuUI, createSlashMenuUI } from "../src/menu-ui";
 
 const PREFIX = "nexus-slash";
 
@@ -13,7 +13,7 @@ interface Harness {
 
 function setup(
   commands: SlashCommandDef[],
-  options: Parameters<typeof createSlashMenuUI>[1] = {}
+  options: Parameters<typeof createSlashMenuUI>[1] = {},
 ): Harness {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -46,9 +46,7 @@ function open(editor: EditorAPI, query: string): void {
 }
 
 function items(menu: SlashMenuUI): HTMLElement[] {
-  return Array.from(
-    menu.element.querySelectorAll<HTMLElement>(`.${PREFIX}-menu__item`)
-  );
+  return Array.from(menu.element.querySelectorAll<HTMLElement>(`.${PREFIX}-menu__item`));
 }
 
 function activeItem(menu: SlashMenuUI): HTMLElement | null {
@@ -89,9 +87,7 @@ describe("createSlashMenuUI lifecycle", () => {
     open(h.editor, "zzz");
     expect(h.menu.element.style.display).toBe("block");
     expect(items(h.menu)).toHaveLength(0);
-    expect(h.menu.element.querySelector(`.${PREFIX}-menu__empty`)?.textContent).toBe(
-      "No matches"
-    );
+    expect(h.menu.element.querySelector(`.${PREFIX}-menu__empty`)?.textContent).toBe("No matches");
   });
 
   it("hides when the trigger disappears", () => {
@@ -152,15 +148,13 @@ describe("createSlashMenuUI rendering", () => {
     ]);
     open(h.editor, "");
     const [withDesc, noDesc] = items(h.menu);
-    expect(withDesc.querySelector(`.${PREFIX}-menu__title`)?.textContent).toBe(
-      "Has description"
-    );
+    expect(withDesc.querySelector(`.${PREFIX}-menu__title`)?.textContent).toBe("Has description");
     expect(withDesc.querySelector<HTMLElement>(`.${PREFIX}-menu__description`)?.textContent).toBe(
-      "Useful note"
+      "Useful note",
     );
-    expect(
-      noDesc.querySelector<HTMLElement>(`.${PREFIX}-menu__description`)?.style.display
-    ).toBe("none");
+    expect(noDesc.querySelector<HTMLElement>(`.${PREFIX}-menu__description`)?.style.display).toBe(
+      "none",
+    );
   });
 
   it("clamps the highlight when the command list shrinks below it", () => {
@@ -322,7 +316,9 @@ describe("createSlashMenuUI document interactions", () => {
   it("ignores mousedown inside the menu element", () => {
     h = setup(baseCommands);
     open(h.editor, "");
-    items(h.menu)[0].dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    items(h.menu)[0].dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
     expect(h.menu.element.style.display).toBe("block");
   });
 

--- a/packages/plugin-slash/test/plugin-slash.test.ts
+++ b/packages/plugin-slash/test/plugin-slash.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  createSlashPlugin,
-  filterSlashCommands,
-  getSlashState,
-  getSlashMatch
-} from "../src/index";
+import { createSlashPlugin, filterSlashCommands, getSlashMatch, getSlashState } from "../src/index";
 
 describe("@floatboat/nexus-plugin-slash", () => {
   it("detects a slash query at the cursor position", () => {
@@ -13,7 +8,7 @@ describe("@floatboat/nexus-plugin-slash", () => {
     expect(getSlashMatch(doc, doc.length)).toEqual({
       from: 7,
       to: 11,
-      query: "hea"
+      query: "hea",
     });
   });
 
@@ -26,12 +21,10 @@ describe("@floatboat/nexus-plugin-slash", () => {
   it("filters slash commands by title and keywords", () => {
     const commands = [
       { id: "heading", title: "Heading", keywords: ["title", "h1"] },
-      { id: "table", title: "Table", keywords: ["grid"] }
+      { id: "table", title: "Table", keywords: ["grid"] },
     ];
 
-    expect(filterSlashCommands(commands, "tit").map((command) => command.id)).toEqual([
-      "heading"
-    ]);
+    expect(filterSlashCommands(commands, "tit").map((command) => command.id)).toEqual(["heading"]);
     expect(filterSlashCommands(commands, "grid").map((command) => command.id)).toEqual(["table"]);
   });
 
@@ -46,7 +39,7 @@ describe("@floatboat/nexus-plugin-slash", () => {
   it("derives slash menu state with filtered commands", () => {
     const commands = [
       { id: "heading", title: "Heading", keywords: ["title"] },
-      { id: "table", title: "Table", keywords: ["grid"] }
+      { id: "table", title: "Table", keywords: ["grid"] },
     ];
     const doc = "/tit";
 
@@ -55,7 +48,7 @@ describe("@floatboat/nexus-plugin-slash", () => {
       from: 0,
       to: 4,
       query: "tit",
-      commands: [{ id: "heading", title: "Heading", keywords: ["title"] }]
+      commands: [{ id: "heading", title: "Heading", keywords: ["title"] }],
     });
   });
 
@@ -65,26 +58,23 @@ describe("@floatboat/nexus-plugin-slash", () => {
       from: null,
       to: null,
       query: "",
-      commands: []
+      commands: [],
     });
   });
 
   it("ranks title-prefix matches above keyword-only matches", () => {
     const commands = [
       { id: "highlight", title: "Highlight" },
-      { id: "heading", title: "Heading", keywords: ["h1"] }
+      { id: "heading", title: "Heading", keywords: ["h1"] },
     ];
     // Title prefix tier; "Heading" (7 chars) wins over "Highlight" (9 chars).
-    expect(filterSlashCommands(commands, "h").map((c) => c.id)).toEqual([
-      "heading",
-      "highlight"
-    ]);
+    expect(filterSlashCommands(commands, "h").map((c) => c.id)).toEqual(["heading", "highlight"]);
   });
 
   it("propagates limit through getSlashState", () => {
     const commands = Array.from({ length: 10 }, (_, i) => ({
       id: `cmd-${i}`,
-      title: `Command ${i}`
+      title: `Command ${i}`,
     }));
     const state = getSlashState("/com", 4, commands, { limit: 2 });
     expect(state.commands).toHaveLength(2);
@@ -92,10 +82,7 @@ describe("@floatboat/nexus-plugin-slash", () => {
 
   it("preserves an optional run callback through filterSlashCommands", () => {
     const run = () => true;
-    const filtered = filterSlashCommands(
-      [{ id: "h1", title: "Heading 1", run }],
-      "head"
-    );
+    const filtered = filterSlashCommands([{ id: "h1", title: "Heading 1", run }], "head");
     expect(filtered[0].run).toBe(run);
   });
 });

--- a/packages/plugin-toolbar/package.json
+++ b/packages/plugin-toolbar/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/plugin-toolbar/src/color-decoration.ts
+++ b/packages/plugin-toolbar/src/color-decoration.ts
@@ -7,21 +7,19 @@
  *   <mark style="background:#ffff00">text</mark>
  */
 
-import { type Extension } from "@codemirror/state";
+import type { Extension } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
-  EditorView,
+  type EditorView,
   ViewPlugin,
   type ViewUpdate,
   WidgetType,
 } from "@codemirror/view";
 
 // Matches <span style="color:...">...</span> and <mark style="background:...">...</mark>
-const COLOR_RE =
-  /<span\s+style="color:\s*([^"]+)">([\s\S]*?)<\/span>/g;
-const HIGHLIGHT_RE =
-  /<mark\s+style="background:\s*([^"]+)">([\s\S]*?)<\/mark>/g;
+const COLOR_RE = /<span\s+style="color:\s*([^"]+)">([\s\S]*?)<\/span>/g;
+const HIGHLIGHT_RE = /<mark\s+style="background:\s*([^"]+)">([\s\S]*?)<\/mark>/g;
 
 /** Zero-width widget used to replace opening/closing tags (hides them). */
 class HiddenTagWidget extends WidgetType {
@@ -30,7 +28,9 @@ class HiddenTagWidget extends WidgetType {
     el.style.display = "none";
     return el;
   }
-  ignoreEvent(): boolean { return false; }
+  ignoreEvent(): boolean {
+    return false;
+  }
 }
 
 const hiddenWidget = Decoration.replace({ widget: new HiddenTagWidget() });
@@ -55,6 +55,7 @@ function findColorRanges(doc: string): ColorRange[] {
 
   COLOR_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard RegExp loop idiom
   while ((m = COLOR_RE.exec(doc)) !== null) {
     const from = m.index;
     const openTag = `<span style="color:${m[1]}">`;
@@ -70,6 +71,7 @@ function findColorRanges(doc: string): ColorRange[] {
   }
 
   HIGHLIGHT_RE.lastIndex = 0;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard RegExp loop idiom
   while ((m = HIGHLIGHT_RE.exec(doc)) !== null) {
     const from = m.index;
     const openTag = `<mark style="background:${m[1]}">`;
@@ -111,7 +113,9 @@ function buildDecorations(view: EditorView): DecorationSet {
     const markDeco =
       r.kind === "color"
         ? Decoration.mark({ attributes: { style: `color:${r.color}` } })
-        : Decoration.mark({ attributes: { style: `background:${r.color};border-radius:2px;padding:0 1px` } });
+        : Decoration.mark({
+            attributes: { style: `background:${r.color};border-radius:2px;padding:0 1px` },
+          });
     decorations.push({ from: r.innerFrom, to: r.innerTo, value: markDeco });
 
     // Hide closing tag

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -1,7 +1,10 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
 
 /** Get the current line containing the anchor position. */
-function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineEnd: number; line: string } {
+function getCurrentLine(
+  doc: string,
+  anchor: number,
+): { lineStart: number; lineEnd: number; line: string } {
   const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
   const lineEndIdx = doc.indexOf("\n", anchor);
   const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
@@ -44,7 +47,7 @@ export function toggleOrderedList(editor: EditorAPI): boolean {
     // Remove other list markers if present
     const ulMatch = line.match(/^[-*+]\s/);
     const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
+    newLine = `1. ${content}`;
   }
 
   const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
@@ -66,7 +69,7 @@ export function toggleUnorderedList(editor: EditorAPI): boolean {
     // Remove ordered list marker if present
     const olMatch = line.match(/^\d+\.\s/);
     const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
+    newLine = `- ${content}`;
   }
 
   const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
@@ -85,10 +88,7 @@ export function insertCodeBlock(editor: EditorAPI): boolean {
   const needsLeadingNewline = from > 0 && doc[from - 1] !== "\n";
   const needsTrailingNewline = to < doc.length && doc[to] !== "\n";
 
-  const block =
-    (needsLeadingNewline ? "\n" : "") +
-    "```\n" + (selected || "") + "\n```" +
-    (needsTrailingNewline ? "\n" : "");
+  const block = `${needsLeadingNewline ? "\n" : ""}\`\`\`\n${selected || ""}\n\`\`\`${needsTrailingNewline ? "\n" : ""}`;
 
   const newDoc = doc.slice(0, from) + block + doc.slice(to);
   editor.setDocument(newDoc);
@@ -156,7 +156,7 @@ export function insertHorizontalRule(editor: EditorAPI): boolean {
   const { anchor } = editor.getSelection();
 
   const needsLeadingNewline = anchor > 0 && doc[anchor - 1] !== "\n";
-  const hr = (needsLeadingNewline ? "\n" : "") + "---\n";
+  const hr = `${needsLeadingNewline ? "\n" : ""}---\n`;
 
   const newDoc = doc.slice(0, anchor) + hr + doc.slice(anchor);
   editor.setDocument(newDoc);

--- a/packages/plugin-toolbar/src/icons.ts
+++ b/packages/plugin-toolbar/src/icons.ts
@@ -10,11 +10,9 @@ const SVG_SIZE = 18;
 
 function svgIcon(paths: string): HTMLElement {
   const wrap = document.createElement("span");
-  wrap.style.cssText = "display:flex;align-items:center;justify-content:center;width:18px;height:18px;";
-  wrap.innerHTML =
-    `<svg width="${SVG_SIZE}" height="${SVG_SIZE}" viewBox="0 0 ${SVG_SIZE} ${SVG_SIZE}" ` +
-    `fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">` +
-    paths + `</svg>`;
+  wrap.style.cssText =
+    "display:flex;align-items:center;justify-content:center;width:18px;height:18px;";
+  wrap.innerHTML = `<svg width="${SVG_SIZE}" height="${SVG_SIZE}" viewBox="0 0 ${SVG_SIZE} ${SVG_SIZE}" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`;
   return wrap;
 }
 
@@ -28,24 +26,15 @@ function textLabel(text: string, extra = ""): HTMLElement {
 // --- exports ---
 
 export function iconUndo(): HTMLElement {
-  return svgIcon(
-    `<path d="M4 7h8a4 4 0 0 1 0 8H11"/>` +
-    `<polyline points="7 4 4 7 7 10"/>`
-  );
+  return svgIcon(`<path d="M4 7h8a4 4 0 0 1 0 8H11"/>` + `<polyline points="7 4 4 7 7 10"/>`);
 }
 
 export function iconRedo(): HTMLElement {
-  return svgIcon(
-    `<path d="M14 7H6a4 4 0 0 0 0 8h1"/>` +
-    `<polyline points="11 4 14 7 11 10"/>`
-  );
+  return svgIcon(`<path d="M14 7H6a4 4 0 0 0 0 8h1"/>` + `<polyline points="11 4 14 7 11 10"/>`);
 }
 
 export function iconLink(): HTMLElement {
-  return svgIcon(
-    `<path d="M10 6H7a3 3 0 0 0 0 6h1"/>` +
-    `<path d="M8 12h4a3 3 0 0 0 0-6h-1"/>`
-  );
+  return svgIcon(`<path d="M10 6H7a3 3 0 0 0 0 6h1"/>` + `<path d="M8 12h4a3 3 0 0 0 0-6h-1"/>`);
 }
 
 export function iconH2(): HTMLElement {
@@ -58,12 +47,14 @@ export function iconH3(): HTMLElement {
 
 export function iconHeadingMenu(): HTMLElement {
   const wrap = document.createElement("span");
-  wrap.style.cssText = "display:inline-flex;align-items:baseline;gap:2px;font-family:system-ui,-apple-system,sans-serif;";
+  wrap.style.cssText =
+    "display:inline-flex;align-items:baseline;gap:2px;font-family:system-ui,-apple-system,sans-serif;";
   const t = document.createElement("span");
   t.textContent = "Hn";
   t.style.cssText = "font-size:11px;font-weight:600;line-height:1;";
   const dot = document.createElement("span");
-  dot.style.cssText = "width:3px;height:3px;border-radius:50%;background:currentColor;flex-shrink:0;margin-bottom:1px;";
+  dot.style.cssText =
+    "width:3px;height:3px;border-radius:50%;background:currentColor;flex-shrink:0;margin-bottom:1px;";
   wrap.append(t, dot);
   return wrap;
 }
@@ -85,46 +76,43 @@ export function iconUnderline(): HTMLElement {
 }
 
 export function iconInlineCode(): HTMLElement {
-  return svgIcon(
-    `<polyline points="6 5 2 9 6 13"/>` +
-    `<polyline points="12 5 16 9 12 13"/>`
-  );
+  return svgIcon(`<polyline points="6 5 2 9 6 13"/>` + `<polyline points="12 5 16 9 12 13"/>`);
 }
 
 export function iconBlockquote(): HTMLElement {
   return svgIcon(
     `<path d="M3 6h4l-1 4H4a2 2 0 0 1 2 2" fill="none"/>` +
-    `<path d="M11 6h4l-1 4h-2a2 2 0 0 1 2 2" fill="none"/>`
+      `<path d="M11 6h4l-1 4h-2a2 2 0 0 1 2 2" fill="none"/>`,
   );
 }
 
 export function iconCodeBlock(): HTMLElement {
   return svgIcon(
     `<rect x="2" y="2" width="14" height="14" rx="2"/>` +
-    `<polyline points="6 6 4 9 6 12"/>` +
-    `<polyline points="12 6 14 9 12 12"/>`
+      `<polyline points="6 6 4 9 6 12"/>` +
+      `<polyline points="12 6 14 9 12 12"/>`,
   );
 }
 
 export function iconOrderedList(): HTMLElement {
   return svgIcon(
     `<line x1="8" y1="4" x2="16" y2="4"/>` +
-    `<line x1="8" y1="9" x2="16" y2="9"/>` +
-    `<line x1="8" y1="14" x2="16" y2="14"/>` +
-    `<text x="3.5" y="6" fill="currentColor" stroke="none" font-size="6" font-family="system-ui" text-anchor="middle">1</text>` +
-    `<text x="3.5" y="11" fill="currentColor" stroke="none" font-size="6" font-family="system-ui" text-anchor="middle">2</text>` +
-    `<text x="3.5" y="16" fill="currentColor" stroke="none" font-size="6" font-family="system-ui" text-anchor="middle">3</text>`
+      `<line x1="8" y1="9" x2="16" y2="9"/>` +
+      `<line x1="8" y1="14" x2="16" y2="14"/>` +
+      `<text x="3.5" y="6" fill="currentColor" stroke="none" font-size="6" font-family="system-ui" text-anchor="middle">1</text>` +
+      `<text x="3.5" y="11" fill="currentColor" stroke="none" font-size="6" font-family="system-ui" text-anchor="middle">2</text>` +
+      `<text x="3.5" y="16" fill="currentColor" stroke="none" font-size="6" font-family="system-ui" text-anchor="middle">3</text>`,
   );
 }
 
 export function iconUnorderedList(): HTMLElement {
   return svgIcon(
     `<line x1="8" y1="4" x2="16" y2="4"/>` +
-    `<line x1="8" y1="9" x2="16" y2="9"/>` +
-    `<line x1="8" y1="14" x2="16" y2="14"/>` +
-    `<circle cx="3.5" cy="4" r="1.5" fill="currentColor" stroke="none"/>` +
-    `<circle cx="3.5" cy="9" r="1.5" fill="currentColor" stroke="none"/>` +
-    `<circle cx="3.5" cy="14" r="1.5" fill="currentColor" stroke="none"/>`
+      `<line x1="8" y1="9" x2="16" y2="9"/>` +
+      `<line x1="8" y1="14" x2="16" y2="14"/>` +
+      `<circle cx="3.5" cy="4" r="1.5" fill="currentColor" stroke="none"/>` +
+      `<circle cx="3.5" cy="9" r="1.5" fill="currentColor" stroke="none"/>` +
+      `<circle cx="3.5" cy="14" r="1.5" fill="currentColor" stroke="none"/>`,
   );
 }
 
@@ -133,21 +121,26 @@ export function iconTextColor(): HTMLElement {
   wrap.style.cssText = "display:inline-flex;flex-direction:column;align-items:center;gap:1px;";
   const a = document.createElement("span");
   a.textContent = "A";
-  a.style.cssText = "font-family:system-ui,-apple-system,sans-serif;font-size:13px;font-weight:600;line-height:1;";
+  a.style.cssText =
+    "font-family:system-ui,-apple-system,sans-serif;font-size:13px;font-weight:600;line-height:1;";
   const bar = document.createElement("span");
-  bar.style.cssText = "width:12px;height:2px;border-radius:1px;background:var(--nexus-accent,#0969da);";
+  bar.style.cssText =
+    "width:12px;height:2px;border-radius:1px;background:var(--nexus-accent,#0969da);";
   wrap.append(a, bar);
   return wrap;
 }
 
 export function iconHighlight(): HTMLElement {
   const wrap = document.createElement("span");
-  wrap.style.cssText = "display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;position:relative;";
+  wrap.style.cssText =
+    "display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;position:relative;";
   const bg = document.createElement("span");
-  bg.style.cssText = "position:absolute;inset:2px;border-radius:2px;background:var(--nexus-accent,#0969da);opacity:0.15;";
+  bg.style.cssText =
+    "position:absolute;inset:2px;border-radius:2px;background:var(--nexus-accent,#0969da);opacity:0.15;";
   const a = document.createElement("span");
   a.textContent = "A";
-  a.style.cssText = "position:relative;font-family:system-ui,-apple-system,sans-serif;font-size:13px;font-weight:600;line-height:1;";
+  a.style.cssText =
+    "position:relative;font-family:system-ui,-apple-system,sans-serif;font-size:13px;font-weight:600;line-height:1;";
   wrap.append(bg, a);
   return wrap;
 }
@@ -155,22 +148,20 @@ export function iconHighlight(): HTMLElement {
 export function iconImage(): HTMLElement {
   return svgIcon(
     `<rect x="2" y="3" width="14" height="12" rx="2"/>` +
-    `<circle cx="6" cy="7" r="1.5" fill="currentColor" stroke="none"/>` +
-    `<path d="M2 12l4-4 3 3 2-2 5 5" fill="none" stroke-width="1.5"/>`
+      `<circle cx="6" cy="7" r="1.5" fill="currentColor" stroke="none"/>` +
+      `<path d="M2 12l4-4 3 3 2-2 5 5" fill="none" stroke-width="1.5"/>`,
   );
 }
 
 export function iconFullscreen(): HTMLElement {
   return svgIcon(
     `<polyline points="4 7 4 4 7 4"/>` +
-    `<polyline points="14 7 14 4 11 4"/>` +
-    `<polyline points="4 11 4 14 7 14"/>` +
-    `<polyline points="14 11 14 14 11 14"/>`
+      `<polyline points="14 7 14 4 11 4"/>` +
+      `<polyline points="4 11 4 14 7 14"/>` +
+      `<polyline points="14 11 14 14 11 14"/>`,
   );
 }
 
 export function iconHorizontalRule(): HTMLElement {
-  return svgIcon(
-    `<line x1="2" y1="9" x2="16" y2="9"/>`
-  );
+  return svgIcon(`<line x1="2" y1="9" x2="16" y2="9"/>`);
 }

--- a/packages/plugin-toolbar/src/index.ts
+++ b/packages/plugin-toolbar/src/index.ts
@@ -9,7 +9,16 @@ import {
   toggleUnorderedList,
 } from "./formatting";
 
-export { toggleBlockquote, toggleOrderedList, toggleUnorderedList, insertCodeBlock, insertImage, insertHorizontalRule, applyTextColor, applyHighlight } from "./formatting";
+export {
+  toggleBlockquote,
+  toggleOrderedList,
+  toggleUnorderedList,
+  insertCodeBlock,
+  insertImage,
+  insertHorizontalRule,
+  applyTextColor,
+  applyHighlight,
+} from "./formatting";
 export { createToolbarUI } from "./toolbar-ui";
 export { colorDecorationExtension } from "./color-decoration";
 export type { ToolbarUI, ToolbarUIOptions, ToolbarButton, ToolbarGroup } from "./toolbar-ui";
@@ -26,18 +35,14 @@ export function toggleWrap(editor: EditorAPI, marker: string): boolean {
 
   if (before === marker && after === marker) {
     // Already wrapped — remove markers
-    const newDoc =
-      doc.slice(0, from - marker.length) +
-      selected +
-      doc.slice(to + marker.length);
+    const newDoc = doc.slice(0, from - marker.length) + selected + doc.slice(to + marker.length);
     editor.setDocument(newDoc);
     editor.setSelection(from - marker.length, to - marker.length);
     return true;
   }
 
   // Wrap selection with markers
-  const newDoc =
-    doc.slice(0, from) + marker + selected + marker + doc.slice(to);
+  const newDoc = doc.slice(0, from) + marker + selected + marker + doc.slice(to);
   editor.setDocument(newDoc);
   editor.setSelection(from + marker.length, to + marker.length);
   return true;
@@ -85,7 +90,7 @@ export function toggleHeading(editor: EditorAPI, level: number): boolean {
   const end = lineEnd === -1 ? doc.length : lineEnd;
   const line = doc.slice(lineStart, end);
 
-  const prefix = "#".repeat(level) + " ";
+  const prefix = `${"#".repeat(level)} `;
   const headingMatch = line.match(/^#{1,6}\s/);
 
   let newLine: string;

--- a/packages/plugin-toolbar/src/toolbar-ui.ts
+++ b/packages/plugin-toolbar/src/toolbar-ui.ts
@@ -1,44 +1,44 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
 
 import {
-  toggleBold,
-  toggleItalic,
-  toggleStrikethrough,
-  toggleInlineCode,
-  insertLink,
-  toggleHeading,
-  toggleWrap,
-} from "./index";
-import {
+  applyHighlight,
+  applyTextColor,
+  insertCodeBlock,
+  insertImage,
   toggleBlockquote,
   toggleOrderedList,
   toggleUnorderedList,
-  insertCodeBlock,
-  insertImage,
-  applyTextColor,
-  applyHighlight,
 } from "./formatting";
 import {
-  iconUndo,
-  iconRedo,
-  iconLink,
+  iconBlockquote,
+  iconBold,
+  iconCodeBlock,
+  iconFullscreen,
   iconH2,
   iconH3,
   iconHeadingMenu,
-  iconBold,
-  iconItalic,
-  iconStrikethrough,
-  iconUnderline,
-  iconInlineCode,
-  iconBlockquote,
-  iconCodeBlock,
-  iconOrderedList,
-  iconUnorderedList,
-  iconTextColor,
   iconHighlight,
   iconImage,
-  iconFullscreen,
+  iconInlineCode,
+  iconItalic,
+  iconLink,
+  iconOrderedList,
+  iconRedo,
+  iconStrikethrough,
+  iconTextColor,
+  iconUnderline,
+  iconUndo,
+  iconUnorderedList,
 } from "./icons";
+import {
+  insertLink,
+  toggleBold,
+  toggleHeading,
+  toggleInlineCode,
+  toggleItalic,
+  toggleStrikethrough,
+  toggleWrap,
+} from "./index";
 
 export interface ToolbarButton {
   id: string;
@@ -141,9 +141,7 @@ function defaultGroups(options?: ToolbarUIOptions): ToolbarGroup[] {
       ],
     },
     {
-      buttons: [
-        { id: "link", title: "Insert link", icon: iconLink, action: insertLink },
-      ],
+      buttons: [{ id: "link", title: "Insert link", icon: iconLink, action: insertLink }],
     },
     {
       buttons: [
@@ -156,8 +154,18 @@ function defaultGroups(options?: ToolbarUIOptions): ToolbarGroup[] {
       buttons: [
         { id: "bold", title: "Bold", icon: iconBold, action: toggleBold },
         { id: "italic", title: "Italic", icon: iconItalic, action: toggleItalic },
-        { id: "strikethrough", title: "Strikethrough", icon: iconStrikethrough, action: toggleStrikethrough },
-        { id: "underline", title: "Underline", icon: iconUnderline, action: (e) => toggleWrap(e, "<u>") },
+        {
+          id: "strikethrough",
+          title: "Strikethrough",
+          icon: iconStrikethrough,
+          action: toggleStrikethrough,
+        },
+        {
+          id: "underline",
+          title: "Underline",
+          icon: iconUnderline,
+          action: (e) => toggleWrap(e, "<u>"),
+        },
         { id: "inline-code", title: "Inline code", icon: iconInlineCode, action: toggleInlineCode },
       ],
     },
@@ -169,8 +177,18 @@ function defaultGroups(options?: ToolbarUIOptions): ToolbarGroup[] {
     },
     {
       buttons: [
-        { id: "ordered-list", title: "Ordered list", icon: iconOrderedList, action: toggleOrderedList },
-        { id: "unordered-list", title: "Unordered list", icon: iconUnorderedList, action: toggleUnorderedList },
+        {
+          id: "ordered-list",
+          title: "Ordered list",
+          icon: iconOrderedList,
+          action: toggleOrderedList,
+        },
+        {
+          id: "unordered-list",
+          title: "Unordered list",
+          icon: iconUnorderedList,
+          action: toggleUnorderedList,
+        },
       ],
     },
     {
@@ -182,7 +200,12 @@ function defaultGroups(options?: ToolbarUIOptions): ToolbarGroup[] {
     {
       buttons: [
         { id: "image", title: "Insert image", icon: iconImage, action: insertImage },
-        { id: "fullscreen", title: "Fullscreen", icon: iconFullscreen, action: () => options?.onFullscreen?.() },
+        {
+          id: "fullscreen",
+          title: "Fullscreen",
+          icon: iconFullscreen,
+          action: () => options?.onFullscreen?.(),
+        },
       ],
     },
   ];
@@ -264,8 +287,8 @@ function showHeadingDropdown(
 
   // Position below the anchor button
   const rect = anchorBtn.getBoundingClientRect();
-  menu.style.top = rect.bottom + 4 + "px";
-  menu.style.left = rect.left + "px";
+  menu.style.top = `${rect.bottom + 4}px`;
+  menu.style.left = `${rect.left}px`;
 
   const levels = [
     { level: 1, label: "Heading 1", fontSize: "17px", fontWeight: "700" },
@@ -311,8 +334,12 @@ function showHeadingDropdown(
       onClose();
     };
 
-    const handleEnter = () => { item.style.background = "var(--nexus-bg-muted, #f0f0f0)"; };
-    const handleLeave = () => { item.style.background = "transparent"; };
+    const handleEnter = () => {
+      item.style.background = "var(--nexus-bg-muted, #f0f0f0)";
+    };
+    const handleLeave = () => {
+      item.style.background = "transparent";
+    };
 
     item.addEventListener("click", handleClick);
     item.addEventListener("mouseenter", handleEnter);
@@ -339,20 +366,72 @@ function showHeadingDropdown(
 
 const COLOR_PALETTE = [
   // row 1: grays + black/white
-  "#000000", "#434343", "#666666", "#999999", "#b7b7b7", "#cccccc", "#d9d9d9", "#efefef", "#f3f3f3", "#ffffff",
+  "#000000",
+  "#434343",
+  "#666666",
+  "#999999",
+  "#b7b7b7",
+  "#cccccc",
+  "#d9d9d9",
+  "#efefef",
+  "#f3f3f3",
+  "#ffffff",
   // row 2: saturated
-  "#ff0000", "#ff9900", "#ffff00", "#00ff00", "#00ffff", "#0000ff", "#9900ff", "#ff00ff", "#f4cccc", "#fce5cd",
+  "#ff0000",
+  "#ff9900",
+  "#ffff00",
+  "#00ff00",
+  "#00ffff",
+  "#0000ff",
+  "#9900ff",
+  "#ff00ff",
+  "#f4cccc",
+  "#fce5cd",
   // row 3: muted
-  "#ea4335", "#ff6d01", "#fbbc04", "#34a853", "#46bdc6", "#4285f4", "#a142f4", "#ff6d9b", "#e06666", "#f6b26b",
+  "#ea4335",
+  "#ff6d01",
+  "#fbbc04",
+  "#34a853",
+  "#46bdc6",
+  "#4285f4",
+  "#a142f4",
+  "#ff6d9b",
+  "#e06666",
+  "#f6b26b",
   // row 4: dark
-  "#cc0000", "#e69138", "#f1c232", "#6aa84f", "#45818e", "#3c78d8", "#674ea7", "#a64d79", "#990000", "#783f04",
+  "#cc0000",
+  "#e69138",
+  "#f1c232",
+  "#6aa84f",
+  "#45818e",
+  "#3c78d8",
+  "#674ea7",
+  "#a64d79",
+  "#990000",
+  "#783f04",
 ];
 
 const HIGHLIGHT_PALETTE = [
-  "#ffff00", "#00ff00", "#00ffff", "#ff9900", "#ff00ff",
-  "#fce5cd", "#d9ead3", "#d0e0e3", "#cfe2f3", "#d9d2e9",
-  "#fff2cc", "#b6d7a8", "#a2c4c9", "#9fc5e8", "#b4a7d6",
-  "#f4cccc", "#ea9999", "#e6b8af", "#dd7e6b", "#cc4125",
+  "#ffff00",
+  "#00ff00",
+  "#00ffff",
+  "#ff9900",
+  "#ff00ff",
+  "#fce5cd",
+  "#d9ead3",
+  "#d0e0e3",
+  "#cfe2f3",
+  "#d9d2e9",
+  "#fff2cc",
+  "#b6d7a8",
+  "#a2c4c9",
+  "#9fc5e8",
+  "#b4a7d6",
+  "#f4cccc",
+  "#ea9999",
+  "#e6b8af",
+  "#dd7e6b",
+  "#cc4125",
 ];
 
 const COLOR_GRID_STYLES = `
@@ -377,8 +456,8 @@ function showColorPicker(
   panel.style.cssText = COLOR_GRID_STYLES;
 
   const rect = anchorBtn.getBoundingClientRect();
-  panel.style.top = rect.bottom + 4 + "px";
-  panel.style.left = rect.left + "px";
+  panel.style.top = `${rect.bottom + 4}px`;
+  panel.style.left = `${rect.left}px`;
 
   const cols = palette.length <= 20 ? 5 : 10;
   const grid = document.createElement("div");
@@ -502,19 +581,37 @@ export function createToolbarUI(editor: EditorAPI, options?: ToolbarUIOptions): 
           e.preventDefault();
           e.stopPropagation();
 
-          if (activeDropdown) { closeDropdown(); return; }
+          if (activeDropdown) {
+            closeDropdown();
+            return;
+          }
 
           if (btn.id === "heading-menu") {
             activeDropdown = showHeadingDropdown(editor, button, closeDropdown);
           } else if (btn.id === "text-color") {
-            activeDropdown = showColorPicker(editor, button, COLOR_PALETTE, applyTextColor, closeDropdown);
+            activeDropdown = showColorPicker(
+              editor,
+              button,
+              COLOR_PALETTE,
+              applyTextColor,
+              closeDropdown,
+            );
           } else if (btn.id === "highlight") {
-            activeDropdown = showColorPicker(editor, button, HIGHLIGHT_PALETTE, applyHighlight, closeDropdown);
+            activeDropdown = showColorPicker(
+              editor,
+              button,
+              HIGHLIGHT_PALETTE,
+              applyHighlight,
+              closeDropdown,
+            );
           }
 
           outsideHandler = (ev: MouseEvent) => {
             const dropdownEl = document.querySelector(".nexus-toolbar-dropdown");
-            if (!button.contains(ev.target as Node) && (!dropdownEl || !dropdownEl.contains(ev.target as Node))) {
+            if (
+              !button.contains(ev.target as Node) &&
+              (!dropdownEl || !dropdownEl.contains(ev.target as Node))
+            ) {
               closeDropdown();
             }
           };

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { createEditor } from "@floatboat/nexus-core";
 import {
-  toggleBold,
-  toggleItalic,
-  toggleInlineCode,
-  insertLink,
-  toggleHeading,
   createToolbarPlugin,
   createToolbarUI,
+  insertLink,
+  toggleBold,
+  toggleHeading,
+  toggleInlineCode,
+  toggleItalic,
 } from "../src/index";
 
 describe("toggleBold", () => {
@@ -126,7 +126,7 @@ describe("createToolbarPlugin", () => {
 
     expect(plugin.name).toBe("plugin-toolbar");
     expect(plugin.shortcuts).toBeDefined();
-    expect(plugin.shortcuts!.length).toBeGreaterThanOrEqual(6);
+    expect(plugin.shortcuts?.length).toBeGreaterThanOrEqual(6);
   });
 
   it("integrates with the editor shortcut system", () => {
@@ -180,7 +180,9 @@ describe("createToolbarUI", () => {
     const toolbar = createToolbarUI(editor);
     document.body.appendChild(toolbar.element);
 
-    const button = toolbar.element.querySelector<HTMLButtonElement>('[data-toolbar-action="unordered-list"]');
+    const button = toolbar.element.querySelector<HTMLButtonElement>(
+      '[data-toolbar-action="unordered-list"]',
+    );
     expect(button).not.toBeNull();
     expect(button?.title).toBe("");
     expect(button?.getAttribute("aria-label")).toBe("Unordered list");

--- a/packages/plugin-vim/package.json
+++ b/packages/plugin-vim/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/plugin-vim/src/index.ts
+++ b/packages/plugin-vim/src/index.ts
@@ -1,5 +1,5 @@
-import { vim } from "@replit/codemirror-vim";
 import type { NexusPlugin } from "@floatboat/nexus-core";
+import { vim } from "@replit/codemirror-vim";
 
 export function createVimPlugin(): NexusPlugin {
   return {

--- a/packages/plugin-vim/test/plugin-vim.test.ts
+++ b/packages/plugin-vim/test/plugin-vim.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createEditor, type EditorAPI } from "@floatboat/nexus-core";
+import { type EditorAPI, createEditor } from "@floatboat/nexus-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createVimPlugin } from "../src/index";
 
 describe("plugin-vim", () => {

--- a/packages/preset-gfm/package.json
+++ b/packages/preset-gfm/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/preset-gfm/src/index.ts
+++ b/packages/preset-gfm/src/index.ts
@@ -5,6 +5,6 @@ import type { NexusPlugin } from "@floatboat/nexus-core";
 export function createGfmPreset(): NexusPlugin {
   return {
     name: "preset-gfm",
-    remarkPlugins: [remarkGfm]
+    remarkPlugins: [remarkGfm],
   };
 }

--- a/packages/preset-gfm/test/preset-gfm.test.ts
+++ b/packages/preset-gfm/test/preset-gfm.test.ts
@@ -9,7 +9,7 @@ describe("@floatboat/nexus-preset-gfm", () => {
     const editor = createEditor({
       container,
       initialValue: "| a | b |\n| - | - |\n| 1 | 2 |",
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     expect(editor.getAst().children[0]?.type).toBe("table");
@@ -21,7 +21,7 @@ describe("@floatboat/nexus-preset-gfm", () => {
     const editor = createEditor({
       container,
       initialValue: "- [x] done",
-      plugins: [createGfmPreset()]
+      plugins: [createGfmPreset()],
     });
 
     const firstChild = editor.getAst().children[0] as List | undefined;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,7 +1,4 @@
-import type {
-  EditorAPI,
-  EditorConfig
-} from "@floatboat/nexus-core";
+import type { EditorAPI, EditorConfig } from "@floatboat/nexus-core";
 import type { RefObject } from "react";
 
 export type UseEditorConfig = Omit<EditorConfig, "container">;

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -20,7 +20,7 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
 
     const instance = createEditor({
       container,
-      ...configRef.current
+      ...configRef.current,
     });
 
     editorRef.current = instance;
@@ -34,6 +34,6 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
 
   return {
     containerRef,
-    editor
+    editor,
   };
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean"
   },

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -7,12 +7,12 @@ export const Editor = defineComponent({
   props: {
     initialValue: {
       type: String,
-      required: false
-    }
+      required: false,
+    },
   },
   setup(props) {
     const { containerRef } = useEditor(props);
 
     return () => h("div", { ref: containerRef });
-  }
+  },
 });

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,7 +1,4 @@
-import type {
-  EditorAPI,
-  EditorConfig
-} from "@floatboat/nexus-core";
+import type { EditorAPI, EditorConfig } from "@floatboat/nexus-core";
 import type { Ref, ShallowRef } from "vue";
 
 export type UseEditorConfig = Omit<EditorConfig, "container">;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -14,7 +14,7 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
 
     editor.value = createEditor({
       container: containerRef.value,
-      ...config
+      ...config,
     });
   });
 
@@ -25,6 +25,6 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
 
   return {
     containerRef,
-    editor
+    editor,
   };
 }

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,14 +1,14 @@
 import { mount } from "@vue/test-utils";
-import { defineComponent, h, nextTick, onMounted } from "vue";
 import { describe, expect, it } from "vitest";
+import { defineComponent, h, nextTick, onMounted } from "vue";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-vue", () => {
   it("renders an editor into the provided container through the Editor component", async () => {
     const wrapper = mount(Editor, {
       props: {
-        initialValue: "# Hello"
-      }
+        initialValue: "# Hello",
+      },
     });
 
     await nextTick();
@@ -36,7 +36,7 @@ describe("@floatboat/nexus-vue", () => {
         });
 
         return () => h("div", { ref: containerRef });
-      }
+      },
     });
 
     mount(Harness);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -23,9 +26,15 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: ^2.1.9
+        version: 2.1.9(vitest@2.1.9(@types/node@24.12.2)(jsdom@25.0.1))
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -231,6 +240,10 @@ packages:
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
@@ -245,12 +258,25 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -261,6 +287,66 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -835,6 +921,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -949,79 +1039,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1247,9 +1324,19 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2241,6 +2328,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2269,6 +2359,11 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -2357,6 +2452,22 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -2509,6 +2620,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-fetch-happen@10.2.1:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
@@ -3263,6 +3381,10 @@ packages:
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -3679,6 +3801,11 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
@@ -3694,17 +3821,25 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/runtime@7.29.2': {}
 
@@ -3712,6 +3847,48 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -4156,6 +4333,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4556,6 +4735,24 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@24.12.2)(jsdom@25.0.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@24.12.2)(jsdom@25.0.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -5827,6 +6024,8 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-escaper@2.0.2: {}
+
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
@@ -5868,6 +6067,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  husky@9.1.7: {}
 
   iconv-corefoundation@1.1.7:
     dependencies:
@@ -5927,6 +6128,27 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   jackspeak@3.4.3:
     dependencies:
@@ -6080,6 +6302,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -7102,6 +7334,12 @@ snapshots:
     dependencies:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   thenify-all@1.6.0:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,15 +8,27 @@ export default defineConfig({
       "@floatboat/nexus-react": path.resolve(__dirname, "packages/react/src/index.ts"),
       "@floatboat/nexus-vue": path.resolve(__dirname, "packages/vue/src/index.ts"),
       "@floatboat/nexus-preset-gfm": path.resolve(__dirname, "packages/preset-gfm/src/index.ts"),
-      "@floatboat/nexus-plugin-slash": path.resolve(__dirname, "packages/plugin-slash/src/index.ts"),
-      "@floatboat/nexus-plugin-history": path.resolve(__dirname, "packages/plugin-history/src/index.ts"),
-      "@floatboat/nexus-plugin-search": path.resolve(__dirname, "packages/plugin-search/src/index.ts"),
-      "@floatboat/nexus-plugin-toolbar": path.resolve(__dirname, "packages/plugin-toolbar/src/index.ts"),
+      "@floatboat/nexus-plugin-slash": path.resolve(
+        __dirname,
+        "packages/plugin-slash/src/index.ts",
+      ),
+      "@floatboat/nexus-plugin-history": path.resolve(
+        __dirname,
+        "packages/plugin-history/src/index.ts",
+      ),
+      "@floatboat/nexus-plugin-search": path.resolve(
+        __dirname,
+        "packages/plugin-search/src/index.ts",
+      ),
+      "@floatboat/nexus-plugin-toolbar": path.resolve(
+        __dirname,
+        "packages/plugin-toolbar/src/index.ts",
+      ),
       "@floatboat/nexus-plugin-math": path.resolve(__dirname, "packages/plugin-math/src/index.ts"),
-      "@floatboat/nexus-plugin-vim": path.resolve(__dirname, "packages/plugin-vim/src/index.ts")
-    }
+      "@floatboat/nexus-plugin-vim": path.resolve(__dirname, "packages/plugin-vim/src/index.ts"),
+    },
   },
   test: {
-    environment: "jsdom"
-  }
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
 ---

##  Summary / 摘要

  为项目引入 Biome + Husky 现代化代码质量基础设施，覆盖格式化、Lint、pre-commit 钩子、CI 检查以及 VSCode 开发体验闭环。同步对现有代码库完成全量格式化。

##  Motivation / 背景与动机

  - Issue: N/A
  - Roadmap (docs/ROADMAP.md): N/A（工程基建）
  - OpenSpec change: N/A

  项目目前完全没有任何 Lint / Format 工具链，代码风格靠人工 CR 维护。引入 Biome（替代 ESLint + Prettier）提供零配置、高性能的开箱即用方案，配合 Husky pre-commit 和 CI形成闭环保障。
  Biome 选型理由：零依赖（比 ESLint+Prettier 组合减少 ~200 个 node_modules）、原生支持 import 排序和 JSON/MD 格式化、无需维护插件版本兼容性。

##  Changes / 变更内容

  - Root:
    - biome.json — 新建，配置 formatter（2 spaces, trailing commas, double quotes）+ linter（recommended rules）+ 3 组 overrides（test 文件、*.md、live-preview-table.ts）
    - .husky/pre-commit — 新建，提交时 biome check --staged，不合规则拒绝提交
    - .vscode/settings.json + .vscode/extensions.json — 新建，保存即自动格式化，推荐 Biome 插件
    - package.json — 新增 @biomejs/biome、husky 依赖，新增 lint / format / lint:fix / prepare 脚本
    - .gitignore — 新增 coverage/，修复 .vscode/ → .vscode/* 支持白名单
    - .github/workflows/ci.yml — 新增并行 lint job，publish job 依赖增加 lint 检查
  - packages/core:
    - event-emitter.ts — Set<Function> → Set<EventMap[keyof EventMap]>
    - live-preview-highlight.ts — noParameterAssign：参数重赋值改为局部变量
    - live-preview-table.ts — 删除死函数 extractCellText，更新残留注释
    - 其余为纯格式化变更（import 排序、trailing commas、分号、行宽折叠）
  - packages/plugin-*:
    - color-decoration.ts — 2 处 regexp loop 添加 biome-ignore
    - 其余为纯格式化变更
  - apps/electron-demo:
    - bridge.d.ts — Window 声明合并添加 biome-ignore
    - link-index.ts / settings.ts / vault-panel.ts / main.ts — 预存 lint 问题添加 biome-ignore
    - 其余为纯格式化变更

##  Testing / 测试

  - [x] pnpm test passes / 全绿（28 files, 314 tests）
  - [x] Affected packages build (pnpm build) / 全部 10 个包 + electron-demo 构建通过
  - [x] New / updated vitest cases：N/A（基建变更，无新用例）
  - [x] Manual verification：
    - pnpm lint — 0 issues
    - pnpm typecheck — 0 errors
    - .husky/pre-commit — 手动执行通过

##  Checklist / 自检清单

  - [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
  - [x] Public API changes update package README / types — 无公共 API 变更
  - [x] Touched live-preview-table.ts — 仅删除死函数 extractCellText，无交互逻辑修改
  - [x] New capability / breaking change — 无破坏性变更。noExplicitAny 暂设为 off（预存 20 处 any），后续单独 PR 清理
  - [x] No secrets / personal vault data committed / 无敏感信息被提交
  - [x] pnpm-lock.yaml 仅包含新增依赖的变更

  ---