### PR TITLE
feat(core): multi-cursor / multi-selection support (ROADMAP #6)

### DIFF
--- a/apps/electron-demo/src/renderer/editor-shell.ts
+++ b/apps/electron-demo/src/renderer/editor-shell.ts
@@ -118,6 +118,9 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
     // edges across the vault). 150ms is imperceptible for typing UX but
     // batches bursts of keystrokes into one parse.
     parseDelayMs: 150,
+    // Multi-cursor editing: Alt-click adds a cursor, Mod-d selects the next
+    // occurrence, Mod-Alt-ArrowUp/Down stacks cursors (ROADMAP #6).
+    multiCursor: true,
     plugins: [
       createGfmPreset(),
       createHistoryPlugin(),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,7 +34,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
 | 5 | `getSelectedText()` API | `core` | P0 | in-progress | No | Public API addition; needs types + tests — PR #8 in review |
-| 6 | Multi-cursor / multi-selection | `core` | P1 | planned | Yes | CM6 supports it; must verify live-preview and table interactions |
+| 6 | Multi-cursor / multi-selection | `core` | P1 | in-progress | Yes | `openspec/changes/add-core-multi-cursor` — opt-in `multiCursor` config; live-preview reveal + table checks verified by regression tests |
 | 7 | AST enhancement / Markdown extensions | `core` + `preset-gfm` | P2 | planned | Yes | Affects serialization and every AST-dependent plugin |
 | 8 | Undo / redo grouping | `plugin-history` | P1 | planned | No | Coordinate with table's `tableEditingCount` |
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -34,7 +34,7 @@
 | # | 功能 | 归属包 | 优先级 | 状态 | 需要 OpenSpec | 备注 |
 |---|---|---|---|---|---|---|
 | 5 | `getSelectedText()` API | `core` | P0 | in-progress | 否 | 公共 API 增量，需补类型 + 测试 —— PR #8 review 中 |
-| 6 | 多光标 / 多选支持 | `core` | P1 | planned | 是 | CM6 已有底层，需在 live-preview 与表格交互中验证不破坏 |
+| 6 | 多光标 / 多选支持 | `core` | P1 | in-progress | 是 | `openspec/changes/add-core-multi-cursor` — opt-in `multiCursor` 配置；live-preview 揭示与表格检查已有回归测试覆盖 |
 | 7 | AST 增强 / Markdown 扩展 | `core` + `preset-gfm` | P2 | planned | 是 | 影响序列化与所有依赖 AST 的插件 |
 | 8 | undo / redo 分组 | `plugin-history` | P1 | planned | 否 | 注意与表格交互的 `tableEditingCount` 协同 |
 

--- a/openspec/changes/add-core-multi-cursor/design.md
+++ b/openspec/changes/add-core-multi-cursor/design.md
@@ -1,0 +1,46 @@
+# Design — Multi-Cursor / Multi-Selection
+
+## Decision 1: Opt-in config flag, not default-on
+
+`drawSelection()` swaps the native caret/selection rendering for CM-drawn layers (`.cm-cursor`, `.cm-selectionBackground`). That is a visible change for every existing consumer even if they never use a second cursor. `multiCursor` therefore defaults to `false`; the electron demo turns it on so the feature is dogfooded. Flipping the default later is a one-line, separately-reviewable decision.
+
+## Decision 2: Hand-rolled `selectNextOccurrence` instead of `@codemirror/search`
+
+`@codemirror/search` exports a `selectNextOccurrence`, but depending on it from core would pull the search panel/UI module into every core consumer's bundle just for one ~50-line command. `plugin-search` already owns that dependency for hosts that want the full search feature. The in-core implementation is a plain forward scan over `state.doc` with wrap-around:
+
+- If **any** range is empty → expand every empty range to the word around it (`state.wordAt`); this invocation adds no new range (VS Code behaviour). If the main range is empty and has no word under it, return `false`.
+- Otherwise → take the main range's text as the query, scan forward from the end of the *last* range, wrapping to the document start; skip occurrences already covered by an existing range; add the first hit as the new **main** range and scroll it into view. No hit anywhere → return `false`.
+- Matching is case-sensitive and not word-bounded (same as CM's behaviour once ranges are non-empty).
+
+## Decision 3: `addCursorAbove/Below` move by logical lines, not visual lines
+
+`view.moveVertically` would respect soft-wrap but depends on pixel measurement, which is unreliable headless (jsdom) and irrelevant for the dominant no-wrap markdown-source case. The commands instead compute the target from the document: previous/next logical line, column preserved via `min(column, targetLine.length)`. The cursor is added from the **topmost** range for Above and the **bottommost** for Below, so repeated presses grow a contiguous cursor stack. Deterministic, fully unit-testable.
+
+## Decision 4: Per-range Enter via one combined dispatch
+
+`handleMarkdownEnter` must keep consuming the key only when it has something markdown-specific to do. New contract:
+
+- If **no** range sits on a list/blockquote line → return `false` (default Enter for all cursors, exactly as before for single-cursor on plain text).
+- Otherwise build one change set covering **all** ranges: continuation prefix for list/quote lines, empty-item exit (delete line content) for empty items, plain `"\n"` for ranges on non-continuable lines, and non-empty (selection) ranges replace their span with `"\n"`.
+- Two cursors on the same empty list item would produce overlapping deletions; the first range on a line wins and subsequent same-line ranges become no-ops (`handledLines` set).
+
+Changes are accumulated with explicit position bookkeeping (`changes` array + per-range new anchors mapped through `state.changes(...)`) rather than N separate dispatches, so the whole edit is one undo step and one `selectionChange`.
+
+## Decision 5: Event payload stays backward-compatible
+
+`selectionChange` currently emits `{ anchor, head }` of the main range. The payload becomes `{ anchor, head, ranges, mainIndex }` — same object shape extended, so `({ anchor, head }) => ...` listeners keep working. `getSelection()` is untouched; `getSelections()` is the multi-range accessor.
+
+## Decision 6: Table widget stays single-cell; only read-only checks widen
+
+Multi-cursor inside contentEditable table cells is out of scope (cells are not CM selections). The two `selection.main` reads in `live-preview-table.ts` widen to all ranges:
+
+- *Whole-table-selected overlay*: shown when **any** range fully covers the table source (`ranges.some(...)`).
+- *Clear range selection when the cursor leaves the table*: only when **every** range head is outside the table span (`ranges.every(...)`) — a secondary cursor inside the table must keep the cell-range selection alive.
+
+Both are pure condition widenings inside the existing rAF poll; no state lifecycle, locking, or DOM mutation changes (audited against the 12 table rules in `CLAUDE.md`).
+
+## Testing strategy
+
+- `multi-cursor.test.ts` (real `createEditor` in jsdom, as the existing suites do): config gating (off → multi-range `setSelections` collapses; on → preserved), all four commands incl. word-expansion / wrap-around / skip-selected / document-edge cases, per-range Enter and autopair behaviour, API + event payload.
+- `live-preview-regressions.test.ts`: two cursors on two different bold spans → both reveal raw `**` markers; collapse to elsewhere → both hidden again. Guards the `.some()`-based reveal logic against future "optimise to main range" regressions.
+- `markdown-keymap.test.ts`: existing single-cursor cases unchanged (behaviour lock), new multi-range cases.

--- a/openspec/changes/add-core-multi-cursor/proposal.md
+++ b/openspec/changes/add-core-multi-cursor/proposal.md
@@ -1,0 +1,61 @@
+# Change: Add Multi-Cursor / Multi-Selection Support to Core
+
+## Why
+
+Roadmap item **#6 — Multi-cursor / multi-selection (`core`, P1)** is the highest-priority core editing feature not yet started. CodeMirror 6 ships the underlying machinery (`EditorState.allowMultipleSelections`, `drawSelection`), but Nexus never enables it, so today any attempt to create multiple selection ranges silently collapses to a single range.
+
+Simply turning the facet on is not enough — the roadmap row itself warns: *"CM6 supports it; must verify live-preview and table interactions"*. An audit of the codebase found four concrete gaps that make naive enablement broken or lossy:
+
+1. **No rendering**: secondary cursors and selections are invisible without `drawSelection()` (the native DOM selection can only show one range).
+2. **`handleMarkdownEnter` is main-range only** (`packages/core/src/markdown-keymap.ts`): with two cursors on two list items, pressing Enter continues the list at the main cursor and *drops the keystroke entirely* for every other cursor, because the keymap consumes the event after dispatching a single-range change.
+3. **`markdownAutoPair` is main-range only** (`packages/core/src/markdown-autopair.ts`): the input handler wraps/pairs at the main selection and returns `true`, so secondary cursors lose the typed character.
+4. **No commands or API**: there is no way to *create* multiple cursors from the keyboard (select-next-occurrence, add-cursor-above/below), and `getSelection` / `setSelection` / the `selectionChange` event only speak single-range.
+
+The live-preview decoration pipeline is already multi-range aware (`buildDecorations` receives `state.selection.ranges` and the helpers in `live-preview-ranges.ts` use `.some()` across ranges), which keeps this change tractable: the work is enablement, command surface, multi-range correctness in the two keymap/input handlers, API exposure, and regression coverage for live-preview/table interplay.
+
+## What Changes
+
+- **Core (`@floatboat/nexus-core`)**:
+  - New `EditorConfig.multiCursor?: boolean` (default **`false`**). When enabled, the editor activates `EditorState.allowMultipleSelections` + `drawSelection()` and installs the multi-cursor keymap. Default-off keeps existing consumers pixel-identical (drawSelection replaces the native caret/selection layer, a visible rendering change).
+  - **New module `packages/core/src/multi-cursor.ts`** exporting four standalone CodeMirror commands (usable by hosts/plugins regardless of config) and the bundled extension:
+    - `selectNextOccurrence` (`Mod-d`) — VS Code-style: empty ranges expand to the word under each cursor first; subsequent invocations add the next occurrence of the main-range text, searching forward from the last range and wrapping past the end of the document; occurrences already covered by a range are skipped. Implemented in-core with a plain document scan — no `@codemirror/search` dependency, which would pull panel/UI infrastructure into every core bundle.
+    - `addCursorAbove` (`Mod-Alt-ArrowUp`) / `addCursorBelow` (`Mod-Alt-ArrowDown`) — add a cursor on the previous/next *logical* line, preserving the column where the line is long enough and clamping to the line end otherwise. Returns `false` at the document edge.
+    - `collapseToMainSelection` (`Escape`) — drop secondary ranges, keep the main one. Returns `false` when the selection is already single-range so other Escape handlers (slash menu, search panel) keep working.
+  - **API additions** (all additive, no breaking changes):
+    - `getSelections(): { ranges: { anchor: number; head: number }[]; mainIndex: number }`
+    - `setSelections(ranges, mainIndex?)` — multiple ranges require `multiCursor: true`; otherwise CM collapses to the main range (documented).
+    - `selectionChange` event payload gains `ranges` and `mainIndex` fields alongside the existing `anchor` / `head` (which keep describing the main range).
+  - **Multi-range correctness fixes**:
+    - `handleMarkdownEnter` rewritten to handle *every* selection range: list/blockquote continuation per cursor, empty-item exit per cursor, plain newline for cursors on non-continuable lines. Single-cursor behaviour is unchanged (verified by the existing `markdown-keymap.test.ts` suite).
+    - `markdownAutoPair` rewritten per-range: wrap each non-empty range, pair-insert at each empty cursor, with the double-marker (`**`, `~~`) char-before check evaluated per range.
+  - **Table widget** (`live-preview-table.ts`, read-only condition tweaks audited against all 12 CLAUDE.md table rules): the whole-table-selected overlay check and the "cursor left the table" range-clear check now consider all selection ranges, not just the main one.
+- **Electron demo**: enables `multiCursor: true` in `editor-shell.ts` so the feature is exercised end-to-end.
+- **Docs**: new `packages/core/README.md` section documenting the config flag, commands, key bindings, and the selections API; `docs/ROADMAP.md` (+ zh) row #6 → `in-progress` with this change id linked.
+
+React/Vue bindings need no code change: both spread `EditorConfig` through (`UseEditorConfig = Omit<EditorConfig, "container">`), so `multiCursor` flows to `createEditor` automatically.
+
+## Impact
+
+- Affected specs:
+  - `editor-core` (ADDED — `multiCursor` config, selections API, `selectionChange` ranges payload)
+  - `multi-cursor` (ADDED — new capability: commands, key bindings, multi-range editing semantics, live-preview/table interplay)
+- Affected code:
+  - `packages/core/src/multi-cursor.ts` (NEW)
+  - `packages/core/src/editor.ts` (wire config, extend API + event payload)
+  - `packages/core/src/types.ts` (config, API, event types)
+  - `packages/core/src/markdown-keymap.ts` (per-range Enter handling)
+  - `packages/core/src/markdown-autopair.ts` (per-range wrap/pair)
+  - `packages/core/src/live-preview-table.ts` (range-aware overlay/clear checks)
+  - `packages/core/src/index.ts` (export commands + types)
+  - `packages/core/test/multi-cursor.test.ts` (NEW)
+  - `packages/core/test/live-preview-regressions.test.ts` (multi-cursor reveal regression)
+  - `packages/core/test/events.test.ts` (selectionChange payload contract)
+  - `vitest.setup.ts` (NEW — stubs jsdom's missing `Range.getClientRects` for drawSelection's measure cycle) + `vitest.config.ts` (`setupFiles`)
+  - `apps/electron-demo/src/renderer/editor-shell.ts` (enable flag)
+  - `packages/core/README.md` (NEW), `docs/ROADMAP.md`, `docs/ROADMAP.zh.md`
+- New dependencies: none.
+- Out of scope (explicit non-goals):
+  - Multi-cursor editing *inside* table-widget cells — cells are contentEditable DOM, not CM selections; the widget keeps its own single-cell editing model.
+  - IME composition across multiple ranges — CM6 composes at the main range only; secondary-range replication during composition follows upstream behaviour.
+  - Rectangular (Alt-drag column) selection — `rectangularSelection()`/`crosshairCursor()` can layer on later; keyboard + Alt-click + Mod-d cover the roadmap intent.
+  - A `selectAllOccurrences` command (Mod-Shift-l) — trivial to add later on top of the same scan helper, kept out to limit keymap surface.

--- a/openspec/changes/add-core-multi-cursor/specs/editor-core/spec.md
+++ b/openspec/changes/add-core-multi-cursor/specs/editor-core/spec.md
@@ -1,0 +1,34 @@
+# Editor Core Spec — Multi-Cursor Config, Selections API, Selection Event
+
+## ADDED Requirements
+
+### Requirement: Multi-Cursor Config Flag
+
+`EditorConfig` SHALL accept an optional `multiCursor?: boolean` (default `false`). When `true`, the editor SHALL allow multiple selection ranges (`EditorState.allowMultipleSelections`), render secondary cursors and selections via `drawSelection`, and install the multi-cursor keymap. When `false` or omitted, selection handling, caret rendering, and key bindings SHALL be byte-identical to the previous release.
+
+#### Scenario: Default keeps single-selection behaviour
+- **WHEN** an editor is created without `multiCursor`
+- **AND** `setSelections` is called with two ranges
+- **THEN** the resulting selection SHALL collapse to a single range (the designated main range)
+
+#### Scenario: Flag enables multiple ranges
+- **WHEN** an editor is created with `multiCursor: true`
+- **AND** `setSelections` is called with two ranges
+- **THEN** both ranges SHALL be retained and reported by `getSelections()`
+
+### Requirement: Selections API
+
+`EditorAPI` SHALL expose `getSelections(): { ranges: { anchor: number; head: number }[]; mainIndex: number }` and `setSelections(ranges: { anchor: number; head?: number }[], mainIndex?: number): void`. `getSelection()` SHALL keep returning the main range only. `setSelections` with an omitted `mainIndex` SHALL designate the last range as main, mirroring CodeMirror's `EditorSelection.create` default of the latest-added range.
+
+#### Scenario: Round-trip through the selections API
+- **WHEN** `setSelections([{ anchor: 2 }, { anchor: 10, head: 14 }], 0)` is called on a multi-cursor editor
+- **THEN** `getSelections()` SHALL return both ranges with `mainIndex: 0`
+- **AND** `getSelection()` SHALL return `{ anchor: 2, head: 2 }`
+
+### Requirement: Selection Change Event Carries All Ranges
+
+The `selectionChange` event payload SHALL be extended to `{ anchor, head, ranges, mainIndex }`, where `anchor` / `head` continue to describe the main range. Existing listeners destructuring only `anchor` / `head` SHALL observe no behavioural change.
+
+#### Scenario: Multi-range payload
+- **WHEN** the selection changes to two cursors at offsets 3 and 9 (main last)
+- **THEN** `selectionChange` SHALL emit `anchor: 9, head: 9, mainIndex: 1` and `ranges` containing both `{ anchor: 3, head: 3 }` and `{ anchor: 9, head: 9 }`

--- a/openspec/changes/add-core-multi-cursor/specs/multi-cursor/spec.md
+++ b/openspec/changes/add-core-multi-cursor/specs/multi-cursor/spec.md
@@ -1,0 +1,89 @@
+# Multi-Cursor Spec — Commands, Key Bindings, Multi-Range Editing Semantics
+
+## ADDED Requirements
+
+### Requirement: Select Next Occurrence Command
+
+`selectNextOccurrence` (bound to `Mod-d` when `multiCursor` is enabled) SHALL implement VS Code-style occurrence selection: if any selection range is empty, every empty range SHALL expand to the word under it and no new range SHALL be added in that invocation; otherwise the next occurrence of the main range's text SHALL be added as the new main range, searching forward from the last range and wrapping past the document end, skipping occurrences already covered by an existing range. The command SHALL return `false` when there is nothing to do (no word under an empty main cursor, or no unselected occurrence exists).
+
+#### Scenario: Empty cursor expands to word
+- **WHEN** the document is `foo bar foo` with a single empty cursor inside the first `foo`
+- **AND** `selectNextOccurrence` runs
+- **THEN** the selection SHALL become exactly the first `foo` (offsets 0–3) with no second range
+
+#### Scenario: Second invocation adds the next occurrence
+- **WHEN** the first `foo` is selected and `selectNextOccurrence` runs
+- **THEN** the second `foo` (offsets 8–11) SHALL be added as the new main range, keeping the first
+
+#### Scenario: Search wraps around the document end
+- **WHEN** only the *last* occurrence of `foo` is selected and `selectNextOccurrence` runs
+- **THEN** the occurrence at the start of the document SHALL be added
+
+#### Scenario: All occurrences selected
+- **WHEN** every occurrence of the main range's text is already covered by a selection range
+- **THEN** the command SHALL return `false` and the selection SHALL not change
+
+### Requirement: Add Cursor Above / Below Commands
+
+`addCursorAbove` (`Mod-Alt-ArrowUp`) and `addCursorBelow` (`Mod-Alt-ArrowDown`) SHALL add an empty cursor on the previous / next logical line relative to the topmost / bottommost existing range, preserving the column when the target line is long enough and clamping to the target line's end otherwise. At the first / last line the command SHALL return `false`.
+
+#### Scenario: Column preserved going down
+- **WHEN** the document is `alpha\nbeta!\ngamma` with a cursor at column 4 of line 1
+- **AND** `addCursorBelow` runs
+- **THEN** a second cursor SHALL appear at column 4 of line 2 and both cursors SHALL remain
+
+#### Scenario: Column clamped to a shorter line
+- **WHEN** a cursor sits at column 10 and the next line has 3 characters
+- **AND** `addCursorBelow` runs
+- **THEN** the new cursor SHALL sit at the end of that 3-character line
+
+### Requirement: Collapse To Main Selection
+
+`collapseToMainSelection` (`Escape`) SHALL reduce a multi-range selection to its main range and SHALL return `false` when the selection is already a single range, so that other `Escape` bindings continue to receive the key.
+
+#### Scenario: Escape collapses secondary cursors
+- **WHEN** three cursors exist and `Escape` is pressed
+- **THEN** only the main cursor SHALL remain
+
+#### Scenario: Escape falls through on single selection
+- **WHEN** a single cursor exists
+- **THEN** `collapseToMainSelection` SHALL return `false` and SHALL not consume the key
+
+### Requirement: Markdown Enter Handles Every Range
+
+With multiple cursors, the markdown Enter handler SHALL apply its behaviour to **every** selection range in a single dispatch (one undo step): list / blockquote continuation for ranges on continuable lines, empty-item exit for empty items, and a plain newline for ranges on other lines. When **no** range is on a continuable line the handler SHALL return `false` and defer to the default Enter behaviour.
+
+#### Scenario: Two list items continue simultaneously
+- **WHEN** the document is `- a\n- b` with one cursor at the end of each line
+- **AND** Enter is pressed
+- **THEN** both items SHALL gain a continuation line (`- a\n- \n- b\n- `-shaped result) and both cursors SHALL sit after their new markers
+
+#### Scenario: Mixed list and plain-text cursors
+- **WHEN** one cursor is on a list item and another is on a plain paragraph line
+- **AND** Enter is pressed
+- **THEN** the list cursor SHALL get a continuation marker and the plain cursor SHALL get a plain newline
+
+### Requirement: Markdown Auto-Pair Handles Every Range
+
+The markdown auto-pair input handler SHALL apply wrapping (non-empty ranges) and pair insertion (empty ranges) at **every** selection range, evaluating the double-marker (`**`, `~~`) preceding-character check per range. Secondary cursors SHALL never lose a typed character to the handler.
+
+#### Scenario: Backtick wraps two selections
+- **WHEN** two words are selected on different lines and `` ` `` is typed
+- **THEN** both words SHALL be wrapped in backticks
+
+### Requirement: Live Preview Reveals At Every Cursor
+
+Live-preview syntax reveal SHALL treat every selection range as a reveal trigger: inline formatting markers SHALL be visible at each range's location simultaneously, and SHALL hide again when no range remains on the corresponding line.
+
+#### Scenario: Two bold spans reveal together
+- **WHEN** the document contains two `**bold**` spans on different lines and one cursor sits in each
+- **THEN** the raw `**` markers of **both** spans SHALL be visible
+- **AND** collapsing to a single cursor on an unrelated line SHALL hide both again
+
+### Requirement: Table Widget Range Checks Consider All Ranges
+
+The table widget's whole-table-selected overlay SHALL show when **any** selection range fully covers the table source, and the widget SHALL clear an active cell-range selection only when **every** selection range head lies outside the table span. Multi-cursor editing inside table cells remains out of scope (cells are contentEditable DOM, not CodeMirror selections).
+
+#### Scenario: Secondary range covering the table shows the overlay
+- **WHEN** the main cursor is above the table and a secondary range spans the entire table source
+- **THEN** the whole-table selection overlay SHALL be shown

--- a/openspec/changes/add-core-multi-cursor/tasks.md
+++ b/openspec/changes/add-core-multi-cursor/tasks.md
@@ -1,0 +1,32 @@
+# Implementation Tasks
+
+## 1. Core — enablement, commands, keymap
+
+- [x] 1.1 Add `EditorConfig.multiCursor?: boolean` to `packages/core/src/types.ts` with JSDoc covering the default and what it enables.
+- [x] 1.2 Create `packages/core/src/multi-cursor.ts`: `selectNextOccurrence`, `addCursorAbove`, `addCursorBelow`, `collapseToMainSelection` commands plus `multiCursorExtension()` bundling `allowMultipleSelections`, an explicit Alt-click `clickAddsSelectionRange` facet, `drawSelection()`, cursor/selection base theme (CSS vars), and the keymap (`Mod-d`, `Mod-Alt-ArrowUp/Down`, `Escape`).
+- [x] 1.3 Wire `config.multiCursor` into the extension list in `packages/core/src/editor.ts`.
+- [x] 1.4 Export the commands and new types from `packages/core/src/index.ts`.
+
+## 2. Core — selections API and event
+
+- [x] 2.1 Add `getSelections()` / `setSelections(ranges, mainIndex?)` to `EditorAPI` (types + implementation).
+- [x] 2.2 Extend the `selectionChange` payload with `ranges` + `mainIndex` while keeping `anchor` / `head` as the main range; update the exact-payload assertion in `packages/core/test/events.test.ts` to the new contract.
+
+## 3. Core — multi-range editing correctness
+
+- [x] 3.1 Rewrite `handleMarkdownEnter` to process every selection range in one dispatch (continuation / empty-item exit / plain newline), returning `false` only when no range is on a continuable line. Same-line duplicate ranges: first wins.
+- [x] 3.2 Rewrite `markdownAutoPair` to wrap / pair at every range, with the double-marker char-before check evaluated per range.
+- [x] 3.3 Widen the two `selection.main` checks in `live-preview-table.ts` (whole-table overlay → `ranges.some`, leave-table clear → `ranges.every`), re-reading the 12 table rules in `CLAUDE.md` before touching the file.
+
+## 4. Tests
+
+- [x] 4.1 New `packages/core/test/multi-cursor.test.ts` (27 cases): config gating, `setSelections`/`getSelections`, `selectionChange` ranges payload, `selectNextOccurrence` (word expansion, add next, wrap-around, skip-selected, no-match → false), `addCursorAbove/Below` (column preserve, clamp, document edge → false), `collapseToMainSelection` (multi → main, single → false), keymap smoke tests (Mod-d, Escape, flag-off), multi-cursor Enter (two list items, mixed, same-line exit dedupe, defer-to-default) and auto-pair (backtick wrap ×2, double-marker ×2, mixed plain-insert).
+- [x] 4.2 Existing single-cursor suites pass unmodified (`markdown-keymap.test.ts` behaviour lock); multi-range Enter cases live in `multi-cursor.test.ts`.
+- [x] 4.3 Extend `packages/core/test/live-preview-regressions.test.ts`: two cursors reveal raw markers in two separate inline spans simultaneously; moving to a single cursor elsewhere hides both.
+- [x] 4.4 `pnpm test` (345 tests, 29 files), `pnpm build`, `pnpm typecheck` all green. Added `vitest.setup.ts` stubbing jsdom's missing `Range.getClientRects` / `getBoundingClientRect` so drawSelection's measure cycle stops logging caught TypeErrors to stderr.
+
+## 5. Demo + docs
+
+- [x] 5.1 Enable `multiCursor: true` in `apps/electron-demo/src/renderer/editor-shell.ts` (`pnpm build:electron-demo` green; manual Alt-click / Mod-d / Mod-Alt-Arrow walkthrough in the running demo is the remaining reviewer step).
+- [x] 5.2 Create `packages/core/README.md` documenting the flag, key bindings, commands, and selections API.
+- [x] 5.3 Update `docs/ROADMAP.md` + `docs/ROADMAP.zh.md` row #6 → `in-progress`, link `add-core-multi-cursor`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,76 @@
+# @floatboat/nexus-core
+
+Framework-agnostic Markdown editor engine powering Nexus-Editor — CodeMirror 6 + Lezer with Obsidian-style live preview. See the [repository README](../../README.md) for the full feature tour; this file documents core-specific public APIs.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-core
+```
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+
+const editor = createEditor({
+  container: document.querySelector("#editor")!,
+  initialValue: "# Hello",
+  livePreview: true,
+});
+```
+
+## Multi-cursor / multi-selection
+
+Opt-in via `multiCursor: true` (off by default — it swaps the native caret/selection rendering for CodeMirror-drawn layers):
+
+```ts
+const editor = createEditor({
+  container,
+  initialValue: "# Hello",
+  multiCursor: true,
+});
+```
+
+When enabled:
+
+| Interaction | Effect |
+|---|---|
+| `Alt`+Click | Add a cursor at the clicked position |
+| `Mod-d` | Select word under cursor, then next occurrence of the selection (VS Code style, wraps around) |
+| `Mod-Alt-ArrowUp` / `Mod-Alt-ArrowDown` | Add a cursor on the previous / next line, column preserved |
+| `Escape` | Collapse to the main selection (falls through to other Escape handlers when already single) |
+
+`Mod` is `Cmd` on macOS and `Ctrl` elsewhere. Markdown niceties are multi-range aware: Enter continues lists/blockquotes at **every** cursor, and the `` ` `` / `**` / `~~` auto-pairing wraps every selection. Live preview reveals raw syntax at every cursor position.
+
+The commands are exported standalone for hosts that want custom bindings, plus the bundled keymap and extension:
+
+```ts
+import {
+  selectNextOccurrence,
+  addCursorAbove,
+  addCursorBelow,
+  collapseToMainSelection,
+  multiCursorKeymap,
+  multiCursorExtension,
+} from "@floatboat/nexus-core";
+```
+
+### Selections API
+
+```ts
+editor.getSelection();   // main range: { anchor, head }
+editor.getSelections();  // all ranges: { ranges: [{ anchor, head }, ...], mainIndex }
+
+editor.setSelection(5);                                  // single cursor
+editor.setSelections([{ anchor: 2 }, { anchor: 9, head: 14 }]);  // multiple ranges
+editor.setSelections([{ anchor: 2 }, { anchor: 9 }], 0);         // explicit main range
+
+editor.on("selectionChange", ({ anchor, head, ranges, mainIndex }) => {
+  // anchor/head describe the main range; ranges carries all of them
+});
+```
+
+Multiple ranges in `setSelections` require `multiCursor: true` — without the flag CodeMirror collapses the selection to its main range.
+
+## Other config highlights
+
+See the `EditorConfig` type for the full surface: `livePreview`, `plugins`, `theme` / `setTheme`, `locale`, `readOnly`, `tabSize`, `direction`, `indentGuides`, `parseDelayMs`, `slashMenuLimit`, `onChange` / `onFocus` / `onBlur` / `onAssetUpload`.

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -1,4 +1,4 @@
-import { Annotation, EditorState } from "@codemirror/state";
+import { Annotation, EditorSelection, EditorState } from "@codemirror/state";
 
 // Annotation attached to dispatches that load content programmatically (e.g.
 // setDocument from file open) so updateListener can skip the user-edit path —
@@ -22,6 +22,7 @@ import { markdownFoldService } from "./markdown-fold";
 import { resolveLocale } from "./locale";
 import { markdownAutoPair } from "./markdown-autopair";
 import { markdownKeymap } from "./markdown-keymap";
+import { multiCursorExtension } from "./multi-cursor";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { createThemeExtension, lightTheme, type NexusTheme } from "./theme";
 import { computeSlashState } from "./slash-state";
@@ -455,6 +456,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
     ? EditorView.contentAttributes.of({ dir: "rtl" })
     : [];
   const indentGuidesExt = config.indentGuides ? indentationMarkers() : [];
+  const multiCursorExt = config.multiCursor ? multiCursorExtension() : [];
 
   const shortcutExtensions =
     shortcuts.length > 0
@@ -567,7 +569,13 @@ export function createEditor(config: EditorConfig): EditorAPI {
             const sel = update.state.selection.main;
 
             if (update.selectionSet) {
-              emitter.emit("selectionChange", { anchor: sel.anchor, head: sel.head });
+              const selection = update.state.selection;
+              emitter.emit("selectionChange", {
+                anchor: sel.anchor,
+                head: sel.head,
+                ranges: selection.ranges.map((range) => ({ anchor: range.anchor, head: range.head })),
+                mainIndex: selection.mainIndex,
+              });
             }
 
             if (slashCommands.length > 0) {
@@ -604,6 +612,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
         directionExt,
         indentGuidesExt,
         markdownKeymap(),
+        multiCursorExt,
         markdownFoldService(),
         keymap.of([indentWithTab]),
         closeBrackets(),
@@ -687,6 +696,13 @@ export function createEditor(config: EditorConfig): EditorAPI {
       const sel = view.state.selection.main;
       return { anchor: sel.anchor, head: sel.head };
     },
+    getSelections() {
+      const selection = view.state.selection;
+      return {
+        ranges: selection.ranges.map((range) => ({ anchor: range.anchor, head: range.head })),
+        mainIndex: selection.mainIndex,
+      };
+    },
     getSlashCommands() {
       return slashCommands;
     },
@@ -711,6 +727,19 @@ export function createEditor(config: EditorConfig): EditorAPI {
 
       view.dispatch({
         selection: { anchor, head },
+        scrollIntoView: true
+      });
+    },
+    setSelections(ranges, mainIndex) {
+      if (destroyed || ranges.length === 0) {
+        return;
+      }
+
+      view.dispatch({
+        selection: EditorSelection.create(
+          ranges.map((range) => EditorSelection.range(range.anchor, range.head ?? range.anchor)),
+          mainIndex ?? ranges.length - 1
+        ),
         scrollIntoView: true
       });
     },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,14 @@ export { createEditor } from "./editor";
 export { markdownAutoPair } from "./markdown-autopair";
 export { markdownFold, markdownFoldService } from "./markdown-fold";
 export { markdownKeymap, handleMarkdownEnter } from "./markdown-keymap";
+export {
+  addCursorAbove,
+  addCursorBelow,
+  collapseToMainSelection,
+  multiCursorExtension,
+  multiCursorKeymap,
+  selectNextOccurrence,
+} from "./multi-cursor";
 export { enLocale, zhLocale, resolveLocale, type NexusLocale } from "./locale";
 export {
   computeSlashState,
@@ -38,6 +46,8 @@ export type {
   NexusPlugin,
   ParseResult,
   ParserLike,
+  SelectionRangeJSON,
+  SelectionState,
   SlashCommandDef,
   SlashMenuState,
   TocEntry,

--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -580,12 +580,20 @@ export class EditableTableWidget extends WidgetType {
       if (!wrapper.isConnected) return;
       const v = self.viewRef.current;
       if (v && !self.editing) {
-        const sel = v.state.selection.main;
+        // Multi-cursor: any range fully covering the table counts as
+        // "table selected"; the cell-range only clears when every cursor
+        // has left the table span.
+        const ranges = v.state.selection.ranges;
         const tableEnd = self.tableFrom + self.source.length;
-        const isSelected = sel.from !== sel.to && sel.from <= self.tableFrom && sel.to >= tableEnd;
+        const isSelected = ranges.some(
+          (range) => !range.empty && range.from <= self.tableFrom && range.to >= tableEnd
+        );
         selectionOverlay.style.display = isSelected ? "block" : "none";
         // If cursor moved outside table, no active interaction, no active range, clear range selection
-        if (rangeStart && !isRangeSelecting && !cellMouseDown && !rangeActive && (sel.head < self.tableFrom || sel.head > tableEnd)) {
+        const allOutside = ranges.every(
+          (range) => range.head < self.tableFrom || range.head > tableEnd
+        );
+        if (rangeStart && !isRangeSelecting && !cellMouseDown && !rangeActive && allOutside) {
           clearRangeSelection();
         }
       } else {

--- a/packages/core/src/markdown-autopair.ts
+++ b/packages/core/src/markdown-autopair.ts
@@ -2,8 +2,12 @@
  * Auto-pair extension for Markdown syntax markers.
  * When the user types **, *, ~~, or ` with a selection, it wraps the selection.
  * When typed without selection, it inserts a matching pair and places the cursor between.
+ *
+ * Multi-cursor aware: wrapping / pair insertion applies to every selection
+ * range in one dispatch, with the double-marker preceding-character check
+ * evaluated per range — secondary cursors never lose the typed character.
  */
-import { type Extension } from "@codemirror/state";
+import { EditorSelection, type Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 
 const PAIRS: Array<{ trigger: string; open: string; close: string }> = [
@@ -17,30 +21,36 @@ const DOUBLE_PAIRS: Array<{ char: string; open: string; close: string }> = [
 ];
 
 export function markdownAutoPair(): Extension {
-  return EditorView.inputHandler.of((view, from, to, text) => {
+  return EditorView.inputHandler.of((view, _from, _to, text) => {
     if (view.composing || view.compositionStarted) return false;
 
-    const sel = view.state.selection.main;
+    const { state } = view;
 
     // --- Single-char pairs (backtick) ---
     for (const pair of PAIRS) {
       if (text !== pair.trigger) continue;
 
-      if (sel.from !== sel.to) {
-        // Wrap selection
-        const selected = view.state.sliceDoc(sel.from, sel.to);
-        view.dispatch({
-          changes: { from: sel.from, to: sel.to, insert: pair.open + selected + pair.close },
-          selection: { anchor: sel.from + pair.open.length, head: sel.from + pair.open.length + selected.length },
-        });
-        return true;
-      }
+      view.dispatch(
+        state.changeByRange((range) => {
+          if (!range.empty) {
+            // Wrap selection
+            const selected = state.sliceDoc(range.from, range.to);
+            return {
+              changes: { from: range.from, to: range.to, insert: pair.open + selected + pair.close },
+              range: EditorSelection.range(
+                range.from + pair.open.length,
+                range.from + pair.open.length + selected.length
+              ),
+            };
+          }
 
-      // Insert pair and place cursor between
-      view.dispatch({
-        changes: { from, to, insert: pair.open + pair.close },
-        selection: { anchor: from + pair.open.length },
-      });
+          // Insert pair and place cursor between
+          return {
+            changes: { from: range.from, insert: pair.open + pair.close },
+            range: EditorSelection.cursor(range.from + pair.open.length),
+          };
+        })
+      );
       return true;
     }
 
@@ -48,29 +58,45 @@ export function markdownAutoPair(): Extension {
     for (const pair of DOUBLE_PAIRS) {
       if (text !== pair.char) continue;
 
-      // Check if the char before cursor is the same char (forming a double)
-      const charBefore = from > 0 ? view.state.sliceDoc(from - 1, from) : "";
-      if (charBefore !== pair.char) continue;
+      // Only step in when some cursor just completed a double marker
+      // (the previous keystroke left `pair.char` right before the range).
+      const charBeforeMatches = (from: number): boolean =>
+        from > 0 && state.sliceDoc(from - 1, from) === pair.char;
+      if (!state.selection.ranges.some((range) => charBeforeMatches(range.from))) continue;
 
-      if (sel.from !== sel.to) {
-        // Selection active: wrap selection with the double marker
-        // Remove the first char we already typed, wrap selection
-        view.dispatch({
-          changes: [
-            { from: from - 1, to: from, insert: "" }, // remove the first char
-            { from: sel.from, to: sel.to, insert: pair.open + view.state.sliceDoc(sel.from, sel.to) + pair.close },
-          ],
-        });
-        return true;
-      }
+      view.dispatch(
+        state.changeByRange((range) => {
+          if (!charBeforeMatches(range.from)) {
+            // This cursor is not completing a double marker — plain insert.
+            return {
+              changes: { from: range.from, to: range.to, insert: text },
+              range: EditorSelection.cursor(range.from + text.length),
+            };
+          }
 
-      // No selection: insert closing pair after the opening
-      // The first char is already in the doc at from-1. We're adding the second char.
-      // Result: **|** with cursor in the middle.
-      view.dispatch({
-        changes: { from, to, insert: pair.char + pair.close },
-        selection: { anchor: from + 1 },
-      });
+          if (!range.empty) {
+            // Selection active: remove the already-typed first char, wrap the selection
+            const selected = state.sliceDoc(range.from, range.to);
+            return {
+              changes: [
+                { from: range.from - 1, to: range.from, insert: "" },
+                { from: range.from, to: range.to, insert: pair.open + selected + pair.close },
+              ],
+              range: EditorSelection.range(
+                range.from - 1 + pair.open.length,
+                range.from - 1 + pair.open.length + selected.length
+              ),
+            };
+          }
+
+          // No selection: the first char is already in the doc at from-1, we're
+          // adding the second. Result: **|** with the cursor in the middle.
+          return {
+            changes: { from: range.from, insert: pair.char + pair.close },
+            range: EditorSelection.cursor(range.from + 1),
+          };
+        })
+      );
       return true;
     }
 

--- a/packages/core/src/markdown-keymap.ts
+++ b/packages/core/src/markdown-keymap.ts
@@ -1,80 +1,101 @@
-import { Prec, type Extension } from "@codemirror/state";
+import { EditorSelection, Prec, type EditorState, type Extension, type SelectionRange } from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 
 const LIST_RE = /^(\s*)([-*+]|\d+[.)]) /;
 const CHECKBOX_RE = /^\[([ xX])\] /;
 const BLOCKQUOTE_RE = /^(\s*>+ ?)/;
 
-/** Handle Enter key for markdown auto-continuation. Returns true if handled. */
-export function handleMarkdownEnter(view: EditorView): boolean {
-  const { state } = view;
-  const sel = state.selection.main;
-  if (!sel.empty) return false;
-
-  const line = state.doc.lineAt(sel.head);
-  const text = line.text;
-
-  // ── List continuation ──
+/** The markdown continuation prefix for the line, or null when the line is plain text. */
+function continuationFor(text: string): { prefix: string; content: string } | null {
   const listMatch = LIST_RE.exec(text);
   if (listMatch) {
     const indent = listMatch[1];
     const marker = listMatch[2];
     const afterMarker = text.slice(listMatch[0].length);
 
-    // Check for checkbox
     const cbMatch = CHECKBOX_RE.exec(afterMarker);
     const content = cbMatch ? afterMarker.slice(cbMatch[0].length) : afterMarker;
 
-    // Empty item → exit list
-    if (!content.trim()) {
-      view.dispatch({
-        changes: { from: line.from, to: line.to, insert: "" },
-        selection: { anchor: line.from }
-      });
-      return true;
-    }
-
-    // Calculate next marker (increment ordered numbers)
+    // Increment ordered-list numbers
     let nextMarker = marker;
     const numMatch = marker.match(/^(\d+)([.)])/);
     if (numMatch) {
       nextMarker = `${parseInt(numMatch[1]) + 1}${numMatch[2]}`;
     }
 
-    const newPrefix = cbMatch
-      ? `${indent}${nextMarker} [ ] `
-      : `${indent}${nextMarker} `;
-
-    view.dispatch({
-      changes: { from: sel.head, insert: "\n" + newPrefix },
-      selection: { anchor: sel.head + 1 + newPrefix.length }
-    });
-    return true;
+    const prefix = cbMatch ? `${indent}${nextMarker} [ ] ` : `${indent}${nextMarker} `;
+    return { prefix, content };
   }
 
-  // ── Blockquote continuation ──
   const quoteMatch = BLOCKQUOTE_RE.exec(text);
   if (quoteMatch) {
     const prefix = quoteMatch[1];
-    const content = text.slice(prefix.length);
-
-    // Empty quote → exit blockquote
-    if (!content.trim()) {
-      view.dispatch({
-        changes: { from: line.from, to: line.to, insert: "" },
-        selection: { anchor: line.from }
-      });
-      return true;
-    }
-
-    view.dispatch({
-      changes: { from: sel.head, insert: "\n" + prefix },
-      selection: { anchor: sel.head + 1 + prefix.length }
-    });
-    return true;
+    return { prefix, content: text.slice(prefix.length) };
   }
 
-  return false;
+  return null;
+}
+
+function isContinuable(state: EditorState, range: SelectionRange): boolean {
+  return range.empty && continuationFor(state.doc.lineAt(range.head).text) !== null;
+}
+
+/**
+ * Handle Enter key for markdown auto-continuation. Returns true if handled.
+ *
+ * Multi-cursor aware: when at least one cursor sits on a list / blockquote
+ * line, every selection range is processed in one dispatch (one undo step) —
+ * continuation or empty-item exit on continuable lines, a plain newline
+ * elsewhere. When no cursor is on a continuable line the handler defers to
+ * the default Enter behaviour.
+ */
+export function handleMarkdownEnter(view: EditorView): boolean {
+  const { state } = view;
+  if (!state.selection.ranges.some((range) => isContinuable(state, range))) return false;
+
+  // Lines already emptied by an "exit list/quote" range: a second cursor on
+  // the same line must become a no-op — its deletion would overlap the first.
+  const exitedLines = new Set<number>();
+
+  view.dispatch(
+    state.changeByRange((range) => {
+      if (!range.empty) {
+        // Default Enter semantics for a non-empty range: replace it with a newline.
+        return {
+          changes: { from: range.from, to: range.to, insert: "\n" },
+          range: EditorSelection.cursor(range.from + 1),
+        };
+      }
+
+      const line = state.doc.lineAt(range.head);
+      const continuation = continuationFor(line.text);
+
+      if (!continuation) {
+        return {
+          changes: { from: range.head, insert: "\n" },
+          range: EditorSelection.cursor(range.head + 1),
+        };
+      }
+
+      // Empty item → exit the list / blockquote by clearing the line.
+      if (!continuation.content.trim()) {
+        if (exitedLines.has(line.from)) {
+          return { range };
+        }
+        exitedLines.add(line.from);
+        return {
+          changes: { from: line.from, to: line.to, insert: "" },
+          range: EditorSelection.cursor(line.from),
+        };
+      }
+
+      return {
+        changes: { from: range.head, insert: "\n" + continuation.prefix },
+        range: EditorSelection.cursor(range.head + 1 + continuation.prefix.length),
+      };
+    })
+  );
+  return true;
 }
 
 export function markdownKeymap(): Extension {

--- a/packages/core/src/multi-cursor.ts
+++ b/packages/core/src/multi-cursor.ts
@@ -1,0 +1,174 @@
+/**
+ * Multi-cursor / multi-selection support (ROADMAP #6).
+ *
+ * CodeMirror ships the state machinery (`allowMultipleSelections`) but the
+ * editor never enables it, and secondary cursors are invisible without
+ * `drawSelection`. This module bundles the enablement extensions with a
+ * VS Code-flavoured command set. Commands are exported standalone so hosts
+ * and plugins can rebind them; `multiCursorExtension()` is what
+ * `createEditor({ multiCursor: true })` installs.
+ */
+import { EditorSelection, EditorState, type Extension, type SelectionRange } from "@codemirror/state";
+import { drawSelection, EditorView, keymap, type Command, type KeyBinding } from "@codemirror/view";
+
+function rangesToSelection(
+  ranges: readonly SelectionRange[],
+  added: SelectionRange
+): EditorSelection {
+  return EditorSelection.create([...ranges, added], ranges.length);
+}
+
+function isCovered(ranges: readonly SelectionRange[], from: number, to: number): boolean {
+  return ranges.some((range) => range.from <= from && range.to >= to);
+}
+
+/**
+ * Find the next occurrence of `query` that no selection range covers yet,
+ * scanning forward from the end of the last range and wrapping around to the
+ * document start. Returns null when every occurrence is already selected.
+ */
+function findNextOccurrence(
+  state: EditorState,
+  query: string
+): { from: number; to: number } | null {
+  const doc = state.doc.toString();
+  const ranges = state.selection.ranges;
+  const searchOrigin = ranges[ranges.length - 1].to;
+
+  for (const start of [searchOrigin, 0]) {
+    let index = doc.indexOf(query, start);
+    while (index !== -1) {
+      // Past the origin on the wrapped pass everything has been seen already.
+      if (start === 0 && index >= searchOrigin) break;
+      if (!isCovered(ranges, index, index + query.length)) {
+        return { from: index, to: index + query.length };
+      }
+      index = doc.indexOf(query, index + 1);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * VS Code-style `Mod-d`. With any empty range: expand every empty range to
+ * the word under it (no new range is added on this invocation). With all
+ * ranges non-empty: add the next occurrence of the main range's text as the
+ * new main range. Matching is case-sensitive and not word-bounded.
+ */
+export const selectNextOccurrence: Command = (view) => {
+  const { state } = view;
+  const selection = state.selection;
+
+  if (selection.ranges.some((range) => range.empty)) {
+    let expanded = false;
+    const ranges = selection.ranges.map((range) => {
+      if (!range.empty) return range;
+      const word = state.wordAt(range.head);
+      if (!word) return range;
+      expanded = true;
+      return EditorSelection.range(word.from, word.to);
+    });
+    if (!expanded) return false;
+    view.dispatch({
+      selection: EditorSelection.create(ranges, selection.mainIndex),
+      userEvent: "select",
+    });
+    return true;
+  }
+
+  const main = selection.main;
+  const query = state.sliceDoc(main.from, main.to);
+  if (!query) return false;
+
+  const next = findNextOccurrence(state, query);
+  if (!next) return false;
+
+  view.dispatch({
+    selection: rangesToSelection(selection.ranges, EditorSelection.range(next.from, next.to)),
+    scrollIntoView: true,
+    userEvent: "select",
+  });
+  return true;
+};
+
+/**
+ * Add an empty cursor on the previous (`forward = false`) or next logical
+ * line, relative to the topmost / bottommost existing range. Logical lines —
+ * not visual lines — so the command stays deterministic in headless
+ * environments and independent of soft-wrap measurement.
+ */
+function addCursorVertically(view: EditorView, forward: boolean): boolean {
+  const { state } = view;
+  const selection = state.selection;
+  const source = forward
+    ? selection.ranges[selection.ranges.length - 1]
+    : selection.ranges[0];
+
+  const sourceLine = state.doc.lineAt(source.head);
+  const targetNumber = sourceLine.number + (forward ? 1 : -1);
+  if (targetNumber < 1 || targetNumber > state.doc.lines) return false;
+
+  const targetLine = state.doc.line(targetNumber);
+  const column = Math.min(source.head - sourceLine.from, targetLine.length);
+  const pos = targetLine.from + column;
+  if (selection.ranges.some((range) => range.empty && range.head === pos)) return false;
+
+  view.dispatch({
+    selection: rangesToSelection(selection.ranges, EditorSelection.cursor(pos)),
+    scrollIntoView: true,
+    userEvent: "select",
+  });
+  return true;
+}
+
+export const addCursorAbove: Command = (view) => addCursorVertically(view, false);
+
+export const addCursorBelow: Command = (view) => addCursorVertically(view, true);
+
+/**
+ * Drop secondary ranges, keep the main one. Returns false on a single-range
+ * selection so other Escape bindings (slash menu, search panel) still fire.
+ */
+export const collapseToMainSelection: Command = (view) => {
+  const selection = view.state.selection;
+  if (selection.ranges.length <= 1) return false;
+  view.dispatch({
+    selection: EditorSelection.create([selection.main]),
+    userEvent: "select",
+  });
+  return true;
+};
+
+export const multiCursorKeymap: readonly KeyBinding[] = [
+  { key: "Mod-d", run: selectNextOccurrence, preventDefault: true },
+  { key: "Mod-Alt-ArrowUp", run: addCursorAbove, preventDefault: true },
+  { key: "Mod-Alt-ArrowDown", run: addCursorBelow, preventDefault: true },
+  { key: "Escape", run: collapseToMainSelection },
+];
+
+// drawSelection replaces the native caret/selection layers, whose defaults
+// are tuned for light backgrounds. Recolour through the theme variables so
+// dark themes keep a visible caret and an accent-tinted selection.
+const multiCursorTheme = EditorView.theme({
+  ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--nexus-text)" },
+  "&.cm-focused .cm-selectionBackground": {
+    background: "var(--nexus-accent)",
+    opacity: "0.25",
+  },
+});
+
+/**
+ * Everything `createEditor({ multiCursor: true })` installs: multiple
+ * selection ranges, drawn cursors/selections, Alt-click to add a range
+ * (explicit facet — VS Code / Obsidian convention), and the command keymap.
+ */
+export function multiCursorExtension(): Extension {
+  return [
+    EditorState.allowMultipleSelections.of(true),
+    EditorView.clickAddsSelectionRange.of((event) => event.altKey),
+    drawSelection(),
+    multiCursorTheme,
+    keymap.of([...multiCursorKeymap]),
+  ];
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -94,6 +94,17 @@ export interface EditorConfig {
   /** Prevent user edits while preserving selection and scrolling. Default: false */
   readOnly?: boolean;
   /**
+   * Enable multi-cursor / multi-selection editing. Default: false.
+   *
+   * When true the editor allows multiple selection ranges, renders secondary
+   * cursors/selections (CodeMirror `drawSelection`), lets Alt-click add a
+   * cursor, and binds `Mod-d` (select next occurrence), `Mod-Alt-ArrowUp/Down`
+   * (add cursor above/below) and `Escape` (collapse to the main selection).
+   * Off by default because `drawSelection` visibly replaces the native caret
+   * and selection rendering for existing consumers.
+   */
+  multiCursor?: boolean;
+  /**
    * Maximum number of slash-menu entries emitted on `slashMenuChange`
    * after ranking. Default: 8. A limit of 0 keeps the menu state open
    * but emits an empty command list (useful for "no results" UIs).
@@ -118,11 +129,24 @@ export interface SlashMenuState {
   coords: { left: number; top: number; bottom: number } | null;
 }
 
+/** One selection range in plain-object form (`anchor` may be after `head`). */
+export interface SelectionRangeJSON {
+  anchor: number;
+  head: number;
+}
+
+/** Full selection snapshot: every range plus which one is the main range. */
+export interface SelectionState {
+  ranges: SelectionRangeJSON[];
+  mainIndex: number;
+}
+
 export interface EditorEventMap {
   change: (doc: string, ast: Root) => void;
   focus: () => void;
   blur: () => void;
-  selectionChange: (selection: { anchor: number; head: number }) => void;
+  /** `anchor` / `head` describe the main range; `ranges` carries all of them. */
+  selectionChange: (selection: { anchor: number; head: number } & SelectionState) => void;
   slashMenuChange: (state: SlashMenuState) => void;
 }
 
@@ -140,9 +164,18 @@ export interface EditorAPI {
   exportHTML(): string;
   setTheme(theme: import("./theme").NexusTheme): void;
   getSelection(): { anchor: number; head: number };
+  /** All selection ranges plus the main-range index. Single-range editors return one entry. */
+  getSelections(): SelectionState;
   getSlashCommands(): SlashCommandDef[];
   uploadAsset(file: File): Promise<string | null>;
   setSelection(anchor: number, head?: number): void;
+  /**
+   * Replace the selection with the given ranges. `mainIndex` defaults to the
+   * last range (CodeMirror's latest-added-is-main convention). Multiple
+   * ranges require `multiCursor: true` — without it CodeMirror collapses the
+   * selection to the main range.
+   */
+  setSelections(ranges: { anchor: number; head?: number }[], mainIndex?: number): void;
   /**
    * Replace the document content.
    *

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -42,7 +42,12 @@ describe("event system", () => {
     editor.on("selectionChange", handler);
     editor.setSelection(5);
 
-    expect(handler).toHaveBeenCalledWith({ anchor: 5, head: 5 });
+    expect(handler).toHaveBeenCalledWith({
+      anchor: 5,
+      head: 5,
+      ranges: [{ anchor: 5, head: 5 }],
+      mainIndex: 0
+    });
     editor.destroy();
   });
 

--- a/packages/core/test/live-preview-regressions.test.ts
+++ b/packages/core/test/live-preview-regressions.test.ts
@@ -60,6 +60,33 @@ describe("live preview regressions", () => {
     editor.destroy();
   });
 
+  // Multi-cursor: every selection range is a reveal trigger. Guards the
+  // `.some()`-across-ranges reveal logic against a future "main range only"
+  // optimisation regression (openspec: add-core-multi-cursor).
+  it("reveals raw markers at every cursor with multi-cursor selections", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "Text **bold** end\n\nother **also** line",
+      livePreview: true,
+      multiCursor: true
+    });
+
+    // One cursor inside each bold span (different lines): both reveal
+    editor.setSelections([{ anchor: 8 }, { anchor: 28 }]);
+    const revealed = container.textContent ?? "";
+    expect(revealed).toContain("**bold**");
+    expect(revealed).toContain("**also**");
+
+    // Collapse to a single cursor on the blank line between them: both hide
+    editor.setSelection(18);
+    const hidden = container.textContent ?? "";
+    expect(hidden).toContain("bold");
+    expect(hidden).toContain("also");
+    expect(hidden).not.toContain("**");
+    editor.destroy();
+  });
+
   // Code block lines must not set font-family or font-size on Decoration.line —
   // only on Decoration.mark. Otherwise CM6's heightmap sees different line heights
   // for code vs regular lines, causing cumulative click drift in long documents.

--- a/packages/core/test/multi-cursor.test.ts
+++ b/packages/core/test/multi-cursor.test.ts
@@ -1,0 +1,389 @@
+import { EditorView, ViewPlugin } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  addCursorAbove,
+  addCursorBelow,
+  collapseToMainSelection,
+  createEditor,
+  handleMarkdownEnter,
+  selectNextOccurrence,
+} from "../src/index";
+
+function createTestEditor(initialValue: string, multiCursor = true) {
+  const container = document.createElement("div");
+  let captured: EditorView | null = null;
+  const editor = createEditor({
+    container,
+    initialValue,
+    multiCursor,
+    plugins: [
+      {
+        name: "capture-view",
+        cmExtensions: [
+          ViewPlugin.define((view) => {
+            captured = view;
+            return {};
+          }),
+        ],
+      },
+    ],
+  });
+  if (!captured) throw new Error("Expected CodeMirror view to be captured");
+  return { editor, view: captured as EditorView, container };
+}
+
+describe("multiCursor config gating", () => {
+  it("collapses multi-range selections when the flag is off (default)", () => {
+    const { editor } = createTestEditor("hello world", false);
+
+    editor.setSelections([{ anchor: 0, head: 5 }, { anchor: 6, head: 11 }]);
+
+    const { ranges, mainIndex } = editor.getSelections();
+    expect(ranges).toEqual([{ anchor: 6, head: 11 }]);
+    expect(mainIndex).toBe(0);
+    editor.destroy();
+  });
+
+  it("retains multiple ranges when the flag is on", () => {
+    const { editor } = createTestEditor("hello world");
+
+    editor.setSelections([{ anchor: 0, head: 5 }, { anchor: 6, head: 11 }]);
+
+    const { ranges, mainIndex } = editor.getSelections();
+    expect(ranges).toEqual([
+      { anchor: 0, head: 5 },
+      { anchor: 6, head: 11 },
+    ]);
+    expect(mainIndex).toBe(1);
+    editor.destroy();
+  });
+
+  it("honours an explicit mainIndex and keeps getSelection() on the main range", () => {
+    const { editor } = createTestEditor("hello world");
+
+    editor.setSelections([{ anchor: 2 }, { anchor: 6, head: 11 }], 0);
+
+    expect(editor.getSelections().mainIndex).toBe(0);
+    expect(editor.getSelection()).toEqual({ anchor: 2, head: 2 });
+    editor.destroy();
+  });
+
+  it("emits selectionChange with all ranges and the main index", () => {
+    const { editor } = createTestEditor("hello world");
+    const handler = vi.fn();
+    editor.on("selectionChange", handler);
+
+    editor.setSelections([{ anchor: 1 }, { anchor: 7 }]);
+
+    expect(handler).toHaveBeenCalledWith({
+      anchor: 7,
+      head: 7,
+      ranges: [
+        { anchor: 1, head: 1 },
+        { anchor: 7, head: 7 },
+      ],
+      mainIndex: 1,
+    });
+    editor.destroy();
+  });
+});
+
+describe("selectNextOccurrence", () => {
+  const DOC = "foo bar foo baz foo";
+
+  it("expands an empty cursor to the word under it without adding a range", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelection(1);
+
+    expect(selectNextOccurrence(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([{ anchor: 0, head: 3 }]);
+    editor.destroy();
+  });
+
+  it("adds the next occurrence as the new main range", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelection(0, 3);
+
+    expect(selectNextOccurrence(view)).toBe(true);
+
+    const { ranges, mainIndex } = editor.getSelections();
+    expect(ranges).toEqual([
+      { anchor: 0, head: 3 },
+      { anchor: 8, head: 11 },
+    ]);
+    expect(mainIndex).toBe(1);
+    editor.destroy();
+  });
+
+  it("skips occurrences already covered by a range", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelections([{ anchor: 0, head: 3 }, { anchor: 8, head: 11 }]);
+
+    expect(selectNextOccurrence(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 0, head: 3 },
+      { anchor: 8, head: 11 },
+      { anchor: 16, head: 19 },
+    ]);
+    editor.destroy();
+  });
+
+  it("wraps past the document end", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelection(16, 19);
+
+    expect(selectNextOccurrence(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 0, head: 3 },
+      { anchor: 16, head: 19 },
+    ]);
+    editor.destroy();
+  });
+
+  it("returns false when every occurrence is selected", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelections([
+      { anchor: 0, head: 3 },
+      { anchor: 8, head: 11 },
+      { anchor: 16, head: 19 },
+    ]);
+
+    expect(selectNextOccurrence(view)).toBe(false);
+    expect(editor.getSelections().ranges).toHaveLength(3);
+    editor.destroy();
+  });
+
+  it("returns false when the empty cursor has no word under it", () => {
+    const { editor, view } = createTestEditor("   ");
+    editor.setSelection(1);
+
+    expect(selectNextOccurrence(view)).toBe(false);
+    editor.destroy();
+  });
+});
+
+describe("addCursorAbove / addCursorBelow", () => {
+  const DOC = "alpha\nbeta!\ngamma";
+
+  it("adds a cursor below, preserving the column", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelection(4);
+
+    expect(addCursorBelow(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 4, head: 4 },
+      { anchor: 10, head: 10 },
+    ]);
+    editor.destroy();
+  });
+
+  it("stacks downward from the bottommost cursor on repeated calls", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelection(4);
+
+    addCursorBelow(view);
+    expect(addCursorBelow(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 4, head: 4 },
+      { anchor: 10, head: 10 },
+      { anchor: 16, head: 16 },
+    ]);
+    editor.destroy();
+  });
+
+  it("clamps the column to a shorter target line", () => {
+    const { editor, view } = createTestEditor("abcdefghij\nabc");
+    editor.setSelection(9);
+
+    expect(addCursorBelow(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 9, head: 9 },
+      { anchor: 14, head: 14 },
+    ]);
+    editor.destroy();
+  });
+
+  it("returns false at the document edges", () => {
+    const { editor, view } = createTestEditor(DOC);
+
+    editor.setSelection(2);
+    expect(addCursorAbove(view)).toBe(false);
+
+    editor.setSelection(DOC.length);
+    expect(addCursorBelow(view)).toBe(false);
+    editor.destroy();
+  });
+
+  it("adds a cursor above from the topmost range", () => {
+    const { editor, view } = createTestEditor(DOC);
+    editor.setSelection(8);
+
+    expect(addCursorAbove(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 2, head: 2 },
+      { anchor: 8, head: 8 },
+    ]);
+    editor.destroy();
+  });
+});
+
+describe("collapseToMainSelection", () => {
+  it("drops secondary ranges and keeps the main one", () => {
+    const { editor, view } = createTestEditor("alpha\nbeta!\ngamma");
+    editor.setSelections([{ anchor: 1 }, { anchor: 7 }, { anchor: 13 }], 1);
+
+    expect(collapseToMainSelection(view)).toBe(true);
+
+    expect(editor.getSelections().ranges).toEqual([{ anchor: 7, head: 7 }]);
+    editor.destroy();
+  });
+
+  it("returns false on a single-range selection so Escape falls through", () => {
+    const { editor, view } = createTestEditor("alpha");
+    editor.setSelection(2);
+
+    expect(collapseToMainSelection(view)).toBe(false);
+    editor.destroy();
+  });
+});
+
+describe("multi-cursor keymap", () => {
+  function keydown(container: HTMLElement, init: KeyboardEventInit): void {
+    const content = container.querySelector("[contenteditable='true']");
+    content?.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init })
+    );
+  }
+
+  it("binds Mod-d to selectNextOccurrence", () => {
+    const { editor, container } = createTestEditor("foo bar foo");
+    editor.setSelection(1);
+
+    keydown(container, { key: "d", ctrlKey: true });
+
+    expect(editor.getSelections().ranges).toEqual([{ anchor: 0, head: 3 }]);
+    editor.destroy();
+  });
+
+  it("binds Escape to collapseToMainSelection", () => {
+    const { editor, container } = createTestEditor("foo bar foo");
+    editor.setSelections([{ anchor: 0, head: 3 }, { anchor: 8, head: 11 }]);
+
+    keydown(container, { key: "Escape" });
+
+    expect(editor.getSelections().ranges).toEqual([{ anchor: 8, head: 11 }]);
+    editor.destroy();
+  });
+
+  it("does not install the keymap when the flag is off", () => {
+    const { editor, container } = createTestEditor("foo bar foo", false);
+    editor.setSelection(1);
+
+    keydown(container, { key: "d", ctrlKey: true });
+
+    expect(editor.getSelections().ranges).toEqual([{ anchor: 1, head: 1 }]);
+    editor.destroy();
+  });
+});
+
+describe("markdown Enter with multiple cursors", () => {
+  it("continues two list items in one undo step", () => {
+    const { editor, view } = createTestEditor("- a\n- b");
+    editor.setSelections([{ anchor: 3 }, { anchor: 7 }]);
+
+    expect(handleMarkdownEnter(view)).toBe(true);
+
+    expect(editor.getDocument()).toBe("- a\n- \n- b\n- ");
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 6, head: 6 },
+      { anchor: 13, head: 13 },
+    ]);
+    editor.destroy();
+  });
+
+  it("mixes list continuation and plain newline across cursors", () => {
+    const { editor, view } = createTestEditor("- a\nplain");
+    editor.setSelections([{ anchor: 3 }, { anchor: 9 }]);
+
+    expect(handleMarkdownEnter(view)).toBe(true);
+
+    expect(editor.getDocument()).toBe("- a\n- \nplain\n");
+    editor.destroy();
+  });
+
+  it("exits an empty item once when two cursors share the line", () => {
+    const { editor, view } = createTestEditor("- a\n- ");
+    editor.setSelections([{ anchor: 5 }, { anchor: 6 }]);
+
+    expect(handleMarkdownEnter(view)).toBe(true);
+
+    expect(editor.getDocument()).toBe("- a\n");
+    editor.destroy();
+  });
+
+  it("defers to the default Enter when no cursor is on a continuable line", () => {
+    const { editor, view } = createTestEditor("plain\ntext");
+    editor.setSelections([{ anchor: 2 }, { anchor: 8 }]);
+
+    expect(handleMarkdownEnter(view)).toBe(false);
+    expect(editor.getDocument()).toBe("plain\ntext");
+    editor.destroy();
+  });
+});
+
+describe("markdown auto-pair with multiple cursors", () => {
+  function runInputHandlers(view: EditorView, text: string): boolean {
+    const main = view.state.selection.main;
+    return view.state
+      .facet(EditorView.inputHandler)
+      .some((handler) => handler(view, main.from, main.to, text, () => {
+        throw new Error("default insert not expected in these tests");
+      }));
+  }
+
+  it("wraps two selections in backticks", () => {
+    const { editor, view } = createTestEditor("one two");
+    editor.setSelections([{ anchor: 0, head: 3 }, { anchor: 4, head: 7 }]);
+
+    expect(runInputHandlers(view, "`")).toBe(true);
+
+    expect(editor.getDocument()).toBe("`one` `two`");
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 1, head: 4 },
+      { anchor: 7, head: 10 },
+    ]);
+    editor.destroy();
+  });
+
+  it("completes double markers at every cursor", () => {
+    const { editor, view } = createTestEditor("*\n*");
+    editor.setSelections([{ anchor: 1 }, { anchor: 3 }]);
+
+    expect(runInputHandlers(view, "*")).toBe(true);
+
+    expect(editor.getDocument()).toBe("****\n****");
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 2, head: 2 },
+      { anchor: 7, head: 7 },
+    ]);
+    editor.destroy();
+  });
+
+  it("plain-inserts at cursors that are not completing a double marker", () => {
+    const { editor, view } = createTestEditor("*\nx");
+    editor.setSelections([{ anchor: 1 }, { anchor: 3 }]);
+
+    expect(runInputHandlers(view, "*")).toBe(true);
+
+    expect(editor.getDocument()).toBe("****\nx*");
+    editor.destroy();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     }
   },
   test: {
-    environment: "jsdom"
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"]
   }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,22 @@
+/**
+ * jsdom does not implement `Range.getClientRects` / `getBoundingClientRect`,
+ * which CodeMirror's drawSelection layer (enabled by `multiCursor: true`)
+ * calls during its measure cycle. CodeMirror catches the resulting
+ * TypeError, but logs it — flooding stderr on every test run that creates a
+ * multi-cursor editor. Stub them with empty geometry: layer rendering is a
+ * no-op headless, selection *state* (what tests assert on) is unaffected.
+ */
+const emptyRectList = (): DOMRectList => {
+  const list = [] as unknown as DOMRectList;
+  (list as unknown as { item: (index: number) => DOMRect | null }).item = () => null;
+  return list;
+};
+
+if (typeof Range !== "undefined") {
+  if (!Range.prototype.getClientRects) {
+    Range.prototype.getClientRects = emptyRectList;
+  }
+  if (!Range.prototype.getBoundingClientRect) {
+    Range.prototype.getBoundingClientRect = () => new DOMRect(0, 0, 0, 0);
+  }
+}


### PR DESCRIPTION
## Summary

Implements **ROADMAP #6 — Multi-cursor / multi-selection** (`core`, P1) as an opt-in `multiCursor` config flag, with the live-preview / table interaction verification the roadmap row calls out, multi-range correctness fixes for the markdown Enter and auto-pair handlers, a selections API, and full test coverage.

OpenSpec change: `openspec/changes/add-core-multi-cursor` (proposal / design / tasks / spec deltas included in this PR).

## Why

CodeMirror 6 ships the state machinery (`EditorState.allowMultipleSelections`), but Nexus never enables it — any attempt at multiple ranges silently collapses. Naive enablement is broken in four concrete ways found during the audit:

1. **No rendering** — secondary cursors are invisible without `drawSelection()` (native DOM selection can only show one range).
2. **`handleMarkdownEnter` is main-range only** — with two cursors on two list items, Enter continues the list at the main cursor and *drops the keystroke* for every other cursor (the keymap consumes the event after a single-range dispatch).
3. **`markdownAutoPair` is main-range only** — same keystroke-loss failure for `` ` `` / `**` / `~~`.
4. **No command surface or API** — no way to create cursors from the keyboard; `getSelection` / `setSelection` / `selectionChange` only speak single-range.

The live-preview decoration pipeline was already multi-range aware (`buildDecorations` receives `state.selection.ranges`; the helpers in `live-preview-ranges.ts` use `.some()` across ranges), which keeps the change tractable — the work is enablement, commands, per-range correctness, API exposure, and regression coverage.

## What changes

### Core — enablement & commands (`packages/core/src/multi-cursor.ts`, new)

- `EditorConfig.multiCursor?: boolean` (default **false**): enables `allowMultipleSelections`, `drawSelection()` (recoloured via the existing `--nexus-*` theme vars), Alt-click add-cursor (explicit `clickAddsSelectionRange` facet — VS Code / Obsidian convention), and the keymap. Default-off because `drawSelection` visibly replaces native caret/selection rendering for existing consumers.
- Commands (also exported standalone for custom bindings):
  - `selectNextOccurrence` (`Mod-d`) — VS Code style: empty ranges expand to the word under them first; then each press adds the next occurrence of the main-range text, scanning forward from the last range with wrap-around, skipping already-covered occurrences. Implemented in-core with a plain document scan — avoids pulling `@codemirror/search`'s panel infrastructure into every core bundle (rationale in `design.md`).
  - `addCursorAbove` / `addCursorBelow` (`Mod-Alt-ArrowUp/Down`) — logical-line based, column preserved / clamped; deterministic headless (no pixel measurement).
  - `collapseToMainSelection` (`Escape`) — returns `false` on single-range so slash menu / search panel Escape handlers keep working.

### Core — selections API (additive, no breaking changes)

- `getSelections(): { ranges, mainIndex }` / `setSelections(ranges, mainIndex?)`.
- `selectionChange` payload extended to `{ anchor, head, ranges, mainIndex }` — `anchor`/`head` still describe the main range, existing listeners unaffected.

### Core — multi-range correctness

- `handleMarkdownEnter` rewritten around `state.changeByRange`: list/blockquote continuation, empty-item exit, or plain newline **per range**, one dispatch = one undo step. Defers to default Enter when no range is on a continuable line — single-cursor behaviour is unchanged (existing `markdown-keymap.test.ts` suite passes unmodified).
- `markdownAutoPair` rewritten per-range; the `**`/`~~` preceding-char check is evaluated per cursor, mixed cases get a plain insert at non-matching cursors.
- `live-preview-table.ts`: the two read-only `selection.main` checks in the rAF poll widen to all ranges (whole-table overlay → `ranges.some`, leave-table range-clear → `ranges.every`). Audited against all 12 table rules in `CLAUDE.md` — no state lifecycle, locking, or DOM mutation changes.

### Demo, docs, test infra

- electron-demo enables `multiCursor: true` (exercised manually: Alt-click, Mod-d, Mod-Alt-Arrow, Escape, live-preview reveal, table interactions).
- New `packages/core/README.md` documenting the flag, key bindings, commands, and selections API; ROADMAP (en/zh) row #6 → `in-progress` with the change id linked.
- `vitest.setup.ts` (new, wired via `setupFiles`): stubs jsdom's missing `Range.getClientRects` / `getBoundingClientRect` so `drawSelection`'s measure cycle stops logging caught TypeErrors to stderr in every multi-cursor test.

## Tests — 345 passing (29 files), `pnpm build` + `pnpm typecheck` green

| Suite | Coverage |
|---|---|
| `multi-cursor.test.ts` (new, 27 cases) | config gating (off → collapse, on → retain), selections API round-trip, event payload, `selectNextOccurrence` (word expansion / add next / wrap / skip-selected / all-selected → false / no word → false), `addCursorAbove/Below` (column preserve / clamp / doc edge → false / stacking), `collapseToMainSelection`, keymap smoke tests (Mod-d, Escape, flag-off inert), multi-cursor Enter (two list items, mixed list+plain, same-line exit dedupe, defer-to-default), multi-cursor auto-pair (backtick wrap ×2, double-marker ×2, mixed plain-insert) |
| `live-preview-regressions.test.ts` | two cursors reveal raw `**` markers in two separate spans simultaneously; collapsing hides both — guards the `.some()`-across-ranges reveal logic |
| `events.test.ts` | `selectionChange` payload contract updated to the extended shape |

## Out of scope (explicit non-goals, see proposal)

- Multi-cursor *inside* table-widget cells (contentEditable DOM, not CM selections)
- IME composition across multiple ranges (follows CM6 upstream behaviour)
- Rectangular Alt-drag selection; `selectAllOccurrences` (both layer on trivially later)
