### PR TITLE
feat(core,react,vue): add onReady callback and getSelectedText() API

### DIFF
--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -687,6 +687,11 @@ export function createEditor(config: EditorConfig): EditorAPI {
       const sel = view.state.selection.main;
       return { anchor: sel.anchor, head: sel.head };
     },
+    getSelectedText() {
+      const sel = view.state.selection.main;
+      if (sel.empty) return "";
+      return view.state.sliceDoc(sel.from, sel.to);
+    },
     getSlashCommands() {
       return slashCommands;
     },
@@ -840,6 +845,8 @@ export function createEditor(config: EditorConfig): EditorAPI {
       view.destroy();
     }
   };
+
+  config.onReady?.(api);
 
   return api;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,6 +103,15 @@ export interface EditorConfig {
   onFocus?: () => void;
   onBlur?: () => void;
   /**
+   * Called once after the editor's CodeMirror view is fully constructed and
+   * the initial document has been parsed. Use this to run setup logic that
+   * depends on the editor being ready (e.g. focusing, loading external state).
+   *
+   * The callback receives the {@link EditorAPI} so hosts don't need to capture
+   * the return value of {@link createEditor} separately.
+   */
+  onReady?: (editor: EditorAPI) => void;
+  /**
    * 资源上传钩子：粘贴 / 拖拽进来的图片或文件交给宿主落盘 / 上传，返回可供 markdown
    * 引用的 URL（相对路径或远程地址）。返回 null 表示放弃，编辑器不会插入坏链接。
    */
@@ -140,6 +149,11 @@ export interface EditorAPI {
   exportHTML(): string;
   setTheme(theme: import("./theme").NexusTheme): void;
   getSelection(): { anchor: number; head: number };
+  /**
+   * Return the text within the current selection. When the selection is
+   * empty (a cursor), returns an empty string.
+   */
+  getSelectedText(): string;
   getSlashCommands(): SlashCommandDef[];
   uploadAsset(file: File): Promise<string | null>;
   setSelection(anchor: number, head?: number): void;

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -3,6 +3,7 @@ import { EditorView, ViewPlugin } from "@codemirror/view";
 import type { Plugin } from "unified";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEditor } from "../src/index";
+import type { EditorAPI } from "../src/types";
 
 function requireEditorView(view: EditorView | null): EditorView {
   if (!view) throw new Error("Expected CodeMirror view to be captured");
@@ -447,6 +448,86 @@ describe("createEditor", () => {
     expect(html).toContain("<strong>bold</strong>");
     expect(html).toContain("<code");
     expect(html).toContain("console.log(1)");
+    editor.destroy();
+  });
+
+  // ── getSelectedText ──
+
+  it("returns empty string when no text is selected", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(5);
+    expect(editor.getSelectedText()).toBe("");
+    editor.destroy();
+  });
+
+  it("returns the selected text range", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(0, 5);
+    expect(editor.getSelectedText()).toBe("hello");
+    editor.destroy();
+  });
+
+  it("returns selected text regardless of selection direction", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(11, 6);
+    expect(editor.getSelectedText()).toBe("world");
+    editor.destroy();
+  });
+
+  it("returns full document text when everything is selected", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "hello world" });
+
+    editor.setSelection(0, 11);
+    expect(editor.getSelectedText()).toBe("hello world");
+    editor.destroy();
+  });
+
+  // ── onReady callback ──
+
+  it("calls onReady after the editor is constructed", () => {
+    const container = document.createElement("div");
+    const readyCalls: string[] = [];
+    const editor = createEditor({
+      container,
+      initialValue: "ready test",
+      onReady(api) {
+        readyCalls.push(api.getDocument());
+      }
+    });
+
+    expect(readyCalls).toEqual(["ready test"]);
+    editor.destroy();
+  });
+
+  it("calls onReady with a fully functional EditorAPI", () => {
+    const container = document.createElement("div");
+    let readyApi: EditorAPI | null = null;
+    const editor = createEditor({
+      container,
+      initialValue: "api test",
+      onReady(api) {
+        readyApi = api;
+      }
+    });
+
+    expect(readyApi).not.toBeNull();
+    expect(readyApi!.getDocument()).toBe("api test");
+    expect(readyApi!.getAst().type).toBe("root");
+    expect(readyApi!.getSelection()).toEqual({ anchor: 0, head: 0 });
+    editor.destroy();
+  });
+
+  it("does not call onReady when no callback is provided", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "no callback" });
+    expect(editor.getDocument()).toBe("no callback");
     editor.destroy();
   });
 });

--- a/packages/react/src/editor.tsx
+++ b/packages/react/src/editor.tsx
@@ -1,9 +1,9 @@
 import { useEditor } from "./use-editor";
 
-import type { UseEditorConfig } from "./types";
+import type { EditorComponentProps } from "./types";
 
-export function Editor(props: UseEditorConfig) {
-  const { containerRef } = useEditor(props);
+export function Editor({ className, style, ...editorConfig }: EditorComponentProps) {
+  const { containerRef } = useEditor(editorConfig);
 
-  return <div ref={containerRef} />;
+  return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorComponentProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,9 +2,16 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { RefObject } from "react";
+import type { CSSProperties, RefObject } from "react";
 
 export type UseEditorConfig = Omit<EditorConfig, "container">;
+
+export interface EditorComponentProps extends UseEditorConfig {
+  /** CSS class name applied to the container div. */
+  className?: string;
+  /** Inline styles applied to the container div. */
+  style?: CSSProperties;
+}
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 describe("@floatboat/nexus-react", () => {
   it("renders an editor into the provided container through the Editor component", () => {
@@ -36,5 +37,33 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady callback after editor initialization", () => {
+    const onReady = vi.fn();
+    const { unmount } = render(
+      <Editor initialValue="ready" onReady={onReady} />
+    );
+
+    expect(onReady).toHaveBeenCalledOnce();
+    const api = onReady.mock.calls[0][0] as EditorAPI;
+    expect(api.getDocument()).toBe("ready");
+    unmount();
+  });
+
+  it("applies className and style to the container div", () => {
+    const { container, unmount } = render(
+      <Editor
+        initialValue="styled"
+        className="my-editor"
+        style={{ height: "400px", border: "1px solid red" }}
+      />
+    );
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("my-editor");
+    expect(wrapper.style.height).toBe("400px");
+    expect(wrapper.style.border).toBe("1px solid red");
+    unmount();
   });
 });

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -1,18 +1,33 @@
-import { defineComponent, h } from "vue";
+import { defineComponent, h, useAttrs } from "vue";
 
 import { useEditor } from "./use-editor";
+import type { EditorComponentProps } from "./types";
 
 export const Editor = defineComponent({
   name: "NexusEditor",
+  inheritAttrs: false,
   props: {
     initialValue: {
       type: String,
       required: false
+    },
+    class: {
+      type: [String, Array, Object] as unknown as () => EditorComponentProps["class"],
+      required: false
+    },
+    style: {
+      type: [String, Object, Array] as unknown as () => EditorComponentProps["style"],
+      required: false
     }
   },
   setup(props) {
-    const { containerRef } = useEditor(props);
+    const attrs = useAttrs();
+    const { containerRef } = useEditor({ ...attrs, ...props } as EditorComponentProps);
 
-    return () => h("div", { ref: containerRef });
+    return () => h("div", {
+      ref: containerRef,
+      class: props.class,
+      style: props.style
+    });
   }
 });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorComponentProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -2,9 +2,16 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { Ref, ShallowRef } from "vue";
+import type { Ref, ShallowRef, StyleValue } from "vue";
 
 export type UseEditorConfig = Omit<EditorConfig, "container">;
+
+export interface EditorComponentProps extends UseEditorConfig {
+  /** CSS class name(s) applied to the container div. */
+  class?: string | Record<string, boolean> | string[];
+  /** Inline styles applied to the container div. */
+  style?: StyleValue;
+}
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,7 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, onMounted } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 describe("@floatboat/nexus-vue", () => {
   it("renders an editor into the provided container through the Editor component", async () => {
@@ -44,5 +45,39 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady callback after editor initialization", async () => {
+    const onReady = vi.fn();
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "ready",
+        onReady
+      }
+    });
+
+    await nextTick();
+
+    expect(onReady).toHaveBeenCalledOnce();
+    const api = onReady.mock.calls[0][0] as EditorAPI;
+    expect(api.getDocument()).toBe("ready");
+    wrapper.unmount();
+  });
+
+  it("applies class and style to the container div", async () => {
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "styled",
+        class: "my-editor",
+        style: { height: "400px", border: "1px solid red" }
+      }
+    });
+
+    await nextTick();
+
+    expect(wrapper.element.className).toContain("my-editor");
+    expect((wrapper.element as HTMLElement).style.height).toBe("400px");
+    expect((wrapper.element as HTMLElement).style.border).toBe("1px solid red");
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Summary

Adds two P0 roadmap features and framework binding improvements:

### Core (`@floatboat/nexus-core`)
- **`onReady` callback** on `EditorConfig` — fires once after the CM6 view and initial AST are fully constructed, passing the `EditorAPI` so hosts don't need to capture `createEditor`'s return value separately.
- **`getSelectedText()`** on `EditorAPI` — returns the text within the current selection (empty string for a cursor). Uses `view.state.sliceDoc()` for correct behavior regardless of selection direction.

### React (`@floatboat/nexus-react`)
- `onReady` flows through `useEditor` hook to `createEditor` automatically (already part of `UseEditorConfig`).
- New `EditorComponentProps` type with `className` and `style` pass-through props on the `<Editor />` component.

### Vue (`@floatboat/nexus-vue`)
- `onReady` flows through `useEditor` composable via `useAttrs()` capture of undeclared props.
- New `EditorComponentProps` type with `class` and `style` pass-through props on the `<Editor />` component.
- `inheritAttrs: false` to allow explicit forwarding of attrs to the container div.

## Test plan

- [x] `getSelectedText()`: empty selection, forward selection, reverse selection, full document selection
- [x] `onReady`: callback receives EditorAPI, called after view construction, works without callback
- [x] React: `onReady` callback fires, `className`/`style` applied to container div
- [x] Vue: `onReady` callback fires, `class`/`style` applied to container div
- [x] All 313 existing tests pass (9 pre-existing Windows path failures in `sample-vault.test.ts`)
- [x] TypeScript type checks pass for core, react, and vue packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)