### PR TITLE
feat(core): Markdown live preview sync scroll

### DIFF
--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -7,6 +7,11 @@ import { createVaultPanel, type VaultPanel } from "./vault-panel";
 import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
 import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
 import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
+import {
+  createSyncScroll,
+  mdastToPreviewHtml,
+  type SyncScrollController,
+} from "@floatboat/nexus-core";
 
 installLongTaskWatch(50);
 
@@ -20,6 +25,40 @@ let backlinks: BacklinksPanel;
 
 const linkIndex = new LinkIndex();
 state.linkIndex = linkIndex;
+
+// ── Preview panel (module-level state) ──
+let previewVisible = false;
+let syncScroll: SyncScrollController | null = null;
+let previewColumn: HTMLElement;
+let previewContainer: HTMLElement;
+const PREVIEW_COLUMN_CLASS = "preview-column";
+
+function togglePreview(): void {
+  previewVisible = !previewVisible;
+  if (!previewColumn) return;
+  previewColumn.style.display = previewVisible ? "flex" : "none";
+
+  if (previewVisible && syncScroll) {
+    syncScroll.setEnabled(true);
+    syncScroll.refreshPreview();
+  } else if (previewVisible && !syncScroll) {
+    const view = shell?.editor?.view;
+    if (!view) {
+      // eslint-disable-next-line no-console
+      console.error("[preview] shell.editor.view is undefined", { shell: !!shell });
+      return;
+    }
+    syncScroll = createSyncScroll({
+      editor: view,
+      previewContainer,
+      renderPreview: () => mdastToPreviewHtml(shell.editor.getAst()),
+      initialSync: true,
+    });
+    syncScroll.refreshPreview();
+  } else {
+    syncScroll?.setEnabled(false);
+  }
+}
 
 function createAppToolbar(): HTMLElement {
   const toolbar = document.createElement("div");
@@ -77,6 +116,13 @@ function createAppToolbar(): HTMLElement {
   settingsBtn.style.fontSize = "16px";
   settingsBtn.addEventListener("click", handleSettings);
 
+  const previewBtn = document.createElement("button");
+  previewBtn.textContent = "👁"; // 👁
+  previewBtn.title = "Toggle preview panel (editor ↔ preview sync scroll)";
+  previewBtn.style.fontSize = "14px";
+  previewBtn.id = "preview-toggle-btn";
+  previewBtn.addEventListener("click", togglePreview);
+
   toolbar.append(
     vaultBtn,
     openBtn,
@@ -87,8 +133,11 @@ function createAppToolbar(): HTMLElement {
     outlineBtn,
     backlinksBtn,
     searchBtn,
-    settingsBtn
+    settingsBtn,
+    previewBtn
   );
+  // eslint-disable-next-line no-console
+  console.log("[toolbar] buttons created:", toolbar.children.length, "previewBtn id:", previewBtn.id);
   return toolbar;
 }
 
@@ -345,7 +394,6 @@ function boot(): void {
   const root = document.getElementById("app");
   if (!root) throw new Error("Missing #app element");
 
-  const appToolbar = createAppToolbar();
   const statusLine = createStatusLine();
 
   const mainArea = document.createElement("div");
@@ -357,13 +405,25 @@ function boot(): void {
   const editorContainer = document.createElement("div");
   editorContainer.className = "editor-container";
 
+  // ── Init preview panel DOM ──
+  previewColumn = document.createElement("div");
+  previewColumn.className = PREVIEW_COLUMN_CLASS;
+  previewColumn.style.display = "none";
+  previewContainer = document.createElement("div");
+  previewContainer.className = "preview-container";
+  previewColumn.appendChild(previewContainer);
+
+  const appToolbar = createAppToolbar();
   root.append(appToolbar, mainArea, statusLine);
 
   shell = createEditorShell({
     container: editorContainer,
     state,
     settings,
-    onStateChange: renderStatus,
+    onStateChange: () => {
+      renderStatus();
+      if (previewVisible && syncScroll) syncScroll.refreshPreview();
+    },
     resolveWikilink: (name) => linkIndex.resolve(name, state.activeFile),
     suggestWikilinks: (q) => {
       const names = linkIndex.getAllNoteNames();
@@ -375,6 +435,9 @@ function boot(): void {
       void handleWikilinkNavigate(target, opts);
     },
   });
+  // Expose for browser console debugging
+  (window as any).__editor = shell.editor;
+  (window as any).__togglePreview = togglePreview;
 
   vault = createVaultPanel({
     onOpenFile: (filePath) => {
@@ -408,7 +471,7 @@ function boot(): void {
   });
 
   editorColumn.append(searchBar.element, editorContainer);
-  mainArea.append(vault.element, editorColumn, outline.element, backlinks.element);
+  mainArea.append(vault.element, editorColumn, previewColumn, outline.element, backlinks.element);
 
   // External file changes → re-seed the index (cheap for typical vaults).
   window.nexusDemo.vault.onChanged(() => {

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -57,6 +57,23 @@ body,
   flex-shrink: 0;
 }
 
+.preview-column {
+  width: 45%;
+  min-width: 300px;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid #ddd;
+  overflow: hidden;
+}
+
+.preview-container {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: #fff;
+}
+
 .editor-container .cm-editor {
   flex: 1;
   min-height: 0;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,7 +50,7 @@ This document maps every planned feature to **package ownership / priority / sta
 
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
-| 13 | Markdown live preview sync scroll | `core` | P2 | planned | No | Only relevant in split-preview mode |
+| 13 | Markdown live preview sync scroll | `core` | P2 | in-progress | No | Only relevant in split-preview mode |
 | 14 | Custom keymap UI | `react` / `vue` + `core` | P2 | planned | Yes | Need to expose keymap register / query API first |
 
 ## 6. React / Vue SDK

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -50,7 +50,7 @@
 
 | # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
 |---|---|---|---|---|---|---|
-| 13 | Markdown live preview 同步滚动 | `core` | P2 | planned | 否 | 仅在分屏 preview 场景生效 |
+| 13 | Markdown live preview 同步滚动 | `core` | P2 | in-progress | 否 | 仅在分屏 preview 场景生效 |
 | 14 | 自定义快捷键界面 | `react` / `vue` + `core` | P2 | planned | 是 | 需要先暴露 keymap 注册 / 查询 API |
 
 ## 6. React / Vue SDK

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -513,6 +513,9 @@ export function createEditor(config: EditorConfig): EditorAPI {
       const lines = view.state.doc.lines;
       return { characters, words, lines };
     },
+    get view(): EditorView {
+      return view;
+    },
     destroy() {
       destroyed = true;
       focused = false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,3 +40,4 @@ export type {
   WidgetDefinition,
   WidgetRenderContext
 } from "./types";
+export { createSyncScroll, mdastToPreviewHtml, type SyncScrollController } from "./live-preview-sync";

--- a/packages/core/src/live-preview-sync.ts
+++ b/packages/core/src/live-preview-sync.ts
@@ -1,0 +1,409 @@
+/**
+ * live-preview-sync.ts — Bidirectional editor ↔ preview sync scroll
+ *
+ * Implements precise position‑based sync (方案C):
+ * 1. mdast‑to‑preview HTML renderer that tags every block with
+ *    `data-pos-from` / `data-pos-to` (source offset).
+ * 2. `createSyncScroll` — bidirectional scroll mirroring with
+ *    anti‑feedback lock and requestAnimationFrame throttling.
+ */
+
+import { EditorView } from "@codemirror/view";
+import type { Root } from "mdast";
+
+// ── Public Types ──────────────────────────────────────────────────────
+
+export interface SyncScrollOptions {
+  /** The CodeMirror EditorView of the source editor. */
+  editor: EditorView;
+  /** Scrollable container that holds the rendered preview HTML. */
+  previewContainer: HTMLElement;
+  /**
+   * Called when the preview content needs to be updated.
+   * Must return an HTML string with `.preview-block` elements
+   * carrying `data-pos-from` / `data-pos-to` attributes.
+   */
+  renderPreview(): string;
+  /** Throttle interval in ms (default 50). */
+  throttleMs?: number;
+  /**
+   * When true, do an initial sync immediately (editor → preview).
+   * Default: true.
+   */
+  initialSync?: boolean;
+}
+
+export interface SyncScrollController {
+  /** Re‑render the preview panel from the current source. */
+  refreshPreview(): void;
+  /** Remove all event listeners and clean up. */
+  destroy(): void;
+  /** Enable / disable sync (default true). */
+  setEnabled(on: boolean): void;
+}
+
+// ── Default preview styles (injected once per container) ──────────────
+
+const PREVIEW_STYLES_ID = "nexus-preview-styles";
+
+function injectPreviewStyles(container: HTMLElement): void {
+  if (container.querySelector(`#${PREVIEW_STYLES_ID}`)) return;
+  const style = document.createElement("style");
+  style.id = PREVIEW_STYLES_ID;
+  style.textContent = [
+    ".nexus-preview{padding:16px 24px;line-height:1.6;overflow-wrap:break-word;font-family:system-ui,sans-serif}",
+    ".nexus-preview h1,.nexus-preview h2,.nexus-preview h3,.nexus-preview h4,.nexus-preview h5,.nexus-preview h6{margin:1em 0 .5em 0;line-height:1.3;font-weight:600}",
+    ".nexus-preview h1{font-size:1.8em;border-bottom:1px solid var(--nexus-border-subtle,#e4e7eb);padding-bottom:.3em}",
+    ".nexus-preview h2{font-size:1.5em;border-bottom:1px solid var(--nexus-border-subtle,#e4e7eb);padding-bottom:.25em}",
+    ".nexus-preview h3{font-size:1.25em}",
+    ".nexus-preview p{margin:.5em 0}",
+    ".nexus-preview pre{background:var(--nexus-bg-subtle,#f6f8fa);border-radius:6px;padding:12px 16px;overflow-x:auto;font-family:monospace;font-size:.9em}",
+    ".nexus-preview code{background:var(--nexus-bg-subtle,#f6f8fa);border-radius:3px;padding:2px 4px;font-family:monospace;font-size:.9em}",
+    ".nexus-preview pre code{background:0;padding:0;border-radius:0}",
+    ".nexus-preview blockquote{margin:.5em 0;padding:0 1em;border-left:3px solid var(--nexus-border,#d0d7de);color:var(--nexus-text-muted,#6e7681)}",
+    ".nexus-preview ul,.nexus-preview ol{margin:.5em 0;padding-left:2em}",
+    ".nexus-preview li{margin:.25em 0}",
+    ".nexus-preview li.task-item{display:flex;align-items:baseline;gap:4px}",
+    ".nexus-preview li.task-item .preview-block{display:inline;margin:0}",
+    ".nexus-preview li.task-item .preview-block p{display:inline;margin:0}",
+    ".nexus-preview table{border-collapse:collapse;margin:.5em 0;width:100%}",
+    ".nexus-preview th,.nexus-preview td{border:1px solid var(--nexus-border-subtle,#d0d7de);padding:6px 10px;text-align:left}",
+    ".nexus-preview th{background:var(--nexus-bg-subtle,#f6f8fa);font-weight:600}",
+    ".nexus-preview hr{border:0;border-top:1px solid var(--nexus-border-subtle,#d0d7de);margin:1.5em 0}",
+    ".nexus-preview a{color:var(--nexus-accent,#0969da);text-decoration:none}",
+    ".nexus-preview a:hover{text-decoration:underline}",
+    ".nexus-preview img{max-width:100%;height:auto;border-radius:4px}",
+    ".nexus-preview del{color:var(--nexus-text-muted,#6e7681)}",
+    ".nexus-preview .footnote-definition{margin:.5em 0;font-size:.9em;color:var(--nexus-text-muted,#6e7681)}",
+    ".nexus-preview .footnote-definition .footnote-ref{font-weight:600;margin-right:.5em}",
+  ].join("");
+  container.appendChild(style);
+}
+
+// ── Sync Scroll ───────────────────────────────────────────────────────
+
+export function createSyncScroll(opts: SyncScrollOptions): SyncScrollController {
+  const { editor, previewContainer, renderPreview, initialSync = true } = opts;
+  let enabled = true;
+  let destroyed = false;
+  let rafId = 0;
+  let lastEditorOffset = -1;
+  let lastPreviewOffset = -1;
+  let lastPreviewHTML = "";
+
+  /**
+   * One-shot suppression: after we programmatically scroll one side, we set
+   * the corresponding flag so the NEXT scroll event on that side is ignored.
+   * This breaks the editor↔preview feedback loop.
+   */
+  let suppressEditorScroll = false;
+  let suppressPreviewScroll = false;
+
+  injectPreviewStyles(previewContainer);
+  previewContainer.classList.add("nexus-preview");
+
+  // ── Editor → Preview ──────────────────────────────────────────────
+
+  function onEditorScroll(): void {
+    if (!enabled || destroyed) return;
+    if (suppressEditorScroll) { suppressEditorScroll = false; return; }
+
+    const offset = topVisibleEditorOffset();
+    if (offset < 0 || offset === lastEditorOffset) return;
+    lastEditorOffset = offset;
+    schedulePreviewSync();
+  }
+
+  function schedulePreviewSync(): void {
+    cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(() => {
+      if (destroyed) return;
+      doSyncPreview();
+    });
+  }
+
+  function doSyncPreview(): void {
+    if (!enabled || destroyed) return;
+    const offset = lastEditorOffset;
+    if (offset < 0) return;
+
+    const blocks = Array.from(previewContainer.querySelectorAll<HTMLElement>(".preview-block"));
+    if (!blocks.length) return;
+
+    // Binary search: find the last block with data-pos-from ≤ offset
+    let lo = 0;
+    let hi = blocks.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      const from = parseInt(blocks[mid].dataset.posFrom ?? "-1", 10);
+      if (from <= offset) lo = mid + 1;
+      else hi = mid;
+    }
+    const target = lo > 0 ? blocks[lo - 1] : null;
+    if (!target) return;
+
+    // Don't scroll if the preview is already showing this block near the top
+    const cr = previewContainer.getBoundingClientRect();
+    const tr = target.getBoundingClientRect();
+    const currentGap = tr.top - cr.top;
+    if (currentGap >= -4 && currentGap < 80) return; // already close enough
+
+    suppressPreviewScroll = true;
+    previewContainer.scrollTop = tr.top - cr.top + previewContainer.scrollTop - 16;
+  }
+
+  // ── Preview → Editor ──────────────────────────────────────────────
+
+  function onPreviewScroll(): void {
+    if (!enabled || destroyed) return;
+    if (suppressPreviewScroll) { suppressPreviewScroll = false; return; }
+
+    const offset = topVisiblePreviewOffset();
+    if (offset < 0 || offset === lastPreviewOffset) return;
+    lastPreviewOffset = offset;
+    scheduleEditorSync();
+  }
+
+  function scheduleEditorSync(): void {
+    cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(() => {
+      if (destroyed) return;
+      doSyncEditor();
+    });
+  }
+
+  function doSyncEditor(): void {
+    if (!enabled || destroyed) return;
+    const offset = lastPreviewOffset;
+    if (offset < 0) return;
+
+    // Don't scroll if the editor is already showing this offset near the top
+    const currentEditorTop = topVisibleEditorOffset();
+    if (currentEditorTop >= 0 && Math.abs(offset - currentEditorTop) < 20) return;
+
+    const docLen = editor.state.doc.length;
+    const clamped = Math.min(Math.max(0, offset), docLen);
+    const line = editor.state.doc.lineAt(clamped);
+
+    suppressEditorScroll = true;
+    editor.dispatch({
+      effects: EditorView.scrollIntoView(line.from, {
+        y: "start",
+        yMargin: 50,
+      }),
+    });
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────
+
+  function topVisibleEditorOffset(): number {
+    const rect = editor.scrollDOM.getBoundingClientRect();
+    const y = rect.top + 1;
+    const pos = editor.posAtCoords({ x: editor.scrollDOM.clientLeft, y });
+    return pos !== null ? pos : -1;
+  }
+
+  function topVisiblePreviewOffset(): number {
+    const scrollTop = previewContainer.scrollTop;
+    if (scrollTop < 2) return 0;
+
+    const blocks = Array.from(previewContainer.querySelectorAll<HTMLElement>(".preview-block"));
+    let bestOffset = 0;
+    for (const block of blocks) {
+      const cr = previewContainer.getBoundingClientRect();
+      const br = block.getBoundingClientRect();
+      const blockVisualTop = br.top - cr.top;
+      if (blockVisualTop >= -4) {
+        bestOffset = parseInt(block.dataset.posFrom ?? "0", 10);
+        break;
+      }
+    }
+    return bestOffset;
+  }
+
+  // ── Wire up ───────────────────────────────────────────────────────
+
+  editor.scrollDOM.addEventListener("scroll", onEditorScroll, { passive: true });
+  previewContainer.addEventListener("scroll", onPreviewScroll, { passive: true });
+
+  if (initialSync) {
+    requestAnimationFrame(() => {
+      if (destroyed) return;
+      const pos = editor.state.selection.main.head;
+      lastEditorOffset = pos;
+      doSyncPreview();
+    });
+  }
+
+  return {
+    refreshPreview() {
+      if (destroyed) return;
+      const html = renderPreview();
+      if (html === lastPreviewHTML) return;
+      lastPreviewHTML = html;
+      // Save and restore scroll position. Clamp to avoid bogus scroll events
+      // when the re-rendered content is shorter than the previous content.
+      const maxScroll = previewContainer.scrollHeight - previewContainer.clientHeight;
+      const scrollPos = Math.min(previewContainer.scrollTop, maxScroll);
+      previewContainer.innerHTML = html;
+      previewContainer.classList.add("nexus-preview");
+      injectPreviewStyles(previewContainer);
+      previewContainer.scrollTop = Math.min(
+        scrollPos,
+        previewContainer.scrollHeight - previewContainer.clientHeight
+      );
+    },
+
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      enabled = false;
+      cancelAnimationFrame(rafId);
+      editor.scrollDOM.removeEventListener("scroll", onEditorScroll);
+      previewContainer.removeEventListener("scroll", onPreviewScroll);
+    },
+
+    setEnabled(on: boolean) {
+      enabled = on;
+    },
+  };
+}
+
+// ── mdast → Preview HTML (with position metadata) ────────────────────
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+
+function renderInline(node: any): string {
+  switch (node.type) {
+    case "text":
+      return esc(node.value);
+    case "strong":
+      return `<strong>${renderInlineNodes(node.children)}</strong>`;
+    case "emphasis":
+      return `<em>${renderInlineNodes(node.children)}</em>`;
+    case "delete":
+      return `<del>${renderInlineNodes(node.children)}</del>`;
+    case "inlineCode":
+      return `<code>${esc(node.value)}</code>`;
+    case "link":
+      return `<a href="${esc(node.url)}"${node.title ? ` title="${esc(node.title)}"` : ""}>${
+        renderInlineNodes(node.children)
+      }</a>`;
+    case "image":
+      return `<img src="${esc(node.url)}" alt="${esc(node.alt ?? "")}"${
+        node.title ? ` title="${esc(node.title)}"` : ""
+      } style="max-width:100%" />`;
+    case "footnoteReference":
+      return `<sup class="footnote-ref"><a href="#fn-${esc(node.identifier)}">${
+        esc(node.label ?? node.identifier)
+      }</a></sup>`;
+    case "html":
+      return node.value;
+    default: {
+      if (typeof node.value === "string") return esc(node.value);
+      if (Array.isArray(node.children)) return renderInlineNodes(node.children);
+      return "";
+    }
+  }
+}
+
+function renderInlineNodes(nodes: any[]): string {
+  return (nodes ?? []).map(renderInline).join("");
+}
+
+function renderBlock(node: any): string {
+  const pf = node.position?.start.offset ?? -1;
+  const pt = node.position?.end.offset ?? -1;
+  const wr = (h: string) =>
+    `<div class="preview-block" data-pos-from="${pf}" data-pos-to="${pt}">${h}</div>`;
+
+  switch (node.type) {
+    case "heading": {
+      const tag = `h${Math.min(6, Math.max(1, node.depth))}`;
+      return wr(`<${tag}>${renderInlineNodes(node.children)}</${tag}>`);
+    }
+    case "paragraph":
+      return wr(`<p>${renderInlineNodes(node.children)}</p>`);
+    case "code":
+      return wr(`<pre${node.lang ? ` data-language="${esc(node.lang)}"` : ""}><code${
+        node.lang ? ` class="language-${esc(node.lang)}"` : ""
+      }>${esc(node.value)}</code></pre>`);
+    case "list": {
+      const tag = node.ordered ? "ol" : "ul";
+      const startAttr =
+        node.ordered && (node.start ?? 1) !== 1 ? ` start="${node.start}"` : "";
+      const items = (node.children ?? [])
+        .map((li: any) => {
+          const checkbox =
+            li.checked !== null && li.checked !== undefined
+              ? `<input type="checkbox"${li.checked ? " checked" : ""} style="margin:0 4px 0 0;vertical-align:middle" disabled />`
+              : "";
+          const cls = li.checked !== null && li.checked !== undefined ? ' class="task-item"' : "";
+          return `<li${cls}>${checkbox}${(li.children ?? []).map(renderBlock).join("")}</li>`;
+        })
+        .join("");
+      return wr(`<${tag}${startAttr}>${items}</${tag}>`);
+    }
+    case "blockquote": {
+      const content = (node.children ?? []).map(renderBlock).join("");
+      return wr(`<blockquote>${content}</blockquote>`);
+    }
+    case "thematicBreak":
+      return wr("<hr />");
+    case "table": {
+      const rows = node.children ?? [];
+      let html = "<table>";
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        const cellTag = i === 0 ? "th" : "td";
+        const cells = (row.children ?? [])
+          .map(
+            (cell: any) =>
+              `<${cellTag}>${renderInlineNodes(cell.children)}</${cellTag}>`
+          )
+          .join("");
+        html += `<tr>${cells}</tr>`;
+      }
+      html += "</table>";
+      return wr(html);
+    }
+    case "html":
+      return wr(node.value);
+    case "definition":
+      return "";
+    case "footnoteDefinition":
+      return wr(
+        `<div class="footnote-definition">` +
+          `<sup class="footnote-ref">${esc(node.identifier)}.</sup> ` +
+          `${(node.children ?? []).map(renderBlock).join("")}` +
+        `</div>`
+      );
+    default: {
+      if (Array.isArray(node.children)) {
+        return wr(
+          `<div class="unknown-block">${node.children.map(renderBlock).join("")}</div>`
+        );
+      }
+      if (typeof node.value === "string") return wr(`<p>${esc(node.value)}</p>`);
+      return "";
+    }
+  }
+}
+
+/**
+ * Render a full mdast `Root` into an HTML fragment suitable for a preview panel.
+ *
+ * Every block-level node is wrapped in a `<div class="preview-block">`
+ * with `data-pos-from` / `data-pos-to` attributes that carry the node's
+ * source offset range — used by `createSyncScroll` for position‑based sync.
+ */
+export function mdastToPreviewHtml(ast: Root): string {
+  return (ast.children as any[])
+    .map((child) => renderBlock(child))
+    .filter(Boolean)
+    .join("\n");
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import type { EditorView } from "@codemirror/view";
 import type { Extension } from "@codemirror/state";
 import type { Blockquote, Code, Definition, Delete, Emphasis, FootnoteDefinition, FootnoteReference, Heading, Html, Image, InlineCode, Link, List, Root, Strong, Table, ThematicBreak } from "mdast";
 import type { Plugin } from "unified";
@@ -158,6 +159,11 @@ export interface EditorAPI {
   off<K extends keyof EditorEventMap>(event: K, handler: EditorEventMap[K]): void;
   getCoordsAtPos(pos: number): { left: number; right: number; top: number; bottom: number } | null;
   getDocumentStats(): { characters: number; words: number; lines: number };
+  /**
+   * The underlying CodeMirror EditorView. Used internally by sync-scroll
+   * and other integrations that need access to the scroll DOM or viewport.
+   */
+  view: EditorView;
 }
 
 export interface SlashCommandDef {

--- a/packages/core/test/live-preview-sync.test.ts
+++ b/packages/core/test/live-preview-sync.test.ts
@@ -1,0 +1,503 @@
+/**
+ * live-preview-sync.test.ts — Tests for mdastToPreviewHtml + createSyncScroll
+ *
+ * mdastToPreviewHtml is a pure function → direct AST construction tests.
+ * createSyncScroll needs DOM/scroll mocking → lifecycle tests.
+ */
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { EditorView } from "@codemirror/view";
+import type { Root, Paragraph, Text, Strong, Emphasis, Link, InlineCode, Image, Delete, Html } from "mdast";
+
+import { lezerStringToMdast } from "../src/lezer-mdast-adapter";
+import { mdastToPreviewHtml, createSyncScroll, type SyncScrollOptions } from "../src/live-preview-sync";
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Build a minimal Root with position offsets. */
+function rootWith(children: Root["children"]): Root {
+  return { type: "root", children };
+}
+
+function text(value: string, offsetStart: number, offsetEnd: number): Text {
+  return { type: "text", value, position: { start: { offset: offsetStart, line: 1, column: 1 }, end: { offset: offsetEnd, line: 1, column: 1 } } };
+}
+
+function paragraph(children: Paragraph["children"], offsetStart: number, offsetEnd: number): Paragraph {
+  return { type: "paragraph", children, position: { start: { offset: offsetStart, line: 1, column: 1 }, end: { offset: offsetEnd, line: 1, column: 1 } } };
+}
+
+/** Strip indentation, newlines and extra whitespace for fuzzy comparison. */
+function normalize(s: string): string {
+  return s.replace(/\s+/g, " ");
+}
+
+beforeAll(() => {
+  if (!("getClientRects" in Range.prototype)) {
+    Object.defineProperty(Range.prototype, "getClientRects", {
+      configurable: true,
+      value: () => [] as unknown as DOMRectList,
+    });
+  }
+  if (!("getBoundingClientRect" in Range.prototype)) {
+    Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => new DOMRect(),
+    });
+  }
+});
+
+// ── mdastToPreviewHtml ────────────────────────────────────────────
+
+describe("mdastToPreviewHtml", () => {
+  it("renders a paragraph", () => {
+    const ast = rootWith([paragraph([text("Hello world", 0, 12)], 0, 12)]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('class="preview-block"');
+    expect(html).toContain('data-pos-from="0"');
+    expect(html).toContain('data-pos-to="12"');
+    expect(html).toContain("<p>Hello world</p>");
+  });
+
+  it("renders headings h1–h6", () => {
+    const ast = rootWith([
+      { type: "heading", depth: 1, children: [text("H1", 0, 2)], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 2, line: 1, column: 1 } } },
+      { type: "heading", depth: 2, children: [text("H2", 3, 5)], position: { start: { offset: 3, line: 1, column: 1 }, end: { offset: 5, line: 1, column: 1 } } },
+      { type: "heading", depth: 6, children: [text("H6", 6, 8)], position: { start: { offset: 6, line: 1, column: 1 }, end: { offset: 8, line: 1, column: 1 } } },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<h1>H1</h1>");
+    expect(html).toContain("<h2>H2</h2>");
+    expect(html).toContain("<h6>H6</h6>");
+  });
+
+  it("clamps heading depth to 1–6", () => {
+    const ast = rootWith([
+      { type: "heading", depth: 0, children: [text("x", 0, 1)], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 1, line: 1, column: 1 } } } as any,
+      { type: "heading", depth: 99, children: [text("y", 2, 3)], position: { start: { offset: 2, line: 1, column: 1 }, end: { offset: 3, line: 1, column: 1 } } } as any,
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<h1>x</h1>");
+    expect(html).toContain("<h6>y</h6>");
+  });
+
+  it("renders code block with language class", () => {
+    const ast = rootWith([
+      { type: "code", lang: "js", value: "const a = 1;", position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 14, line: 1, column: 1 } } },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('data-language="js"');
+    expect(html).toContain('class="language-js"');
+    expect(html).toContain("const a = 1;");
+  });
+
+  it("renders code block without language", () => {
+    const ast = rootWith([
+      { type: "code", lang: null, value: "plain", position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 5, line: 1, column: 1 } } },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<pre><code>plain</code></pre>");
+    expect(html).not.toContain("data-language");
+  });
+
+  it("renders blockquote", () => {
+    const inner = paragraph([text("quote", 1, 6)], 1, 6);
+    const ast = rootWith([
+      { type: "blockquote", children: [inner], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 7, line: 1, column: 1 } } } as any,
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("<p>quote</p>");
+  });
+
+  it("renders thematic break", () => {
+    const ast = rootWith([
+      { type: "thematicBreak", position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 3, line: 1, column: 1 } } },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<hr />");
+  });
+
+  it("renders ordered list with start attribute", () => {
+    const ast = rootWith([
+      {
+        type: "list", ordered: true, start: 3, children: [
+          { type: "listItem", spread: false, checked: null, children: [paragraph([text("one", 0, 3)], 0, 3)], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 3, line: 1, column: 1 } } },
+          { type: "listItem", spread: false, checked: null, children: [paragraph([text("two", 4, 7)], 4, 7)], position: { start: { offset: 4, line: 1, column: 1 }, end: { offset: 7, line: 1, column: 1 } } },
+        ],
+        position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 8, line: 1, column: 1 } },
+      },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('<ol start="3">');
+    expect(html).toContain("<li>");
+    expect(html).toContain("<p>one</p>");
+    expect(html).toContain("<p>two</p>");
+    expect(html).toContain("</ol>");
+  });
+
+  it("renders unordered list", () => {
+    const ast = rootWith([
+      {
+        type: "list", ordered: false, start: null, children: [
+          { type: "listItem", spread: false, checked: null, children: [paragraph([text("A", 0, 1)], 0, 1)], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 1, line: 1, column: 1 } } },
+          { type: "listItem", spread: false, checked: null, children: [paragraph([text("B", 2, 3)], 2, 3)], position: { start: { offset: 2, line: 1, column: 1 }, end: { offset: 3, line: 1, column: 1 } } },
+        ],
+        position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 4, line: 1, column: 1 } },
+      },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<ul>");
+    expect(html).toContain("</ul>");
+  });
+
+  it("renders task items with checkbox (checked and unchecked)", () => {
+    const ast = rootWith([
+      {
+        type: "list", ordered: false, start: null, children: [
+          {
+            type: "listItem", spread: false, checked: true, children: [paragraph([text("done", 3, 7)], 3, 7)],
+            position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 7, line: 1, column: 1 } },
+          },
+          {
+            type: "listItem", spread: false, checked: false, children: [paragraph([text("todo", 11, 15)], 11, 15)],
+            position: { start: { offset: 8, line: 1, column: 1 }, end: { offset: 15, line: 1, column: 1 } },
+          },
+        ],
+        position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 16, line: 1, column: 1 } },
+      },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('class="task-item"');
+    // Two checkboxes: exactly one has the checked attribute
+    expect((html.match(/<input type="checkbox"/g) || [])).toHaveLength(2);
+    expect((html.match(/ checked /g) || [])).toHaveLength(1);
+  });
+
+  it("renders table with header and rows", () => {
+    const ast = rootWith([
+      {
+        type: "table", children: [
+          {
+            type: "tableRow", children: [
+              { type: "tableCell", children: [text("Name", 1, 5)] },
+              { type: "tableCell", children: [text("Age", 6, 9)] },
+            ],
+          },
+          {
+            type: "tableRow", children: [
+              { type: "tableCell", children: [text("Alice", 10, 15)] },
+              { type: "tableCell", children: [text("30", 16, 18)] },
+            ],
+          },
+        ],
+        position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 19, line: 1, column: 1 } },
+      },
+      // We also need an align property for the type
+    ] as any);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>Name</th>");
+    expect(html).toContain("<th>Age</th>");
+    expect(html).toContain("<td>Alice</td>");
+    expect(html).toContain("<td>30</td>");
+    expect(html).toContain("</table>");
+  });
+
+  it("renders inline formatting: strong, emphasis, delete, inlineCode", () => {
+    const ast = rootWith([
+      paragraph([
+        text("before ", 0, 7),
+        { type: "strong", children: [text("bold", 9, 13)] } as Strong,
+        text(" ", 14, 15),
+        { type: "emphasis", children: [text("italic", 16, 22)] } as Emphasis,
+        text(" ", 23, 24),
+        { type: "delete", children: [text("struck", 26, 32)] } as Delete,
+        text(" ", 33, 34),
+        { type: "inlineCode", value: "code" } as InlineCode,
+      ], 0, 40),
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<del>struck</del>");
+    expect(html).toContain("<code>code</code>");
+  });
+
+  it("renders links with href and optional title", () => {
+    const children = [text("Example", 1, 8)] as any;
+    const ast = rootWith([paragraph([
+      { type: "link", url: "https://x.com", title: null, children } as Link,
+    ], 0, 10)]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('<a href="https://x.com">');
+    expect(html).toContain("Example</a>");
+    expect(html).not.toContain("title=");
+  });
+
+  it("renders images with alt and title", () => {
+    const ast = rootWith([paragraph([
+      { type: "image", url: "/img.png", alt: "pic", title: "Caption" } as Image,
+    ], 0, 10)]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('src="/img.png"');
+    expect(html).toContain('alt="pic"');
+    expect(html).toContain('title="Caption"');
+  });
+
+  it("renders footnote reference", () => {
+    const ast = rootWith([paragraph([
+      text("text", 0, 4),
+      { type: "footnoteReference", identifier: "fn1", label: "1" } as any,
+    ], 0, 10)]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('<sup class="footnote-ref">');
+    expect(html).toContain('<a href="#fn-fn1">1</a>');
+  });
+
+  it("renders footnote definition", () => {
+    const inner = paragraph([text("note", 4, 8)], 4, 8);
+    const ast = rootWith([
+      { type: "footnoteDefinition", identifier: "fn1", label: "1", children: [inner], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 10, line: 1, column: 1 } } } as any,
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('class="footnote-definition"');
+    expect(html).toContain("fn1.");
+    expect(html).toContain("<p>note</p>");
+  });
+
+  it("renders raw HTML inline", () => {
+    const ast = rootWith([paragraph([
+      text("a", 0, 1),
+      { type: "html", value: "<b>raw</b>" } as Html,
+    ], 0, 12)]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<b>raw</b>");
+  });
+
+  it("renders definition as empty string", () => {
+    const ast = rootWith([
+      { type: "definition", identifier: "ref", url: "https://x.com", title: null } as any,
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toBe("");
+  });
+
+  it("renders unknown node with children as unknown-block", () => {
+    const ast = rootWith([
+      { type: "custom", children: [paragraph([text("x", 0, 1)], 0, 1)], position: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 2, line: 1, column: 1 } } } as any,
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('class="unknown-block"');
+    expect(html).toContain("<p>x</p>");
+  });
+
+  it("escapes HTML special characters in text", () => {
+    const ast = rootWith([paragraph([text("<script>alert('x')</script>", 0, 27)], 0, 27)]);
+    const html = mdastToPreviewHtml(ast);
+    // esc() handles &, <, > but not single quotes
+    expect(html).toContain("&lt;script&gt;alert('x')&lt;/script&gt;");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("escapes HTML in inline code", () => {
+    const ast = rootWith([paragraph([
+      { type: "inlineCode", value: "<b>danger</b>" } as InlineCode,
+    ], 0, 18)]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<code>&lt;b&gt;danger&lt;/b&gt;</code>");
+  });
+
+  it("throws on null children (caller must ensure valid Root)", () => {
+    expect(() => mdastToPreviewHtml({ type: "root", children: null as any })).toThrow();
+  });
+
+  it("handles empty root", () => {
+    const ast = rootWith([]);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toBe("");
+  });
+
+  it("marks every block with preview-block class and data-pos attributes", () => {
+    const ast = rootWith([
+      paragraph([text("p1", 0, 2)], 0, 2),
+      { type: "heading", depth: 2, children: [text("h", 3, 4)], position: { start: { offset: 3, line: 1, column: 1 }, end: { offset: 4, line: 1, column: 1 } } },
+      { type: "code", lang: null, value: "c", position: { start: { offset: 5, line: 1, column: 1 }, end: { offset: 6, line: 1, column: 1 } } },
+    ]);
+    const html = mdastToPreviewHtml(ast);
+    const blocks = html.match(/class="preview-block"/g);
+    expect(blocks).toHaveLength(3);
+    expect(html).toContain('data-pos-from="0" data-pos-to="2"');
+    expect(html).toContain('data-pos-from="3" data-pos-to="4"');
+    expect(html).toContain('data-pos-from="5" data-pos-to="6"');
+  });
+});
+
+// ── Integration: lezerStringToMdast → mdastToPreviewHtml ───────────
+
+describe("mdastToPreviewHtml (integration via lezerStringToMdast)", () => {
+  it("renders a full markdown document with multiple block types", () => {
+    const md = "# Title\n\nHello **world**\n\n- one\n- two\n";
+    const ast = lezerStringToMdast(md);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<h1>");
+    expect(html).toContain("Title");
+    expect(html).toContain("<strong>world</strong>");
+    expect(html).toContain("<li>");
+    expect(html).toContain("<ul>");
+    // All blocks should have position data
+    expect(html).toContain('data-pos-from="');
+    expect(html).toContain('data-pos-to="');
+  });
+
+  it("renders task list items with checkboxes", () => {
+    const md = "- [x] done\n- [ ] todo\n";
+    const ast = lezerStringToMdast(md);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain('class="task-item"');
+    expect(html).toContain('<input type="checkbox" checked');
+    expect(html).toContain('<input type="checkbox" ');
+    // Note: text content inside task items depends on the lezer-mdast-adapter
+    // version — some emit Paragraph wrappers, some don't. We only verify
+    // that checkboxes render correctly regardless.
+  });
+
+  it("renders table with GFM pipe syntax", () => {
+    const md = "| A | B |\n| --- | --- |\n| 1 | 2 |\n";
+    const ast = lezerStringToMdast(md);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>");
+    expect(html).toContain("<td>1</td>");
+    expect(html).toContain("</table>");
+  });
+
+  it("renders blockquote, code, and horizontal rule", () => {
+    const md = "> quote\n\n```\ncode\n```\n\n---\n";
+    const ast = lezerStringToMdast(md);
+    const html = mdastToPreviewHtml(ast);
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("<p>quote</p>");
+    expect(html).toContain("<pre><code>");
+    expect(html).toContain("<hr />");
+  });
+});
+
+// ── createSyncScroll ──────────────────────────────────────────────
+
+describe("createSyncScroll", () => {
+  it("returns a SyncScrollController with destroy, refreshPreview, setEnabled", () => {
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: () => "<p>test</p>",
+      initialSync: false,
+    });
+    expect(ctrl).toHaveProperty("destroy");
+    expect(ctrl).toHaveProperty("refreshPreview");
+    expect(ctrl).toHaveProperty("setEnabled");
+    ctrl.destroy();
+  });
+
+  it("injects preview styles into the container", () => {
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: () => "",
+      initialSync: false,
+    });
+    expect(previewContainer.querySelector("#nexus-preview-styles")).not.toBeNull();
+    expect(previewContainer.classList.contains("nexus-preview")).toBe(true);
+    ctrl.destroy();
+  });
+
+  it("refreshPreview updates innerHTML from renderPreview", () => {
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: () => '<div class="preview-block">hello</div>',
+      initialSync: false,
+    });
+    ctrl.refreshPreview();
+    expect(previewContainer.innerHTML).toContain("hello");
+    expect(previewContainer.innerHTML).toContain('class="preview-block"');
+    ctrl.destroy();
+  });
+
+  it("refreshPreview skips innerHTML update when HTML is unchanged", () => {
+    const renderFn = vi.fn(() => "<p>same</p>");
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: renderFn,
+      initialSync: false,
+    });
+    ctrl.refreshPreview();
+    const innerHTMLafterFirst = previewContainer.innerHTML;
+    ctrl.refreshPreview();
+    // renderFn is called each time, but innerHTML should not be re-set
+    expect(renderFn).toHaveBeenCalledTimes(2);
+    // innerHTML should still have the content from the first call
+    expect(previewContainer.innerHTML).toBe(innerHTMLafterFirst);
+    ctrl.destroy();
+  });
+
+  it("setEnabled(true/false) toggles syncing", () => {
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: () => "",
+      initialSync: false,
+    });
+    // Default is enabled
+    ctrl.setEnabled(false);
+    // Should not crash when disabled
+    ctrl.refreshPreview();
+    ctrl.setEnabled(true);
+    ctrl.refreshPreview();
+    ctrl.destroy();
+  });
+
+  it("destroy is idempotent", () => {
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: () => "",
+      initialSync: false,
+    });
+    ctrl.destroy();
+    // Second destroy should not throw
+    ctrl.destroy();
+    // Methods should not throw after destroy
+    ctrl.refreshPreview();
+    ctrl.setEnabled(false);
+  });
+
+  it("does not crash on initialSync with empty document", () => {
+    vi.useFakeTimers();
+    const editor = { scrollDOM: document.createElement("div"), state: { doc: { toString: () => "", length: 0, lineAt: () => ({ from: 0 }) }, selection: { main: { head: 0 } } } } as unknown as EditorView;
+    const previewContainer = document.createElement("div");
+    const ctrl = createSyncScroll({
+      editor,
+      previewContainer,
+      renderPreview: () => "",
+      initialSync: true,
+    });
+    // Run pending rAF from initialSync
+    vi.runAllTimers();
+    ctrl.destroy();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->
实现P2 Roadmap功能：`#`13 Markdown live preview 同步滚动
在electron-demo中新增分屏preview视图，实现了分屏preview与编辑界面同步滚动

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue: 目前缺少分屏preview视图，需要实现分屏preview与编辑界面同步滚动
- Roadmap (docs/ROADMAP.md):  ROADMAP.md `#`13
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
  - core/src/live-preview-sync.ts （新增）
    - `createSyncScroll()` — 双向同步滚动控制器，编辑器与预览面板通过 source-offset 位置匹配实现同步，rAF 节流 + 一次性标记位防反馈回路  
    - `mdastToPreviewHtml()` — 将 mdast AST 渲染为 HTML，每个块级节点带 `data-pos-from` / `data-pos-to` 属性用于定位。支持所有 GFM 节点类型，包括 task item 的 `<input type="checkbox">` 渲染
    - 内置 `.nexus-preview` 样式集，使用 `--nexus-*` CSS 变量，防重复注入
  - core/src/editor.ts,core/src/types.ts
    - 在公共 API 中添加view：EditorView，以便sync-scroll能够访问 scrollDOM
  - core/src/index.ts
    - 导出 createSyncScroll, mdastToPreviewHtml, SyncScrollController
  - core/test/live-preview-sync.test.ts (new)
    - 35 个 vitest 用例覆盖：
      - mdast→HTML 渲染：所有块类型、内联格式、HTML 转义、位置属性
      - 集成测试：lezerStringToMdast 真实解析后渲染
      - createSyncScroll 生命周期：创建、刷新、setEnabled、destroy
- `packages/plugin-*`:
- `apps/electron-demo`:
  - apps/electron-demo/src/renderer/app.ts
    - 工具栏新增 👁 预览切换按钮
    - 右侧新增 `preview-column`，初始隐藏
    - `onStateChange` 触发预览自动刷新
    - 暴露 `__editor` / `__togglePreview` 调试接口
  - apps/electron-demo/src/renderer/style.css
    - .preview-column — 预览列的容器，在 .main-area 的 flex 布局中占 45% 宽度（最小 300px、最大  600px），带左边框与编辑器列分隔
    - .preview-container — 预览内容容器，填满列高度、可纵向滚动、白色背景
- `openspec/`:
- `docs/`: ROADMAP.md,ROADMAP.zh.md 中 `#`13 被标记为in_progress

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [x] `pnpm test` passes / 全绿，331 passed
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
- [x] 新增的live-preview-sync.test.ts 35个case passed
- [x] Manual UI check in electron-demo / electron-demo 手动验证：
- [x] 测试打开preview视图，分别在编辑界面和preview界面滑动，另外的窗口中的内容会跟随滑动

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — 改了公共 API 已同步 README 与类型，--同步修改了types.ts，无README需修改
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则 -- 未修改该文件
- [x] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec -- 无需OpenSpec
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)
此处上传了preview界面的测试gif
<img width="800" height="576" alt="Markdown live preview sync scroll" src="https://github.com/user-attachments/assets/6207ebdc-bab2-4e03-ba55-aadb43b1720b" />


<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->