### PR TITLE
feat: add editor container props and onReady

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 export default function App() {
   return (
     <Editor
+      className="nexus-editor-shell"
+      aria-label="Markdown editor"
       initialValue="# Hello, Nexus 👋"
       plugins={[createGfmPreset()]}
       livePreview
+      onReady={(editor) => editor.focus()}
       onChange={(doc, ast) => console.log(doc)}
     />
   );
@@ -94,6 +97,7 @@ export default function App() {
 ```
 
 > 💡 **New to CodeMirror?** You don't need to know it. `<Editor />` handles the lifecycle — just drop it in.
+> `className`, `style`, `data-*`, and `aria-*` props are applied to the host container; `onReady` receives the core editor API after mount.
 </details>
 
 <details>
@@ -107,9 +111,12 @@ import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 
 <template>
   <Editor
+    class="nexus-editor-shell"
+    aria-label="Markdown editor"
     initial-value="# Hello"
     :plugins="[createGfmPreset()]"
     :live-preview="true"
+    :on-ready="(editor) => editor.focus()"
     @change="(doc) => console.log(doc)"
   />
 </template>

--- a/README.zh.md
+++ b/README.zh.md
@@ -84,9 +84,12 @@ import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 export default function App() {
   return (
     <Editor
+      className="nexus-editor-shell"
+      aria-label="Markdown editor"
       initialValue="# 你好，Nexus 👋"
       plugins={[createGfmPreset()]}
       livePreview
+      onReady={(editor) => editor.focus()}
       onChange={(doc, ast) => console.log(doc)}
     />
   );
@@ -94,6 +97,7 @@ export default function App() {
 ```
 
 > 💡 **不熟 CodeMirror？** 不需要懂。`<Editor />` 已经处理好生命周期，直接用就行。
+> `className`、`style`、`data-*` 和 `aria-*` 会透传给宿主容器；`onReady` 会在挂载后收到 core editor API。
 </details>
 
 <details>
@@ -107,9 +111,12 @@ import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
 
 <template>
   <Editor
+    class="nexus-editor-shell"
+    aria-label="Markdown editor"
     initial-value="# 你好"
     :plugins="[createGfmPreset()]"
     :live-preview="true"
+    :on-ready="(editor) => editor.focus()"
     @change="(doc) => console.log(doc)"
   />
 </template>

--- a/packages/react/src/editor.tsx
+++ b/packages/react/src/editor.tsx
@@ -1,9 +1,48 @@
 import { useEditor } from "./use-editor";
 
-import type { UseEditorConfig } from "./types";
+import type { EditorProps, UseEditorConfig } from "./types";
 
-export function Editor(props: UseEditorConfig) {
-  const { containerRef } = useEditor(props);
+export function Editor(props: EditorProps) {
+  const {
+    initialValue,
+    parser,
+    parseDelayMs,
+    livePreview,
+    plugins,
+    theme,
+    locale,
+    tabSize,
+    direction,
+    indentGuides,
+    readOnly,
+    slashMenuLimit,
+    onChange,
+    onFocus,
+    onBlur,
+    onAssetUpload,
+    onReady,
+    ...containerProps
+  } = props;
+  const editorConfig: UseEditorConfig = {
+    initialValue,
+    parser,
+    parseDelayMs,
+    livePreview,
+    plugins,
+    theme,
+    locale,
+    tabSize,
+    direction,
+    indentGuides,
+    readOnly,
+    slashMenuLimit,
+    onChange,
+    onFocus,
+    onBlur,
+    onAssetUpload,
+    onReady
+  };
+  const { containerRef } = useEditor(editorConfig);
 
-  return <div ref={containerRef} />;
+  return <div {...containerProps} ref={containerRef} />;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,9 +2,14 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { RefObject } from "react";
+import type { HTMLAttributes, RefObject } from "react";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  onReady?: (editor: EditorAPI) => void;
+}
+
+export type EditorProps = UseEditorConfig &
+  Omit<HTMLAttributes<HTMLDivElement>, keyof UseEditorConfig | "children">;
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -18,13 +18,15 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
+    const { onReady, ...editorConfig } = configRef.current;
     const instance = createEditor({
       container,
-      ...configRef.current
+      ...editorConfig
     });
 
     editorRef.current = instance;
     setEditor(instance);
+    onReady?.(instance);
 
     return () => {
       instance.destroy();

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
 import { describe, expect, it } from "vitest";
+import type { EditorAPI } from "@floatboat/nexus-core";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-react", () => {
@@ -13,6 +14,32 @@ describe("@floatboat/nexus-react", () => {
     unmount();
 
     expect(container.querySelector(".cm-editor")).toBeNull();
+  });
+
+  it("passes container props through and calls onReady with the core editor", () => {
+    const readyEditors: EditorAPI[] = [];
+    const { container, unmount } = render(
+      <Editor
+        initialValue="# Ready"
+        id="nexus-react-editor"
+        className="editor-shell"
+        data-testid="editor-host"
+        aria-label="Markdown editor"
+        onReady={(editor) => readyEditors.push(editor)}
+      />
+    );
+
+    const host = container.querySelector<HTMLElement>("[data-testid='editor-host']");
+
+    expect(host).not.toBeNull();
+    expect(host?.id).toBe("nexus-react-editor");
+    expect(host?.classList.contains("editor-shell")).toBe(true);
+    expect(host?.getAttribute("aria-label")).toBe("Markdown editor");
+    expect(host?.querySelector(".cm-editor")).not.toBeNull();
+    expect(readyEditors).toHaveLength(1);
+    expect(readyEditors[0]?.getDocument()).toBe("# Ready");
+
+    unmount();
   });
 
   it("exposes the core editor api through useEditor", () => {
@@ -36,5 +63,24 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady from useEditor when the editor is mounted", () => {
+    const readyDocs: string[] = [];
+
+    function Harness() {
+      const { containerRef } = useEditor({
+        initialValue: "hook-ready",
+        onReady(editor) {
+          readyDocs.push(editor.getDocument());
+        }
+      });
+
+      return <div ref={containerRef} />;
+    }
+
+    render(<Harness />);
+
+    expect(readyDocs).toEqual(["hook-ready"]);
   });
 });

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -1,18 +1,36 @@
 import { defineComponent, h } from "vue";
+import type { PropType } from "vue";
 
 import { useEditor } from "./use-editor";
+import type { UseEditorConfig } from "./types";
+
+const editorProps = {
+  initialValue: String,
+  parser: Object as PropType<UseEditorConfig["parser"]>,
+  parseDelayMs: Number,
+  livePreview: [Boolean, Object] as PropType<UseEditorConfig["livePreview"]>,
+  plugins: Array as PropType<UseEditorConfig["plugins"]>,
+  theme: Object as PropType<UseEditorConfig["theme"]>,
+  locale: Object as PropType<UseEditorConfig["locale"]>,
+  tabSize: Number,
+  direction: String as PropType<UseEditorConfig["direction"]>,
+  indentGuides: Boolean,
+  readOnly: Boolean,
+  slashMenuLimit: Number,
+  onChange: Function as PropType<UseEditorConfig["onChange"]>,
+  onFocus: Function as PropType<UseEditorConfig["onFocus"]>,
+  onBlur: Function as PropType<UseEditorConfig["onBlur"]>,
+  onAssetUpload: Function as PropType<UseEditorConfig["onAssetUpload"]>,
+  onReady: Function as PropType<UseEditorConfig["onReady"]>
+};
 
 export const Editor = defineComponent({
   name: "NexusEditor",
-  props: {
-    initialValue: {
-      type: String,
-      required: false
-    }
-  },
-  setup(props) {
+  inheritAttrs: false,
+  props: editorProps,
+  setup(props, { attrs }) {
     const { containerRef } = useEditor(props);
 
-    return () => h("div", { ref: containerRef });
+    return () => h("div", { ...attrs, ref: containerRef });
   }
 });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -2,9 +2,14 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { Ref, ShallowRef } from "vue";
+import type { HTMLAttributes, Ref, ShallowRef } from "vue";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  onReady?: (editor: EditorAPI) => void;
+}
+
+export type EditorProps = UseEditorConfig &
+  Omit<HTMLAttributes, keyof UseEditorConfig | "ref">;
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -12,10 +12,12 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
+    const { onReady, ...editorConfig } = config;
     editor.value = createEditor({
       container: containerRef.value,
-      ...config
+      ...editorConfig
     });
+    onReady?.(editor.value);
   });
 
   onBeforeUnmount(() => {

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, onMounted } from "vue";
 import { describe, expect, it } from "vitest";
+import type { EditorAPI } from "@floatboat/nexus-core";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-vue", () => {
@@ -19,6 +20,36 @@ describe("@floatboat/nexus-vue", () => {
     wrapper.unmount();
 
     expect(wrapper.element.querySelector(".cm-editor")).toBeNull();
+  });
+
+  it("passes container attrs through and calls onReady with the core editor", async () => {
+    const readyEditors: EditorAPI[] = [];
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "# Ready",
+        onReady(editor: EditorAPI) {
+          readyEditors.push(editor);
+        }
+      },
+      attrs: {
+        id: "nexus-vue-editor",
+        class: "editor-shell",
+        "data-testid": "editor-host",
+        "aria-label": "Markdown editor"
+      }
+    });
+
+    await nextTick();
+
+    expect(wrapper.element.id).toBe("nexus-vue-editor");
+    expect(wrapper.classes()).toContain("editor-shell");
+    expect(wrapper.attributes("data-testid")).toBe("editor-host");
+    expect(wrapper.attributes("aria-label")).toBe("Markdown editor");
+    expect(wrapper.element.querySelector(".cm-editor")).not.toBeNull();
+    expect(readyEditors).toHaveLength(1);
+    expect(readyEditors[0]?.getDocument()).toBe("# Ready");
+
+    wrapper.unmount();
   });
 
   it("exposes the core editor api through useEditor", async () => {
@@ -44,5 +75,28 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady from useEditor when the editor is mounted", async () => {
+    const readyDocs: string[] = [];
+
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef } = useEditor({
+          initialValue: "hook-ready",
+          onReady(editor) {
+            readyDocs.push(editor.getDocument());
+          }
+        });
+
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    mount(Harness);
+
+    await nextTick();
+
+    expect(readyDocs).toEqual(["hook-ready"]);
   });
 });


### PR DESCRIPTION
## Summary / 摘要

Add `onReady` lifecycle callbacks and host container prop passthrough for the React and Vue editor bindings.

## Motivation / 背景与动机

Implements roadmap item #4: `<Editor />` container pass-through props + `onReady` callback for React and Vue SDKs.

- Issue:
- Roadmap (docs/ROADMAP.md): #4 `<Editor />` container pass-through props + `onReady` callback
- OpenSpec change: Not required

## Changes / 变更内容

- `packages/react`:
  - Add `EditorProps` and `onReady` support to `UseEditorConfig`.
  - Split editor config props from host div props in `<Editor />`.
  - Pass host attributes such as `className`, `style`, `data-*`, and `aria-*` to the container.

- `packages/vue`:
  - Add `EditorProps` and `onReady` support to `UseEditorConfig`.
  - Declare editor config props on `<Editor />`.
  - Use `$attrs` for host container passthrough.

- `docs`:
  - Document `onReady` and container passthrough in English and Chinese README examples.

## Testing / 测试

- [x] `corepack pnpm exec vitest run`
- [x] `corepack pnpm -r exec tsc --noEmit`
- [x] `corepack pnpm -r --filter './packages/*' run build`
- [x] Added React and Vue Vitest coverage for `onReady` and container passthrough.

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
  - Not touched
- [x] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
  - Not required by roadmap
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

No visible editor UI change; this updates SDK lifecycle and host container props.