### PR TITLE
feat(electron-demo): refresh workspace shell

### DIFF
--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -21,11 +21,56 @@ let backlinks: BacklinksPanel;
 const linkIndex = new LinkIndex();
 state.linkIndex = linkIndex;
 
+type AppIcon = "vault" | "outline" | "backlinks" | "search" | "settings";
+
+const APP_ICONS: Record<AppIcon, string> = {
+  vault: '<path d="M4 5.5h6l1.5 2H20v11H4z"/><path d="M4 8h16"/>',
+  outline: '<path d="M8 6h12M8 12h12M8 18h12"/><path d="M4 6h.01M4 12h.01M4 18h.01"/>',
+  backlinks: '<path d="M10 13a5 5 0 0 0 7.5.5l2-2a5 5 0 0 0-7-7l-1.15 1.15"/><path d="M14 11a5 5 0 0 0-7.5-.5l-2 2a5 5 0 0 0 7 7l1.15-1.15"/>',
+  search: '<circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/>',
+  settings: '<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06A1.7 1.7 0 0 0 15 19.4a1.7 1.7 0 0 0-1 .6 1.7 1.7 0 0 0-.4 1.1V21h-4v-.1A1.7 1.7 0 0 0 8.6 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-.6-1 1.7 1.7 0 0 0-1.1-.4H3v-4h.1A1.7 1.7 0 0 0 4.6 8.6a1.7 1.7 0 0 0-.34-1.88l-.06-.06 2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.6a1.7 1.7 0 0 0 1-.6 1.7 1.7 0 0 0 .4-1.1V3h4v.1A1.7 1.7 0 0 0 15.4 4.6a1.7 1.7 0 0 0 1.88-.34l.06-.06 2.83 2.83-.06.06A1.7 1.7 0 0 0 19.4 9c.17.36.38.7.6 1 .28.3.67.46 1.1.46h.1v4h-.1c-.43 0-.82.16-1.1.46-.22.3-.43.64-.6 1.08Z"/>',
+};
+
+function createIcon(name: AppIcon): SVGSVGElement {
+  const namespace = "http://www.w3.org/2000/svg";
+  const icon = document.createElementNS(namespace, "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "1.8");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.innerHTML = APP_ICONS[name];
+  return icon;
+}
+
+function createUtilityButton(
+  name: AppIcon,
+  label: string,
+  onClick: () => void,
+  toggle = false
+): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "toolbar-icon-button";
+  button.title = label;
+  button.setAttribute("aria-label", label);
+  if (toggle) button.setAttribute("aria-pressed", "true");
+  button.appendChild(createIcon(name));
+  button.addEventListener("click", onClick);
+  return button;
+}
+
 function createAppToolbar(): HTMLElement {
-  const toolbar = document.createElement("div");
+  const toolbar = document.createElement("header");
   toolbar.className = "toolbar";
 
+  const fileActions = document.createElement("div");
+  fileActions.className = "toolbar-file-actions";
+
   const vaultBtn = document.createElement("button");
+  vaultBtn.type = "button";
   vaultBtn.textContent = "Vault";
   vaultBtn.title = "Open a folder as a vault";
   vaultBtn.addEventListener("click", () => {
@@ -33,62 +78,47 @@ function createAppToolbar(): HTMLElement {
   });
 
   const openBtn = document.createElement("button");
+  openBtn.type = "button";
   openBtn.textContent = "Open";
   openBtn.addEventListener("click", handleOpen);
 
   const saveBtn = document.createElement("button");
+  saveBtn.type = "button";
   saveBtn.textContent = "Save";
   saveBtn.addEventListener("click", handleSave);
 
   const saveAsBtn = document.createElement("button");
+  saveAsBtn.type = "button";
   saveAsBtn.textContent = "Save As";
   saveAsBtn.addEventListener("click", handleSaveAs);
 
-  const spacer = document.createElement("div");
-  spacer.style.flex = "1";
+  fileActions.append(vaultBtn, openBtn, saveBtn, saveAsBtn);
 
-  const vaultToggleBtn = document.createElement("button");
-  vaultToggleBtn.textContent = "\uD83D\uDCD1"; // 📑
-  vaultToggleBtn.title = "Toggle vault panel";
-  vaultToggleBtn.style.fontSize = "14px";
-  vaultToggleBtn.addEventListener("click", toggleVault);
+  const utilityActions = document.createElement("div");
+  utilityActions.className = "toolbar-utility-actions";
+  const vaultToggleBtn = createUtilityButton("vault", "Toggle vault panel", () => {
+    toggleVault();
+    syncToggleState(vaultToggleBtn, vault.element);
+  }, true);
+  const outlineBtn = createUtilityButton("outline", "Toggle outline", () => {
+    toggleOutline();
+    syncToggleState(outlineBtn, outline.element);
+  }, true);
+  const backlinksBtn = createUtilityButton("backlinks", "Toggle backlinks panel", () => {
+    toggleBacklinks();
+    syncToggleState(backlinksBtn, backlinks.element);
+  }, true);
+  const searchBtn = createUtilityButton("search", "Search (Ctrl+F)", () => searchBar.open());
+  const settingsBtn = createUtilityButton("settings", "Settings", handleSettings);
 
-  const outlineBtn = document.createElement("button");
-  outlineBtn.textContent = "\u2630"; // ☰
-  outlineBtn.title = "Toggle outline";
-  outlineBtn.style.fontSize = "14px";
-  outlineBtn.addEventListener("click", toggleOutline);
-
-  const backlinksBtn = document.createElement("button");
-  backlinksBtn.textContent = "\uD83D\uDD17"; // 🔗
-  backlinksBtn.title = "Toggle backlinks panel";
-  backlinksBtn.style.fontSize = "14px";
-  backlinksBtn.addEventListener("click", toggleBacklinks);
-
-  const searchBtn = document.createElement("button");
-  searchBtn.textContent = "\uD83D\uDD0D"; // 🔍
-  searchBtn.title = "Search (Ctrl+F)";
-  searchBtn.style.fontSize = "14px";
-  searchBtn.addEventListener("click", () => searchBar.open());
-
-  const settingsBtn = document.createElement("button");
-  settingsBtn.textContent = "\u2699"; // ⚙
-  settingsBtn.title = "Settings";
-  settingsBtn.style.fontSize = "16px";
-  settingsBtn.addEventListener("click", handleSettings);
-
-  toolbar.append(
-    vaultBtn,
-    openBtn,
-    saveBtn,
-    saveAsBtn,
-    spacer,
+  utilityActions.append(
     vaultToggleBtn,
     outlineBtn,
     backlinksBtn,
     searchBtn,
     settingsBtn
   );
+  toolbar.append(fileActions, utilityActions);
   return toolbar;
 }
 
@@ -188,6 +218,10 @@ function togglePanel(panel: HTMLElement, onShow?: () => void): void {
   } else {
     panel.style.display = "none";
   }
+}
+
+function syncToggleState(button: HTMLButtonElement, panel: HTMLElement): void {
+  button.setAttribute("aria-pressed", String(panel.style.display !== "none"));
 }
 
 function toggleOutline(): void {

--- a/apps/electron-demo/src/renderer/backlinks-panel.ts
+++ b/apps/electron-demo/src/renderer/backlinks-panel.ts
@@ -133,11 +133,13 @@ export function createBacklinksPanel(options: BacklinksPanelOptions): BacklinksP
   root.style.cssText = PANEL_STYLES;
 
   const header = document.createElement("div");
+  header.className = "nexus-panel-header";
   header.style.cssText = HEADER_STYLES;
   header.textContent = "Backlinks";
   root.appendChild(header);
 
   const list = document.createElement("div");
+  list.className = "nexus-backlinks-list";
   list.style.cssText = LIST_STYLES;
   root.appendChild(list);
 

--- a/apps/electron-demo/src/renderer/outline-panel.ts
+++ b/apps/electron-demo/src/renderer/outline-panel.ts
@@ -66,10 +66,12 @@ export function createOutlinePanel(editor: EditorAPI): OutlinePanel {
   panel.style.cssText = PANEL_STYLES;
 
   const header = document.createElement("div");
+  header.className = "nexus-panel-header";
   header.style.cssText = HEADER_STYLES;
   header.textContent = "Outline";
 
   const list = document.createElement("div");
+  list.className = "nexus-outline-list";
   list.style.cssText = LIST_STYLES;
 
   panel.append(header, list);

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -4,43 +4,166 @@
   box-sizing: border-box;
 }
 
+:root {
+  color-scheme: light;
+  --workspace-chrome: #f4f4f4;
+  --workspace-line: #dedede;
+  --workspace-line-soft: #e9e9e9;
+  --workspace-text: #232323;
+  --workspace-muted: #858585;
+  --workspace-faint: #b7b7b7;
+  --workspace-hover: #e9e9e9;
+}
+
 html,
 body,
 #app {
   height: 100%;
 }
 
+body {
+  overflow: hidden;
+  background: #fff;
+}
+
+button,
+input {
+  font: inherit;
+}
+
 #app {
   display: flex;
   flex-direction: column;
-  font-family: system-ui, sans-serif;
+  min-width: 720px;
+  color: var(--workspace-text);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .toolbar {
   display: flex;
-  gap: 8px;
-  padding: 8px 12px;
-  background: #f0f0f0;
-  border-bottom: 1px solid #ddd;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 58px;
+  padding: 8px 13px;
+  background: var(--workspace-chrome);
+  border-bottom: 1px solid var(--workspace-line);
   flex-shrink: 0;
 }
 
+.toolbar-file-actions,
+.toolbar-utility-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .toolbar button {
-  padding: 4px 12px;
+  height: 39px;
+  padding: 0 16px;
+  border: 1px solid #868686;
+  border-radius: 3px;
+  background: linear-gradient(#fafafa, #f1f1f1);
+  color: #161616;
+  font-size: 16px;
+  line-height: 1;
   cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.toolbar button:hover {
+  border-color: #626262;
+  background: #fff;
+}
+
+.toolbar button:focus-visible {
+  outline: 2px solid var(--nexus-accent, #356fd4);
+  outline-offset: 2px;
+}
+
+.toolbar .toolbar-icon-button {
+  width: 51px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+}
+
+.toolbar-icon-button svg {
+  width: 19px;
+  height: 19px;
+}
+
+.toolbar-icon-button[aria-pressed="true"] {
+  background: #ededed;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .main-area {
   flex: 1;
   display: flex;
+  min-height: 0;
   overflow: hidden;
+}
+
+.nexus-vault-panel {
+  width: 290px !important;
+  border-right-color: var(--workspace-line-soft) !important;
 }
 
 .editor-column {
   flex: 1;
+  min-width: 300px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.nexus-outline-panel {
+  width: 268px !important;
+  border-right-color: var(--workspace-line-soft) !important;
+  border-left: 1px solid var(--workspace-line-soft);
+}
+
+.backlinks-panel {
+  width: 340px !important;
+  border-left-color: var(--workspace-line-soft) !important;
+}
+
+.nexus-panel-header {
+  min-height: 41px;
+  padding: 0 14px !important;
+  display: flex !important;
+  align-items: center !important;
+  border-bottom-color: var(--workspace-line-soft) !important;
+  color: var(--workspace-muted) !important;
+  font-size: 13px !important;
+  font-weight: 650 !important;
+  letter-spacing: 0.5px !important;
+}
+
+.nexus-vault-header {
+  gap: 5px !important;
+}
+
+.nexus-vault-header button {
+  width: 29px;
+  height: 29px;
+  padding: 0 !important;
+  display: grid;
+  place-items: center;
+  color: #8b949e !important;
+}
+
+.nexus-panel-title {
+  font-size: 13px !important;
+  color: var(--workspace-muted) !important;
+}
+
+.nexus-vault-tree,
+.nexus-outline-list,
+.nexus-backlinks-list {
+  scrollbar-color: #c9c9c9 transparent;
+  scrollbar-width: thin;
 }
 
 .editor-container {
@@ -55,6 +178,30 @@ body,
 .editor-container > [data-nexus-toolbar],
 .editor-container > [role="toolbar"] {
   flex-shrink: 0;
+  min-height: 52px;
+  padding: 7px 17px !important;
+  gap: 3px !important;
+  background: #fafafa !important;
+  border-bottom: 1px dotted #6d6d6d !important;
+  overflow-x: auto;
+}
+
+.editor-container .nexus-toolbar-btn {
+  width: 31px !important;
+  height: 31px !important;
+  color: #858585 !important;
+  border-radius: 3px !important;
+}
+
+.editor-container .nexus-toolbar-btn:hover {
+  color: #444 !important;
+  background: var(--workspace-hover) !important;
+}
+
+.editor-container .nexus-toolbar-separator {
+  height: 25px !important;
+  margin: 0 5px !important;
+  background: #dedede !important;
 }
 
 .editor-container .cm-editor {
@@ -63,13 +210,101 @@ body,
   height: auto;
 }
 
+.editor-container .cm-scroller {
+  font-family: inherit;
+}
+
+.editor-container .cm-content {
+  padding-top: 17px;
+}
+
+.editor-container .cm-gutters {
+  min-width: 40px;
+  background: #f8f9fa;
+  border-right-color: var(--workspace-line-soft);
+}
+
+.editor-container .cm-lineNumbers .cm-gutterElement {
+  padding-right: 10px;
+  color: #b4b4b4;
+}
+
 .status-line {
-  padding: 4px 12px;
-  font-size: 13px;
-  color: #666;
+  min-height: 11px;
+  max-height: 24px;
+  padding: 3px 12px;
+  overflow: hidden;
+  color: #777;
   background: #fafafa;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--workspace-line-soft);
+  font-size: 11px;
+  line-height: 17px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   flex-shrink: 0;
+}
+
+@media (max-width: 1500px) {
+  .nexus-vault-panel {
+    width: 240px !important;
+  }
+
+  .nexus-outline-panel {
+    width: 220px !important;
+  }
+
+  .backlinks-panel {
+    width: 280px !important;
+  }
+}
+
+@media (max-width: 1050px) {
+  .toolbar-file-actions,
+  .toolbar-utility-actions {
+    gap: 6px;
+  }
+
+  .toolbar button {
+    padding: 0 12px;
+  }
+
+  .nexus-vault-panel {
+    width: 190px !important;
+  }
+
+  .nexus-outline-panel {
+    width: 170px !important;
+  }
+
+  .backlinks-panel {
+    width: 220px !important;
+  }
+
+  .editor-column {
+    min-width: 260px;
+  }
+}
+
+@media (max-width: 820px) {
+  .toolbar .toolbar-icon-button {
+    width: 42px;
+  }
+
+  .nexus-vault-panel {
+    width: 160px !important;
+  }
+
+  .nexus-outline-panel {
+    width: 140px !important;
+  }
+
+  .backlinks-panel {
+    width: 180px !important;
+  }
+
+  .editor-column {
+    min-width: 240px;
+  }
 }
 
 /* Syntax highlighting for fenced code blocks.

--- a/apps/electron-demo/src/renderer/vault-panel.ts
+++ b/apps/electron-demo/src/renderer/vault-panel.ts
@@ -188,9 +188,11 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
   panel.style.cssText = PANEL_STYLES;
 
   const header = document.createElement("div");
+  header.className = "nexus-panel-header nexus-vault-header";
   header.style.cssText = HEADER_STYLES;
 
   const title = document.createElement("div");
+  title.className = "nexus-panel-title";
   title.style.cssText = HEADER_TITLE_STYLES;
   title.textContent = "Vault";
 
@@ -230,6 +232,7 @@ export function createVaultPanel(callbacks: VaultPanelCallbacks): VaultPanel {
   }
 
   const tree = document.createElement("div");
+  tree.className = "nexus-vault-tree";
   tree.style.cssText = TREE_STYLES;
 
   panel.append(header, tree);

--- a/openspec/changes/update-electron-workspace-shell/proposal.md
+++ b/openspec/changes/update-electron-workspace-shell/proposal.md
@@ -1,0 +1,16 @@
+# Change: Update the Electron workspace shell
+
+## Why
+The Electron demo exposes the right editor capabilities, but its default browser-like styling does not present them as a cohesive desktop workspace. The supplied reference establishes a clearer hierarchy for file actions, panel controls, navigation, editing, outline, and backlinks.
+
+## What Changes
+- Restyle the Electron demo as a compact four-column writing workspace.
+- Replace emoji utility controls with consistent monochrome SVG icons.
+- Expose pressed state for panel toggle buttons.
+- Align panel headers, empty states, editor toolbar, gutters, and status line with the reference layout.
+- Preserve all existing file, vault, search, settings, outline, and backlink behavior.
+
+## Impact
+- Affected specs: electron-demo workspace shell
+- Affected code: `apps/electron-demo/src/renderer/app.ts`, renderer panels, and `style.css`
+- No changes to package APIs, persistence, or Electron IPC

--- a/openspec/changes/update-electron-workspace-shell/specs/electron-workspace-shell/spec.md
+++ b/openspec/changes/update-electron-workspace-shell/specs/electron-workspace-shell/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Reference workspace layout
+The Electron demo SHALL present file actions, vault navigation, the editor, outline navigation, and backlinks in a visually coherent desktop workspace based on the supplied reference.
+
+#### Scenario: Initial workspace
+- **WHEN** the Electron renderer starts
+- **THEN** file actions appear in the leading area of the top bar
+- **AND** panel, search, and settings controls appear in the trailing area
+- **AND** the vault, editor, outline, and backlinks regions remain visually distinct
+
+### Requirement: Panel toggle state
+Panel toggle controls SHALL expose whether their associated panel is currently visible.
+
+#### Scenario: Toggle a workspace panel
+- **WHEN** the user activates a vault, outline, or backlinks toggle
+- **THEN** the corresponding panel changes visibility
+- **AND** the control's pressed state reflects the resulting visibility
+
+### Requirement: Responsive workspace
+The workspace SHALL preserve the editor as the primary surface when the available window width is constrained.
+
+#### Scenario: Narrow window
+- **WHEN** the application window becomes narrower than the full four-column layout
+- **THEN** secondary panels use reduced widths or are hidden at defined breakpoints
+- **AND** the editor remains usable

--- a/openspec/changes/update-electron-workspace-shell/tasks.md
+++ b/openspec/changes/update-electron-workspace-shell/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+- [x] 1.1 Rework the application toolbar structure and icon controls.
+- [x] 1.2 Add stable classes to workspace panel internals.
+- [x] 1.3 Implement the reference-inspired workspace styling and responsive behavior.
+- [x] 1.4 Verify panel controls retain accessible labels and pressed state.
+
+## 2. Verification
+- [x] 2.1 Run Electron demo tests.
+- [x] 2.2 Run the Electron demo production build.
+- [x] 2.3 Review the rendered workspace and update this checklist.


### PR DESCRIPTION
## Summary
- restyle the Electron demo main workspace to match the supplied four-column reference
- replace emoji utility controls with consistent SVG icons and accessible pressed states
- add responsive panel sizing while preserving existing vault, editor, outline, and backlinks behavior
- document the UI change through OpenSpec proposal, requirements, and completed tasks

## Verification
- `pnpm --filter @floatboat/nexus-electron-demo test` (58 tests passed)
- `pnpm --filter @floatboat/nexus-electron-demo exec tsc --noEmit`
- `pnpm --filter @floatboat/nexus-electron-demo build`
- visually reviewed the renderer at 2048x1000 against the supplied reference

## Notes
- Vite still reports the repository's existing large-chunk warning during production build.