### PR TITLE
feat(core): add selection controls to setDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 editor.getDocument()          // current Markdown string
 editor.getAst()               // current mdast Root
 editor.setDocument(md)        // replace entire document
+editor.setDocument(md, { silent: true, preserveSelection: true })
+editor.setDocument(md, { selection: { anchor: 0 } })
 editor.setSelection(pos)      // move cursor
 editor.focus() / editor.blur()
 editor.destroy()

--- a/README.zh.md
+++ b/README.zh.md
@@ -207,6 +207,8 @@ pnpm dev:electron-demo
 editor.getDocument()          // 当前 Markdown 文本
 editor.getAst()               // 当前 mdast 语法树
 editor.setDocument(md)        // 替换整个文档
+editor.setDocument(md, { silent: true, preserveSelection: true })
+editor.setDocument(md, { selection: { anchor: 0 } })
 editor.setSelection(pos)      // 移动光标
 editor.focus() / editor.blur()
 editor.destroy()

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -32,8 +32,10 @@ import type {
   EditorEventContext,
   EditorEventHandler,
   EditorEventMap,
+  EditorSelectionRange,
   NexusPlugin,
   ParserLike,
+  SetDocumentOptions,
   TocEntry,
 } from "./types";
 import { createWidgetExtension } from "./widget-extension";
@@ -157,6 +159,32 @@ function extractToc(ast: Root): TocEntry[] {
   return entries;
 }
 
+function clampPosition(pos: number, docLength: number): number {
+  if (!Number.isFinite(pos)) return 0;
+  return Math.max(0, Math.min(docLength, Math.trunc(pos)));
+}
+
+function resolveDocumentSelection(
+  before: EditorSelectionRange,
+  docLength: number,
+  opts: SetDocumentOptions | undefined,
+): EditorSelectionRange | undefined {
+  if (opts?.selection) {
+    const anchor = clampPosition(opts.selection.anchor, docLength);
+    const head = clampPosition(opts.selection.head ?? opts.selection.anchor, docLength);
+    return { anchor, head };
+  }
+
+  if (opts?.preserveSelection) {
+    return {
+      anchor: clampPosition(before.anchor, docLength),
+      head: clampPosition(before.head, docLength),
+    };
+  }
+
+  return undefined;
+}
+
 function createParser(plugins: NexusPlugin[]): ParserLike {
   // Build the unified pipeline ONCE, not per-parse call. Each
   // `unified().use(...)` chain resolves plugin graphs, initializes extensions,
@@ -259,7 +287,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
   // 组合输入（IME）状态与被推迟的文档回灌。组合输入进行中调用 setDocument 会被
   // 推迟到 compositionend 再应用，避免整文档替换打断输入法、丢失合成中文字、视口跳顶。
   let composing = false;
-  let pendingDocumentLoad: { next: string; silent: boolean } | null = null;
+  let pendingDocumentLoad: { next: string; opts?: SetDocumentOptions } | null = null;
   // Initial AST: when a custom parser is provided, honour it (tests rely on
   // this — they install plugins that mutate the tree). Otherwise use the
   // Lezer string parser, which is dramatically faster than remark and
@@ -364,23 +392,33 @@ export function createEditor(config: EditorConfig): EditorAPI {
   }
 
   // 整文档替换的实际执行体。setDocument（公开 API）在组合输入中会推迟调用本函数。
-  function performSetDocument(next: string, silent: boolean) {
+  function performSetDocument(next: string, opts?: SetDocumentOptions) {
     const beforeSelection = view.state.selection.main;
+    const silent = opts?.silent === true;
+    const selection = resolveDocumentSelection(
+      { anchor: beforeSelection.anchor, head: beforeSelection.head },
+      next.length,
+      opts
+    );
     debugNexus("setDocument", {
       silent,
       oldLength: view.state.doc.length,
       nextLength: next.length,
       beforeSelection: { anchor: beforeSelection.anchor, head: beforeSelection.head },
+      selection,
     });
 
-    view.dispatch({
+    const dispatchSpec = {
       changes: {
         from: 0,
         to: view.state.doc.length,
         insert: next
       },
       annotations: silent ? silentDocChange.of(true) : undefined,
-    });
+      ...(selection ? { selection } : {}),
+    };
+
+    view.dispatch(dispatchSpec);
 
     // silent 模式下仍同步 currentAst，使 getAst() / getTableOfContents() 反映已载入文件。
     if (silent) {
@@ -395,10 +433,10 @@ export function createEditor(config: EditorConfig): EditorAPI {
   // compositionend 时应用被推迟的文档回灌；整文档替换后排队中的组合输入变更已失效。
   function applyPendingDocumentLoad(): boolean {
     if (!pendingDocumentLoad) return false;
-    const { next, silent } = pendingDocumentLoad;
+    const { next, opts } = pendingDocumentLoad;
     pendingDocumentLoad = null;
     pendingCompositionMarkdown = null;
-    performSetDocument(next, silent);
+    performSetDocument(next, opts);
     return true;
   }
 
@@ -719,20 +757,18 @@ export function createEditor(config: EditorConfig): EditorAPI {
         return;
       }
 
-      const silent = opts?.silent === true;
-
       // 组合输入（IME）进行中：整文档替换会打断输入法、丢失合成中文字并把视口重置到顶部。
       // 推迟到 compositionend 再应用，只保留最后一次请求。
       if (composing || view.composing || view.compositionStarted) {
-        pendingDocumentLoad = { next, silent };
+        pendingDocumentLoad = { next, opts };
         debugNexus("setDocument-deferred-composing", {
-          silent,
+          silent: opts?.silent === true,
           nextLength: next.length,
         });
         return;
       }
 
-      performSetDocument(next, silent);
+      performSetDocument(next, opts);
     },
     replaceSelection(text) {
       if (destroyed) return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export type {
   EditorEventHandler,
   EditorEventHandlers,
   EditorEventMap,
+  EditorSelectionRange,
   LivePreviewConfig,
   LivePreviewLabels,
   LivePreviewNode,
@@ -40,6 +41,7 @@ export type {
   ParserLike,
   SlashCommandDef,
   SlashMenuState,
+  SetDocumentOptions,
   TocEntry,
   WidgetDefinition,
   WidgetRenderContext

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -133,6 +133,32 @@ export interface TocEntry {
   to: number;
 }
 
+export interface EditorSelectionRange {
+  anchor: number;
+  head: number;
+}
+
+export interface SetDocumentOptions {
+  /**
+   * When true, skip the onChange pipeline. Use when loading a file from disk
+   * to avoid treating the load as a user edit.
+   */
+  silent?: boolean;
+  /**
+   * Keep the current main selection after replacing the document. Positions
+   * are clamped to the new document length.
+   */
+  preserveSelection?: boolean;
+  /**
+   * Apply an explicit selection after replacing the document. Takes precedence
+   * over preserveSelection. head defaults to anchor.
+   */
+  selection?: {
+    anchor: number;
+    head?: number;
+  };
+}
+
 export interface EditorAPI {
   getDocument(): string;
   getAst(): Root;
@@ -154,7 +180,7 @@ export interface EditorAPI {
    * 并把视口重置到顶部。此时本次替换会延迟到 compositionend 再应用，只保留
    * 最后一次请求。
    */
-  setDocument(next: string, opts?: { silent?: boolean }): void;
+  setDocument(next: string, opts?: SetDocumentOptions): void;
   replaceSelection(text: string): void;
   undo(): boolean;
   redo(): boolean;

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -90,6 +90,88 @@ describe("createEditor", () => {
     editor.destroy();
   });
 
+  it("preserves selection when setDocument is called with preserveSelection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(6, 11);
+    editor.setDocument("hello nexus", { preserveSelection: true });
+
+    expect(editor.getDocument()).toBe("hello nexus");
+    expect(editor.getSelection()).toEqual({ anchor: 6, head: 11 });
+    editor.destroy();
+  });
+
+  it("clamps preserved selection to the new document length", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "0123456789" });
+
+    editor.setSelection(8, 10);
+    editor.setDocument("abc", { preserveSelection: true });
+
+    expect(editor.getSelection()).toEqual({ anchor: 3, head: 3 });
+    editor.destroy();
+  });
+
+  it("applies explicit selection after setDocument", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "old" });
+
+    editor.setDocument("new document", {
+      selection: { anchor: 4, head: 12 },
+    });
+
+    expect(editor.getSelection()).toEqual({ anchor: 4, head: 12 });
+    editor.destroy();
+  });
+
+  it("clamps explicit setDocument selection positions", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "old" });
+
+    editor.setDocument("abc", {
+      selection: { anchor: -10, head: 99 },
+    });
+
+    expect(editor.getSelection()).toEqual({ anchor: 0, head: 3 });
+    editor.destroy();
+  });
+
+  it("lets explicit selection override preserveSelection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "old document" });
+
+    editor.setSelection(0, 3);
+    editor.setDocument("new document", {
+      preserveSelection: true,
+      selection: { anchor: 4 },
+    });
+
+    expect(editor.getSelection()).toEqual({ anchor: 4, head: 4 });
+    editor.destroy();
+  });
+
+  it("preserves selection for silent document loads without emitting change", () => {
+    const container = document.createElement("div");
+    const docs: string[] = [];
+    const editor = createEditor({
+      container,
+      initialValue: "# Old",
+      onChange(doc) {
+        docs.push(doc);
+      },
+    });
+
+    editor.setSelection(2);
+    editor.setDocument("# New", { silent: true, preserveSelection: true });
+
+    expect(editor.getDocument()).toBe("# New");
+    expect(editor.getSelection()).toEqual({ anchor: 2, head: 2 });
+    expect(docs).toEqual([]);
+    expect(editor.getAst().children[0]?.type).toBe("heading");
+    editor.destroy();
+  });
+
   it("keeps the editor usable when the parser throws", () => {
     const container = document.createElement("div");
     const docs: string[] = [];
@@ -365,7 +447,7 @@ describe("createEditor", () => {
 
     editor.destroy();
 
-    expect(() => editor.setDocument("after-destroy")).not.toThrow();
+    expect(() => editor.setDocument("after-destroy", { preserveSelection: true })).not.toThrow();
     expect(() => editor.focus()).not.toThrow();
     expect(() => editor.blur()).not.toThrow();
 
@@ -508,6 +590,53 @@ describe("createEditor — composition-safe setDocument", () => {
     view.contentDOM.dispatchEvent(new Event("compositionend", { bubbles: true }));
     // 组合输入结束后才应用被推迟的回灌。
     expect(editor.getDocument()).toBe("external load");
+    editor.destroy();
+  });
+
+  it("keeps deferred setDocument selection options after IME composition ends", () => {
+    const container = document.createElement("div");
+    let capturedView: EditorView | null = null;
+    const editor = createEditor({
+      container,
+      initialValue: "hello world",
+      plugins: [{ name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] }],
+    });
+    const view = requireEditorView(capturedView);
+
+    editor.setSelection(6, 11);
+    view.contentDOM.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+    editor.setDocument("hello nexus", { silent: true, preserveSelection: true });
+
+    expect(editor.getDocument()).toBe("hello world");
+
+    view.contentDOM.dispatchEvent(new Event("compositionend", { bubbles: true }));
+
+    expect(editor.getDocument()).toBe("hello nexus");
+    expect(editor.getSelection()).toEqual({ anchor: 6, head: 11 });
+    editor.destroy();
+  });
+
+  it("uses the latest deferred setDocument call while IME composition is active", () => {
+    const container = document.createElement("div");
+    let capturedView: EditorView | null = null;
+    const editor = createEditor({
+      container,
+      initialValue: "base text",
+      plugins: [{ name: "capture", cmExtensions: [captureViewPlugin((view) => (capturedView = view))] }],
+    });
+    const view = requireEditorView(capturedView);
+
+    editor.setSelection(5, 9);
+    view.contentDOM.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+    editor.setDocument("first", { preserveSelection: true });
+    editor.setDocument("second", { selection: { anchor: 2, head: 99 } });
+
+    expect(editor.getDocument()).toBe("base text");
+
+    view.contentDOM.dispatchEvent(new Event("compositionend", { bubbles: true }));
+
+    expect(editor.getDocument()).toBe("second");
+    expect(editor.getSelection()).toEqual({ anchor: 2, head: 6 });
     editor.destroy();
   });
 


### PR DESCRIPTION
## Summary / 摘要

Add selection controls to `EditorAPI.setDocument()`, allowing callers to preserve the current selection or apply an explicit selection after replacing the document.

为 `EditorAPI.setDocument()` 增加选区控制能力：整文档替换后可保留当前光标/选区，或指定新的选区。

## Changes / 变更

- Add `SetDocumentOptions` and `EditorSelectionRange`.
- Support `preserveSelection` and explicit `selection`.
- Clamp selection positions to the new document length.
- Preserve existing `silent` behavior.
- Carry full options through IME-deferred document loads.
- 
## Scope / 后续

This PR intentionally keeps plugin-layer migrations out of scope. Some toolbar/search flows currently replace the document and then restore selection in a separate step. Once the core API is accepted, those call sites can be migrated in a focused follow-up PR to reduce review scope and avoid conflicts with ongoing plugin work.

本 PR 有意不改造 toolbar/search 等插件层调用，保持 core API 变更聚焦。当前部分插件流程仍采用 `setDocument()` 后再 `setSelection()` 的两步更新；待 core API 合入后，可单独提交插件层迁移 PR，降低本次 review 范围和与现有插件 PR 的冲突风险。

## Testing / 测试

- `corepack pnpm exec vitest run packages/core/test/editor.test.ts` passed
- `corepack pnpm -r exec tsc --noEmit` passed
- `corepack pnpm --filter @floatboat/nexus-core build` passed
- `corepack pnpm exec vitest run --exclude apps/electron-demo/test/sample-vault.test.ts` passed

Note: full `vitest run` has pre-existing Windows-local failures in `apps/electron-demo/test/sample-vault.test.ts` related to path separator / sample-vault fixture assertions.