### PR TITLE
feat(ci): add Vitest coverage reporting to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,16 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
 
       - name: Build packages
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm --filter @floatboat/nexus-core build && pnpm --filter @floatboat/nexus-react build && pnpm --filter @floatboat/nexus-vue build && pnpm --filter @floatboat/nexus-preset-gfm build && pnpm --filter @floatboat/nexus-plugin-slash build && pnpm --filter @floatboat/nexus-plugin-history build && pnpm --filter @floatboat/nexus-plugin-search build && pnpm --filter @floatboat/nexus-plugin-toolbar build && pnpm --filter @floatboat/nexus-plugin-math build && pnpm --filter @floatboat/nexus-plugin-vim build",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "dev:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo dev",
     "build:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo build",
     "publish:packages": "pnpm -r --filter \"./packages/*\" publish --access public --no-git-checks"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     }
   },
   test: {
-    environment: "jsdom"
+    environment: "jsdom",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["packages/*/src/**/*.ts"],
+      exclude: ["**/index.ts"],
+    },
   }
 });


### PR DESCRIPTION
 ## Summary / 摘要

  为 CI 流程集成 Vitest 覆盖率统计，终端打印覆盖率表格并上传报告产物。

  ##Motivation / 背景与动机

  - Issue: N/A
  - Roadmap (docs/ROADMAP.md): N/A（CI 工程基建）
  - OpenSpec change: N/A

  当前 CI 仅运行测试但无覆盖率数据输出，缺少代码质量量化指标。@vitest/coverage-v8 已在 devDependencies 中，零额外依赖即可启用。

  ##Changes / 变更内容

  - Root:
    - vitest.config.ts — 新增 coverage 配置：v8 provider，text / json / html 三种 reporter，仅统计 packages/*/src/**/*.ts，排除 barrel 文件 **/index.ts
    - package.json — 新增 test:coverage 脚本
    - .github/workflows/ci.yml — verify job 中 pnpm test → pnpm test:coverage，新增 upload-artifact@v4 上传 coverage/ 产物（retention 14 天，if: always() 确保失败时仍可下载分析）

  ##Testing / 测试

  - [x] pnpm test:coverage passes / 全绿（28 files, 314 tests, 74.66% stmts）
  - [x] Affected packages build — N/A（无代码变更）
  - [x] New / updated vitest cases — N/A
  - [x] Manual verification — 本地运行 pnpm test:coverage 终端打印覆盖率表格，coverage/ 目录生成 html/json 报告

  ##Checklist / 自检清单

  - [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
  - [x] Public API changes update package README / types — 无公共 API 变更
  - [x] Touched live-preview-table.ts — N/A
  - [x] New capability / breaking change — 无破坏性变更
  - [x] No secrets / personal vault data committed / 无敏感信息被提交
  - [x] @vitest/coverage-v8 已在 devDependencies 中，无新增依赖