### PR TITLE
fix(electron): Fix the issue of incompatible file paths during execution on the Windows operating system

### DIFF
--- a/apps/electron-demo/src/renderer/link-index.ts
+++ b/apps/electron-demo/src/renderer/link-index.ts
@@ -1,4 +1,5 @@
 import { scanWikiLinks, type WikiLinkMatch } from "@floatboat/nexus-core";
+import { normalizeSlashes, joinPath } from "./path-utils";
 
 /** Prefer requestIdleCallback for yielding; fall back to a macrotask otherwise. */
 function yieldToIdle(): Promise<void> {
@@ -51,15 +52,6 @@ function dirname(p: string): string {
   const norm = p.replace(/\\/g, "/");
   const slash = norm.lastIndexOf("/");
   return slash >= 0 ? norm.slice(0, slash) : "";
-}
-
-function joinPath(dir: string, rel: string): string {
-  if (!dir) return rel;
-  return `${dir}/${rel}`.replace(/\\/g, "/");
-}
-
-function normalizeSlashes(p: string): string {
-  return p.replace(/\\/g, "/");
 }
 
 /**

--- a/apps/electron-demo/src/renderer/path-utils.ts
+++ b/apps/electron-demo/src/renderer/path-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalize path slashes to forward slashes (Unix-style).
+ * Useful for cross-platform path comparisons.
+ */
+export function normalizeSlashes(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+/**
+ * Join path segments with forward slashes.
+ * Unlike path.join(), always returns forward slashes regardless of platform.
+ */
+export function joinPath(...parts: string[]): string {
+  return parts.join("/").replace(/\\/g, "/").replace(/\/+/g, "/");
+}

--- a/apps/electron-demo/test/path-utils.test.ts
+++ b/apps/electron-demo/test/path-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSlashes, joinPath } from "../src/renderer/path-utils";
+
+describe("normalizeSlashes", () => {
+  it("returns path unchanged when already using forward slashes", () => {
+    expect(normalizeSlashes("foo/bar/baz")).toBe("foo/bar/baz");
+  });
+
+  it("converts Windows backslashes to forward slashes", () => {
+    expect(normalizeSlashes("foo\\bar\\baz")).toBe("foo/bar/baz");
+  });
+
+  it("converts mixed slashes to forward slashes", () => {
+    expect(normalizeSlashes("foo/bar\\baz/qux")).toBe("foo/bar/baz/qux");
+  });
+
+  it("handles UNC paths", () => {
+    expect(normalizeSlashes("\\\\server\\share\\folder")).toBe("//server/share/folder");
+  });
+
+  it("converts multiple consecutive backslashes to forward slashes", () => {
+    expect(normalizeSlashes("foo\\\\bar\\\\baz")).toBe("foo//bar//baz");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeSlashes("")).toBe("");
+  });
+
+  it("handles root path", () => {
+    expect(normalizeSlashes("\\")).toBe("/");
+  });
+});
+
+describe("joinPath", () => {
+  it("joins two segments", () => {
+    expect(joinPath("foo", "bar")).toBe("foo/bar");
+  });
+
+  it("joins multiple segments", () => {
+    expect(joinPath("foo", "bar", "baz")).toBe("foo/bar/baz");
+  });
+
+  it("normalizes mixed slashes in segments", () => {
+    expect(joinPath("foo\\bar", "baz\\qux")).toBe("foo/bar/baz/qux");
+  });
+
+  it("handles leading slash in segment", () => {
+    expect(joinPath("/foo", "bar")).toBe("/foo/bar");
+  });
+
+  it("handles trailing slash in segment", () => {
+    expect(joinPath("foo/", "bar")).toBe("foo/bar");
+  });
+
+  it("collapses multiple consecutive slashes", () => {
+    expect(joinPath("foo//", "//bar")).toBe("foo/bar");
+  });
+
+  it("handles single segment", () => {
+    expect(joinPath("foo")).toBe("foo");
+  });
+
+  it("handles empty segments", () => {
+    expect(joinPath("foo", "", "bar")).toBe("foo/bar");
+  });
+
+  it("handles Windows-style paths as segments", () => {
+    expect(joinPath("foo\\bar", "baz")).toBe("foo/bar/baz");
+  });
+});

--- a/apps/electron-demo/test/sample-vault.test.ts
+++ b/apps/electron-demo/test/sample-vault.test.ts
@@ -3,6 +3,7 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { scanWikiLinks } from "@floatboat/nexus-core";
 import { LinkIndex, findAnchorPosition, parseAnchor } from "../src/renderer/link-index";
+import { normalizeSlashes } from "../src/renderer/path-utils";
 
 const VAULT_ROOT = path.resolve(__dirname, "../sample-vault");
 const SUPPORTED = new Set([".md", ".markdown", ".txt"]);
@@ -54,7 +55,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
     const idx = await buildIndex();
     const hub = path.join(VAULT_ROOT, "index.md");
     const hits = idx.getBacklinks(hub);
-    const sources = new Set(hits.map((h) => path.relative(VAULT_ROOT, h.sourcePath)));
+    const sources = new Set(hits.map((h) => normalizeSlashes(path.relative(VAULT_ROOT, h.sourcePath))));
     // README is documentation, not a note that must link in; every *other*
     // markdown file should.
     const expected = [
@@ -71,25 +72,25 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
       "work/Inbox.md",
       "work/Meeting.md",
     ];
-    for (const e of expected) expect(sources.has(e)).toBe(true);
+    for (const e of expected) expect(sources.has(normalizeSlashes(e))).toBe(true);
   });
 
   it("[[AI]] from Daily resolves to Topics/AI.md (globally unique basename)", async () => {
     const idx = await buildIndex();
     const daily = path.join(VAULT_ROOT, "Daily/2026-04-20.md");
-    expect(idx.resolve("AI", daily)).toBe(path.join(VAULT_ROOT, "Topics/AI.md"));
+    expect(idx.resolve("AI", daily)).toBe(normalizeSlashes(path.join(VAULT_ROOT, "Topics/AI.md")));
   });
 
   it("[[Meeting]] from work/Inbox.md resolves to work/Meeting.md (same-dir wins)", async () => {
     const idx = await buildIndex();
     const inbox = path.join(VAULT_ROOT, "work/Inbox.md");
-    expect(idx.resolve("Meeting", inbox)).toBe(path.join(VAULT_ROOT, "work/Meeting.md"));
+    expect(idx.resolve("Meeting", inbox)).toBe(normalizeSlashes(path.join(VAULT_ROOT, "work/Meeting.md")));
   });
 
   it("[[Meeting]] from personal/Diary.md resolves to personal/Meeting.md (symmetric)", async () => {
     const idx = await buildIndex();
     const diary = path.join(VAULT_ROOT, "personal/Diary.md");
-    expect(idx.resolve("Meeting", diary)).toBe(path.join(VAULT_ROOT, "personal/Meeting.md"));
+    expect(idx.resolve("Meeting", diary)).toBe(normalizeSlashes(path.join(VAULT_ROOT, "personal/Meeting.md")));
   });
 
   it("[[Ghost Note]] in ghost-demo.md is unresolved (creates-on-click scenario)", async () => {
@@ -133,7 +134,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
       expect(hits).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            sourcePath: file.path,
+            sourcePath: normalizeSlashes(file.path),
             target: match.target,
           }),
         ])
@@ -144,36 +145,36 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("Testing.md shows linked backlinks from current sample-vault references", async () => {
     const idx = await buildIndex();
     const testingPath = path.join(VAULT_ROOT, "Topics/Testing.md");
-    const linked = idx.getBacklinks(testingPath).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const linked = idx.getBacklinks(testingPath).map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(linked.length).toBeGreaterThan(0);
-    expect(linked).toContain("Projects/Nexus-Editor.md");
+    expect(linked).toContain(normalizeSlashes("Projects/Nexus-Editor.md"));
   });
 
   it("Bob.md has an unlinked mention in Alice.md (plain text 'Bob' outside brackets)", async () => {
     const idx = await buildIndex();
     const bob = path.join(VAULT_ROOT, "People/Bob.md");
     const mentions = idx.getUnlinkedMentions(bob);
-    const sources = mentions.map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    expect(sources).toContain("People/Alice.md");
+    const sources = mentions.map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
+    expect(sources).toContain(normalizeSlashes("People/Alice.md"));
   });
 
   it("AI.md has an unlinked mention in Alice.md and Daily/2026-04-20.md has a linked one", async () => {
     const idx = await buildIndex();
     const ai = path.join(VAULT_ROOT, "Topics/AI.md");
-    const unlinked = idx.getUnlinkedMentions(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    const linked = idx.getBacklinks(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    expect(unlinked).toContain("People/Alice.md"); // plain text "AI" in Alice.md
-    expect(linked).toContain("Daily/2026-04-20.md"); // [[AI]] in the daily
+    const unlinked = idx.getUnlinkedMentions(ai).map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
+    const linked = idx.getBacklinks(ai).map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
+    expect(unlinked).toContain(normalizeSlashes("People/Alice.md")); // plain text "AI" in Alice.md
+    expect(linked).toContain(normalizeSlashes("Daily/2026-04-20.md")); // [[AI]] in the daily
   });
 
   it("v2-shaped anchors in Ideas.md resolve to the underlying file, not ghosts", async () => {
     const idx = await buildIndex();
     const ideas = path.join(VAULT_ROOT, "Projects/Ideas.md");
     expect(idx.resolve("Projects/Nexus-Editor#Context", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+      normalizeSlashes(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
     expect(idx.resolve("Projects/Nexus-Editor^some-block", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+      normalizeSlashes(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
   });
 


### PR DESCRIPTION
Fix the issue of incompatible file paths during execution on the Windows operating system

## Summary / 摘要

Fix the issue of incompatible file paths during execution on the Windows operating system

## Motivation / 背景与动机

Encountered an incompatible file path error when executing the pnpm test command in CMD and PowerShell under Windows 10 system

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `apps/electron-demo/src/renderer/path-utils.ts`: new file
- `apps/electron-demo/test/path-utils.ts`: Fix references
- `apps/electron-demo/test/sample-vault.test.ts`: Fix references
- `apps/electron-demo/test/path-utils.test.ts`: new file

## Testing / 测试

- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：`apps/electron-demo/test/sample-vault.test.ts`、 `apps/electron-demo/test/path-utils.test.ts`
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [x] No secrets / personal vault data committed / 无敏感信息被提交
