### PR TITLE
fix(core): resolve timer and listener leaks in table widget, live pre…

### DIFF
--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -48,6 +48,23 @@ const SEPARATOR_RE = /^\|?\s*[-:]+\s*(\|\s*[-:]+\s*)*\|?\s*$/;
 // place to store column widths and we don't want to write sidecar files
 // for this. Values: [rowGripWidth, ...dataColumnWidths].
 const tableColumnWidths = new Map<string, number[]>();
+const MAX_WIDTH_ENTRIES = 50;
+
+function getTableWidth(key: string): number[] | undefined {
+  const hit = tableColumnWidths.get(key);
+  if (!hit) return undefined;
+  tableColumnWidths.delete(key);
+  tableColumnWidths.set(key, hit);
+  return hit;
+}
+
+function setTableWidth(key: string, value: number[]): void {
+  tableColumnWidths.set(key, value);
+  if (tableColumnWidths.size > MAX_WIDTH_ENTRIES) {
+    const oldest = tableColumnWidths.keys().next().value;
+    if (oldest !== undefined) tableColumnWidths.delete(oldest);
+  }
+}
 
 const ROW_GRIP_WIDTH = 16;
 const MIN_COLUMN_WIDTH = 48;
@@ -303,6 +320,7 @@ const DRAG_HIGHLIGHT_BG = "rgba(124, 108, 250, 0.08)";
 export class EditableTableWidget extends WidgetType {
   private editing = false;
   private cleanupEditingLocks: (() => void) | null = null;
+  private _docMouseDown: ((e: MouseEvent) => void) | null = null;
 
   constructor(
     private node: Table,
@@ -320,6 +338,10 @@ export class EditableTableWidget extends WidgetType {
   ignoreEvent(): boolean { return true; }
 
   destroy(): void {
+    if (this._docMouseDown) {
+      document.removeEventListener("mousedown", this._docMouseDown);
+      this._docMouseDown = null;
+    }
     this.cleanupEditingLocks?.();
     this.cleanupEditingLocks = null;
   }
@@ -539,7 +561,7 @@ export class EditableTableWidget extends WidgetType {
     const startColumnResize = (dataColIdx: number, startX: number): void => {
       acquireEditingLock("drag");
       const baseWidths = (() => {
-        const saved = tableColumnWidths.get(widthKey);
+        const saved = getTableWidth(widthKey);
         if (saved && saved.length === colCount + 1) return saved.slice();
         return measureColumnWidths();
       })();
@@ -561,7 +583,7 @@ export class EditableTableWidget extends WidgetType {
         document.removeEventListener("mouseup", onUp);
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
-        tableColumnWidths.set(widthKey, baseWidths.slice());
+        setTableWidth(widthKey, baseWidths.slice());
         releaseEditingLock("drag");
       };
       document.addEventListener("mousemove", onMove);
@@ -1455,7 +1477,7 @@ export class EditableTableWidget extends WidgetType {
     // Re-apply column widths the user previously set via drag (keyed by
     // header line in `tableColumnWidths`). Done after the rows are
     // mounted so colgroup + the widths take effect on the actual DOM.
-    const savedWidths = tableColumnWidths.get(widthKey);
+    const savedWidths = getTableWidth(widthKey);
     if (savedWidths && savedWidths.length === colCount + 1) {
       applyColumnWidths(savedWidths);
     }
@@ -1532,14 +1554,14 @@ export class EditableTableWidget extends WidgetType {
     });
 
     // Click outside table clears all selection
-    const onDocMouseDown = (e: MouseEvent): void => {
-      if (!wrapper.isConnected) { document.removeEventListener("mousedown", onDocMouseDown); return; }
+    this._docMouseDown = (e: MouseEvent): void => {
+      if (!wrapper.isConnected) { document.removeEventListener("mousedown", this._docMouseDown!); return; }
       if (!wrapper.contains(e.target as Node)) {
         clearSelection();
         clearRangeSelection();
       }
     };
-    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("mousedown", this._docMouseDown);
 
     wrapper.addEventListener("keydown", (e) => {
       if (e.key === "Delete" || e.key === "Backspace") {
@@ -1653,7 +1675,13 @@ function showContextMenu(
     menu.style.top = Math.max(margin, y - rect.height) + "px";
   }
 
+  let menuTimer: ReturnType<typeof setTimeout> | null = null;
+
   function cleanup(): void {
+    if (menuTimer !== null) {
+      clearTimeout(menuTimer);
+      menuTimer = null;
+    }
     menu.remove();
     ownerDocument.removeEventListener("mousedown", close);
   }
@@ -1663,5 +1691,8 @@ function showContextMenu(
       cleanup();
     }
   }
-  setTimeout(() => ownerDocument.addEventListener("mousedown", close), 0);
+  menuTimer = setTimeout(() => {
+    ownerDocument.addEventListener("mousedown", close);
+    menuTimer = null;
+  }, 0);
 }

--- a/packages/core/src/live-preview.ts
+++ b/packages/core/src/live-preview.ts
@@ -215,7 +215,24 @@ function loadMermaid(): Promise<MermaidAPI> {
 }
 
 const MERMAID_CACHE = new Map<string, { svg: string; height: number }>();
+const MERMAID_CACHE_LIMIT = 50;
 let mermaidIdCounter = 0;
+
+function getMermaidCache(key: string): { svg: string; height: number } | undefined {
+  const hit = MERMAID_CACHE.get(key);
+  if (!hit) return undefined;
+  MERMAID_CACHE.delete(key);
+  MERMAID_CACHE.set(key, hit);
+  return hit;
+}
+
+function setMermaidCache(key: string, value: { svg: string; height: number }): void {
+  MERMAID_CACHE.set(key, value);
+  if (MERMAID_CACHE.size > MERMAID_CACHE_LIMIT) {
+    const oldest = MERMAID_CACHE.keys().next().value;
+    if (oldest !== undefined) MERMAID_CACHE.delete(oldest);
+  }
+}
 
 class MermaidWidget extends WidgetType {
   constructor(
@@ -232,7 +249,7 @@ class MermaidWidget extends WidgetType {
   ignoreEvent(): boolean { return true; }
 
   get estimatedHeight(): number {
-    const cached = MERMAID_CACHE.get(this.source);
+    const cached = getMermaidCache(this.source);
     return cached ? cached.height : 80;
   }
 
@@ -308,7 +325,7 @@ class MermaidWidget extends WidgetType {
       svg.style.margin = "0 auto";
     };
 
-    const cached = MERMAID_CACHE.get(this.source);
+    const cached = getMermaidCache(this.source);
     if (cached) {
       diagramHost.innerHTML = cached.svg;
       normalizeSvg(diagramHost);
@@ -396,7 +413,7 @@ class MermaidWidget extends WidgetType {
         const { svg } = await m.render(id, sourceAtRender);
         cleanupOrphans(id);
         if (!container.isConnected) {
-          MERMAID_CACHE.set(sourceAtRender, { svg, height: 0 });
+          setMermaidCache(sourceAtRender, { svg, height: 0 });
           return;
         }
         diagramHost.style.color = "";
@@ -406,7 +423,7 @@ class MermaidWidget extends WidgetType {
         diagramHost.innerHTML = svg;
         normalizeSvg(diagramHost);
         const h = container.offsetHeight || 0;
-        MERMAID_CACHE.set(sourceAtRender, { svg, height: h });
+        setMermaidCache(sourceAtRender, { svg, height: h });
         this.viewRef.current?.requestMeasure();
       } catch (err) {
         cleanupOrphans(id);
@@ -1363,6 +1380,7 @@ export function createLivePreviewExtension(
 
   const viewCapture = ViewPlugin.fromClass(
     class {
+      compositionTimer: ReturnType<typeof setTimeout> | null = null;
       constructor(readonly view: EditorView) {
         viewRef.current = view;
       }
@@ -1372,6 +1390,10 @@ export function createLivePreviewExtension(
       }
 
       destroy(): void {
+        if (this.compositionTimer !== null) {
+          clearTimeout(this.compositionTimer);
+          this.compositionTimer = null;
+        }
         if (viewRef.current === this.view) viewRef.current = null;
       }
     }
@@ -1390,7 +1412,11 @@ export function createLivePreviewExtension(
       return false;
     },
     compositionend(_event, view) {
-      setTimeout(() => {
+      const plugin = view.plugin(viewCapture);
+      if (!plugin) return;
+      if (plugin.compositionTimer) clearTimeout(plugin.compositionTimer);
+      plugin.compositionTimer = setTimeout(() => {
+        plugin.compositionTimer = null;
         if (view.compositionStarted) return;
         try {
           view.dispatch({ effects: rebuildAfterComposition.of(null) });

--- a/packages/core/src/widget-extension.ts
+++ b/packages/core/src/widget-extension.ts
@@ -228,6 +228,7 @@ export function createWidgetExtension(
 
   const viewCapture = ViewPlugin.fromClass(
     class {
+      compositionTimer: ReturnType<typeof setTimeout> | null = null;
       constructor(readonly view: EditorView) {
         viewRef.current = view;
       }
@@ -235,6 +236,10 @@ export function createWidgetExtension(
         viewRef.current = this.view;
       }
       destroy(): void {
+        if (this.compositionTimer !== null) {
+          clearTimeout(this.compositionTimer);
+          this.compositionTimer = null;
+        }
         if (viewRef.current === this.view) viewRef.current = null;
       }
     }
@@ -242,7 +247,11 @@ export function createWidgetExtension(
 
   const compositionHandler = EditorView.domEventHandlers({
     compositionend(_event, view) {
-      setTimeout(() => {
+      const plugin = view.plugin(viewCapture);
+      if (!plugin) return;
+      if (plugin.compositionTimer) clearTimeout(plugin.compositionTimer);
+      plugin.compositionTimer = setTimeout(() => {
+        plugin.compositionTimer = null;
         if (view.compositionStarted) return;
         try {
           view.dispatch({ effects: rebuildAfterComposition.of(null) });

--- a/packages/core/src/wikilinks.ts
+++ b/packages/core/src/wikilinks.ts
@@ -5,7 +5,7 @@ import {
   type Completion
 } from "@codemirror/autocomplete";
 import { StateEffect, StateField, type Extension, type Range, type Transaction } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
+import { Decoration, type DecorationSet, EditorView, ViewPlugin } from "@codemirror/view";
 
 import type { NexusPlugin } from "./types";
 
@@ -285,9 +285,25 @@ export function createWikilinksExtension(options: WikilinksOptions = {}): Extens
     },
   });
 
+  const viewCapture = ViewPlugin.fromClass(
+    class {
+      compositionTimer: ReturnType<typeof setTimeout> | null = null;
+      destroy(): void {
+        if (this.compositionTimer !== null) {
+          clearTimeout(this.compositionTimer);
+          this.compositionTimer = null;
+        }
+      }
+    },
+  );
+
   const compositionHandler = EditorView.domEventHandlers({
     compositionend(_event, view) {
-      setTimeout(() => {
+      const plugin = view.plugin(viewCapture);
+      if (!plugin) return;
+      if (plugin.compositionTimer) clearTimeout(plugin.compositionTimer);
+      plugin.compositionTimer = setTimeout(() => {
+        plugin.compositionTimer = null;
         if (view.compositionStarted) return;
         try {
           view.dispatch({ effects: rebuildAfterComposition.of(null) });
@@ -315,7 +331,7 @@ export function createWikilinksExtension(options: WikilinksOptions = {}): Extens
     },
   });
 
-  const exts: Extension[] = [field, compositionHandler, clickHandler];
+  const exts: Extension[] = [field, viewCapture, compositionHandler, clickHandler];
 
   if (options.suggest) {
     exts.push(


### PR DESCRIPTION
## Summary / 摘要

修复 7 个定时器、事件监听器和缓存泄漏问题，覆盖 `table widget`、`live preview` 和 `wikilinks` 等组件。

## Motivation / 背景与动机

- **Issue:** N/A
- **Roadmap:** N/A
- **OpenSpec change:** N/A

四个文件存在 timer / listener / Map 泄漏：

1. `live-preview-table.ts` — 表格 widget 销毁时 `document.addEventListener("mousedown", ...)` 无显式清理，仅依赖“下次点击时 DOM 已脱离才自删”。
2. `widget-extension.ts` / `live-preview.ts` / `wikilinks.ts` — `compositionend` 的 `setTimeout` 不存 timer ID，view destroy 后回调仍可能执行 dispatch；且 wikilinks 连 `destroy()` 钩子都没有。
3. `live-preview-table.ts` / `live-preview.ts` — `tableColumnWidths` Map 和 `MERMAID_CACHE` Map 只写不删，session 级无限增长。
4. `live-preview-table.ts` — 右键菜单的 `setTimeout(0)` 不存 timer ID，`cleanup()` 在 timer 触发前执行时，后续注册的 document 监听器永远不清理。

## Changes / 变更内容

- **`packages/core/src/live-preview-table.ts`**:
  - `onDocMouseDown` 从 `toDOM()` 局部变量提升为类字段 `_docMouseDown`，`destroy()` 中显式 `removeEventListener`。
  - `tableColumnWidths` Map 增加 `getTableWidth`/`setTableWidth` LRU 封装，上限 50，通过 touch-on-get 实现真正的 LRU 淘汰。
  - 右键菜单 `setTimeout(0)` 存入 `timer ID`，在 `cleanup()` 里调用 `clearTimeout`。

- **`packages/core/src/widget-extension.ts`**:
  - `viewCapture` ViewPlugin 新增 `compositionTimer` 字段，`destroy()` 里调用 `clearTimeout`。
  - `compositionend` handler 通过 `view.plugin(viewCapture)` 访问 Per-View timer，确保多实例隔离。

- **`packages/core/src/live-preview.ts`**:
  - 应用同样的 `compositionTimer` Per-View 修复。
  - `MERMAID_CACHE` Map 增加 `getMermaidCache`/`setMermaidCache` LRU 封装，上限 50。

- **`packages/core/src/wikilinks.ts`**:
  - 新增 `viewCapture` ViewPlugin，专门挂载 `compositionTimer` 并实现 `destroy()` 清理。
  - `compositionend` handler 改为 Per-View timer 模式。

## Testing / 测试

- [x] pnpm test passes / 全绿（28 files, 314 tests）
- [x] Affected packages build (`pnpm build`) / 全部 10 包 + electron-demo 构建通过
- [x] New / updated vitest cases — N/A（纯内部清理修复，现有测试覆盖所有修改路径）
- [x] pnpm typecheck / 0 errors

## Checklist / 自检清单

- [x] Title follows Conventional Commits
- [x] Public API changes update package README / types — 无公共 API 变更
- [x] Touched `live-preview-table.ts` — 仅添加 `destroy()` 清理路径和 LRU 封装，未改动交互逻辑
- [x] New capability / breaking change — 无
- [x] No secrets / personal vault data committed — 无敏感信息被提交