### PR TITLE
feat(wordcount): add @floatboat/nexus-plugin-wordcount with markdown-aware stats

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Examples: `feat/toolbar-list-toggle`, `fix/search-regex-escape`, `docs/roadmap-u
   | `react` | `packages/react` |
   | `vue` | `packages/vue` |
   | `gfm` | `packages/preset-gfm` |
-  | `history` / `search` / `slash` / `toolbar` / `math` / `vim` | corresponding `plugin-*` |
+  | `history` / `search` / `slash` / `toolbar` / `math` / `vim` / `wordcount` | corresponding `plugin-*` |
   | `electron` | `apps/electron-demo` |
   | `live-preview` / `wikilinks` / `image` | core subsystems (historical usage) |
   | `openspec` | `openspec/` |

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -12,7 +12,7 @@
 |---|---|
 | `packages/core` | 核心编辑器（CodeMirror 6 内核、live-preview、AST） |
 | `packages/preset-gfm` | GFM 默认预设 |
-| `packages/plugin-*` | 各功能插件（history / search / slash / toolbar / math / vim） |
+| `packages/plugin-*` | 各功能插件（history / search / slash / toolbar / math / vim / wordcount） |
 | `packages/react`、`packages/vue` | 框架 SDK |
 | `apps/electron-demo` | 桌面端 demo / 集成测试场 |
 | `openspec/` | 规格驱动（proposal / specs / archive） |
@@ -45,7 +45,7 @@
   | `react` | `packages/react` |
   | `vue` | `packages/vue` |
   | `gfm` | `packages/preset-gfm` |
-  | `history` / `search` / `slash` / `toolbar` / `math` / `vim` | 对应 `plugin-*` |
+  | `history` / `search` / `slash` / `toolbar` / `math` / `vim` / `wordcount` | 对应 `plugin-*` |
   | `electron` | `apps/electron-demo` |
   | `live-preview` / `wikilinks` / `image` | core 内部子系统（沿用历史用法） |
   | `openspec` | `openspec/` |

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 ## 📦 Packages
 
 <details>
-<summary><b>Full package list (10 packages)</b> — click to expand</summary>
+<summary><b>Full package list (11 packages)</b> — click to expand</summary>
 
 | Package | Description |
 |---|---|
@@ -179,6 +179,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 | `@floatboat/nexus-plugin-toolbar` | Toolbar primitives for formatting commands |
 | `@floatboat/nexus-plugin-math` | Inline / block math rendering (KaTeX) |
 | `@floatboat/nexus-plugin-vim` | Vim keybindings powered by `@replit/codemirror-vim` |
+| `@floatboat/nexus-plugin-wordcount` | Markdown-aware word / character / CJK / reading-time stats + ARIA-live status bar |
 
 </details>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -165,7 +165,7 @@ pnpm dev:electron-demo
 ## 📦 包列表
 
 <details>
-<summary><b>完整包列表（10 个包）</b> —— 点击展开</summary>
+<summary><b>完整包列表（11 个包）</b> —— 点击展开</summary>
 
 | 包名 | 说明 |
 |---|---|
@@ -179,6 +179,7 @@ pnpm dev:electron-demo
 | `@floatboat/nexus-plugin-toolbar` | 工具栏基础组件与格式化命令 |
 | `@floatboat/nexus-plugin-math` | 行内 / 块级数学公式渲染（KaTeX） |
 | `@floatboat/nexus-plugin-vim` | Vim 键位（基于 `@replit/codemirror-vim`） |
+| `@floatboat/nexus-plugin-wordcount` | Markdown 感知的字数 / 字符数 / 中日韩字符 / 阅读时长统计 + ARIA 状态栏 |
 
 </details>
 

--- a/apps/electron-demo/package.json
+++ b/apps/electron-demo/package.json
@@ -27,6 +27,7 @@
     "@floatboat/nexus-plugin-search": "workspace:*",
     "@floatboat/nexus-plugin-slash": "workspace:*",
     "@floatboat/nexus-plugin-toolbar": "workspace:*",
+    "@floatboat/nexus-plugin-wordcount": "workspace:*",
     "@floatboat/nexus-preset-gfm": "workspace:*",
     "highlight.js": "^11.11.0"
   },

--- a/apps/electron-demo/src/renderer/editor-shell.ts
+++ b/apps/electron-demo/src/renderer/editor-shell.ts
@@ -9,6 +9,11 @@ import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
 import { createToolbarPlugin, createToolbarUI, type ToolbarUI } from "@floatboat/nexus-plugin-toolbar";
 import { createSearchPlugin } from "@floatboat/nexus-plugin-search";
 import { createSlashMenuUI, type SlashMenuUI } from "@floatboat/nexus-plugin-slash";
+import {
+  attachWordCountPlugin,
+  createWordCountPlugin,
+  type WordCountPlugin
+} from "@floatboat/nexus-plugin-wordcount";
 import type { AppState } from "./state";
 import { type EditorSettings, settingsToTheme } from "./settings";
 
@@ -78,6 +83,8 @@ export interface EditorShell {
   toolbar: ToolbarUI;
   /** The floating slash-command menu mounted on document.body. */
   slashMenu: SlashMenuUI;
+  /** Markdown-aware word-count plugin (handle + status bar). */
+  wordcount: WordCountPlugin;
   applySettings(settings: EditorSettings): void;
   loadDocument(content: string): void;
   destroy(): void;
@@ -104,6 +111,14 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
     suggest: suggestWikilinks ? (q) => suggestWikilinks(q) : undefined,
   });
 
+  // The wordcount plugin reads `editor.getAst()` on each (debounced)
+  // change — no double parsing — and mounts an ARIA-live status bar in
+  // the editor container's footer. Bound to the editor instance via
+  // `attachWordCountPlugin` once `createEditor` returns.
+  const wordcount = createWordCountPlugin({
+    statusBar: { container, classPrefix: "nexus-wordcount" },
+  });
+
   // No more parser worker. Live-preview drives off `syntaxTree(state)` from
   // @codemirror/lang-markdown (incremental, intrinsic to EditorState), and
   // editor.ts builds mdast for `getAst()` / `change` events synchronously
@@ -124,6 +139,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
       createToolbarPlugin(),
       createSearchPlugin(),
       wikilinksPlugin,
+      wordcount,
     ],
     livePreview: settings.livePreview
       ? {
@@ -321,10 +337,17 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
   // ancestors). Its lifecycle is tied to the shell — destroyed below.
   const slashMenu = createSlashMenuUI(editor);
 
+  // Bind the wordcount plugin now that the editor is fully constructed.
+  // The plugin's status-bar widget mounts on its first emission (next
+  // microtask), so it's already wired by the time the user sees the
+  // first paint.
+  attachWordCountPlugin(wordcount, editor);
+
   return {
     editor,
     toolbar,
     slashMenu,
+    wordcount,
     applySettings(next: EditorSettings) {
       editor.setTheme(settingsToTheme(next));
     },
@@ -347,6 +370,7 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
         `${(t1 - t0).toFixed(1)}ms`, { bytes: content.length });
     },
     destroy() {
+      wordcount.destroy();
       slashMenu.destroy();
       toolbar.destroy();
       editor.destroy();

--- a/apps/electron-demo/src/renderer/style.css
+++ b/apps/electron-demo/src/renderer/style.css
@@ -160,3 +160,33 @@ body,
   font-style: italic;
   text-align: center;
 }
+
+/* --- nexus-plugin-wordcount status bar -------------------------------- */
+.nexus-wordcount__bar {
+  position: absolute;
+  right: 12px;
+  bottom: 6px;
+  display: inline-flex;
+  gap: 12px;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--nexus-font, system-ui, -apple-system, "Segoe UI", sans-serif);
+  color: var(--nexus-text-muted, #6b7280);
+  background: var(--nexus-surface, rgba(255, 255, 255, 0.85));
+  border: 1px solid var(--nexus-border, rgba(0, 0, 0, 0.08));
+  border-radius: 6px;
+  pointer-events: none;
+  user-select: none;
+  z-index: 2;
+  backdrop-filter: blur(6px);
+}
+
+.nexus-wordcount__bar > span {
+  white-space: nowrap;
+}
+
+.nexus-wordcount__selection {
+  color: var(--nexus-accent, #2563eb);
+  font-weight: 500;
+}

--- a/apps/electron-demo/vite.config.ts
+++ b/apps/electron-demo/vite.config.ts
@@ -56,6 +56,10 @@ export default defineConfig({
         __dirname,
         "../../packages/plugin-slash/src/index.ts"
       ),
+      "@floatboat/nexus-plugin-wordcount": path.resolve(
+        __dirname,
+        "../../packages/plugin-wordcount/src/index.ts"
+      ),
     },
   },
   server: {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,6 +82,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 24 | TypeScript type coverage | repo-wide | P0 | in-progress | No | Ongoing; new code enforces strict |
 | 25 | End-to-end testing | repo infra | P1 | planned | No | Candidate: Playwright against electron-demo |
 | 26 | CI/CD pipeline polish | `.github/workflows` | P1 | planned | No | Publish workflow exists; missing PR check / e2e gate |
+| 28 | Markdown-aware word / reading-time stats | new `plugin-wordcount` | P1 | done | Yes | Walks editor AST (no double parse) + CJK-first + ARIA status bar — see `openspec/changes/add-plugin-wordcount` |
 
 ---
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -82,6 +82,7 @@
 | 24 | TypeScript 类型覆盖 | 全仓库 | P0 | in-progress | 否 | 持续推进，新代码强制 strict |
 | 25 | End-to-End 测试 | 仓库基建 | P1 | planned | 否 | 候选：Playwright，跑 electron-demo |
 | 26 | CI/CD 流程完善 | `.github/workflows` | P1 | planned | 否 | 已有 publish workflow，缺 PR check / e2e gate |
+| 28 | Markdown 感知字数 / 阅读时长统计 | 新包 `plugin-wordcount` | P1 | done | 是 | 复用编辑器 AST（不重复解析）+ 中日韩优先 + ARIA 状态栏 —— 见 `openspec/changes/add-plugin-wordcount` |
 
 ---
 

--- a/openspec/changes/add-plugin-wordcount/design.md
+++ b/openspec/changes/add-plugin-wordcount/design.md
@@ -1,0 +1,197 @@
+## Context
+
+Two existing facts shape this design:
+
+1. `@floatboat/nexus-core` already parses the document to **mdast** on
+   every change (see `packages/core/src/editor.ts` — debounced `parse`
+   into the `Root` AST cached on the API), and exposes the parsed AST
+   via `editor.getAst()`. A wordcount plugin that re-parses the
+   document for itself would double the parsing cost on every
+   keystroke.
+2. `EditorAPI.getDocumentStats()` exists but is naive — it does
+   `doc.trim().split(/\s+/)` on the raw Markdown source. We must not
+   silently change that API's semantics; existing consumers may have
+   built on the current behaviour. The new plugin is a *layer*, not
+   a replacement.
+
+## Goals / Non-Goals
+
+- **Goals**
+  - First-class CJK support (per-character counting by default) so
+    Chinese / Japanese / Korean documents report meaningful numbers.
+  - Markdown-aware exclusions (code, math, HTML, frontmatter,
+    footnote / link definitions).
+  - Selection stats updated synchronously while full-doc stats are
+    debounced.
+  - Reading-time estimate that uses different rates for Latin words
+    vs. CJK characters (a 1,000-character Chinese paragraph is read
+    in ~2 minutes, not ~4).
+  - Zero new external dependencies — read the AST `core` already
+    produces.
+  - Optional status-bar UI that's framework-agnostic and ARIA-live.
+- **Non-Goals**
+  - Per-heading word counts (TOC-style). Trivial to layer on top
+    later; left out to keep v1 surface small.
+  - Locale-aware sentence segmentation (`Intl.Segmenter` with
+    `granularity: "sentence"`). We expose a heuristic and document its
+    limits; hosts can swap in their own segmenter in a v2.
+  - Replacing `EditorAPI.getDocumentStats()` — would be a public-API
+    semantic break. Left for a separate proposal.
+
+## Decisions
+
+### Decision 1: New plugin package, not a core enhancement
+
+`@floatboat/nexus-plugin-wordcount` lives in `packages/plugin-wordcount/`.
+
+**Alternatives considered:**
+
+- *Extend `core.getDocumentStats()` to be Markdown-aware.* Would
+  change the semantics of an existing public method (e.g. a Notion
+  embed that relies on the current naive count would see different
+  numbers). Even if we add new fields, current consumers reading
+  `words` would silently shift. Rejected: breaks SemVer expectation
+  on an unversioned beta API more than necessary.
+- *Drop it into `preset-gfm`.* The preset is about Markdown
+  extensions (tables, task lists), not statistics. Mixing in a
+  cross-cutting capability would muddy the package's purpose.
+  Rejected.
+- *Headless utility only (no plugin / status bar).* Loses the
+  out-of-the-box "drop in and see counts" affordance. The bar is
+  cheap (few dozen DOM nodes) and trivially opt-in via
+  `statusBar: false`. Rejected.
+
+The plugin package mirrors `plugin-history` exactly: ESM-only build
+with `tsup`, workspace dep on `@floatboat/nexus-core`, no deps on
+other plugins.
+
+### Decision 2: Read the AST `core` already parsed, never re-parse
+
+`createWordCountPlugin` reads the document via `editor.getDocument()`
+and the AST via `editor.getAst()`. Both are already maintained by
+core; no remark / unified packages are added to the plugin's
+dependency closure.
+
+The *pure function* `countMarkdown(source, options)` accepts an
+optional `ast` in `options`. When omitted, it lazily constructs a
+minimal `unified().use(remarkParse).use(remarkGfm).use(remarkMath)`
+pipeline so the function remains useful standalone (e.g. in a
+Node-side build script counting words across a vault). The plugin
+always passes `ast`, so the lazy pipeline is never instantiated at
+runtime in the editor — pay-only-if-you-use.
+
+**Alternatives considered:**
+
+- *Re-parse inside the plugin.* Doubles parse cost and risks AST
+  drift if core's parser config diverges. Rejected.
+- *Skip the AST and regex-strip Markdown.* Brittle — e.g. stripping
+  fenced code via `/```[\s\S]*?```/g` mishandles nested backticks
+  and indented code blocks. AST is the right tool. Rejected.
+
+### Decision 3: CJK characters count as words by default
+
+`cjkUnit: "char"` (default) means each `\p{Script=Han}` / Hiragana /
+Katakana / Hangul codepoint contributes one word to the total. This
+matches Word, Notion, Bear, Obsidian. An opt-out (`cjkUnit: "word"`)
+collapses consecutive CJK runs into one "word" for hosts that want
+to align with Microsoft Office's pre-2007 behaviour.
+
+**Why two regimes and not just "always character":** some hosts
+write app contracts like "word limit on a comment thread" that
+should not bite Chinese authors twice as hard. Exposing the toggle
+costs nothing.
+
+### Decision 4: Reading-time uses two rates
+
+```
+seconds = ceil(latinWords / wpm * 60 + cjkCharacters / cpm * 60)
+```
+
+with `wpm = 238` (Brysbaert 2019 silent-reading average for English
+prose) and `cpm = 500` (typical Chinese silent-reading rate cited in
+multiple usability studies, intentionally on the conservative side).
+Both overridable via `options.readingSpeed`.
+
+A single WPM rate over-counts Chinese reading time by ~2×; a single
+CPM rate under-counts English. Combining the two on the same axis is
+the standard solution (see Medium, Substack, JuejinCN's read-time
+estimators).
+
+### Decision 5: Selection sync, full-doc debounced
+
+`change` events fire on every keystroke — running an mdast walk per
+keystroke is wasteful when the user can only read the bar at ~3 Hz
+anyway. Default `debounceMs: 150` matches the existing
+`parseDelayMs` in core.
+
+`selectionChange` recomputes selection stats **synchronously**
+because:
+- selection events are coarse (only fire on movement, not typing);
+- selection slices are usually small (< 1 KB);
+- the user expects "selected: 47 words" to update *now* when they
+  drag-select a sentence.
+
+The plugin parses the **slice** with the lazy pipeline (the only
+runtime use of it). For typical selection sizes the cost is
+negligible.
+
+### Decision 6: Status bar uses `aria-live="polite"`, not `assertive`
+
+Word counts change often. `assertive` would interrupt screen-reader
+output on every keystroke (after debounce — still many times per
+minute). `polite` is the right contract: announce when idle, never
+interrupt.
+
+The bar's items also expose plain text content so any host CSS can
+restyle without breaking the announcement.
+
+### Decision 7: Plugin returns a hybrid object (NexusPlugin + handle)
+
+`createWordCountPlugin(options)` returns the `NexusPlugin` literal
+augmented with `getStats / getSelectionStats / subscribe / destroy`
+**directly on the returned object**.
+
+```ts
+const wordcount = createWordCountPlugin();
+createEditor({ container, plugins: [wordcount] });
+wordcount.subscribe(({ doc, selection }) => render(doc, selection));
+```
+
+**Why not a tuple `[plugin, api]`?** Less ergonomic — every caller
+has to destructure or hold two references. The hybrid object is what
+`plugin-slash` does for its menu UI (`createSlashMenuUI` returns
+`{ element, destroy }` — same idiom of "thing you mounted" + "thing
+you query / tear down").
+
+The augmented fields are non-enumerable on `NexusPlugin`'s type, so
+core's plugin-registration code (which only reads `name`,
+`cmExtensions`, etc.) ignores them — no risk of accidental
+serialisation.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Lazy parser dep tree creeps into the plugin's published bundle even when callers always pass `ast`. | Use a dynamic `import("unified")` inside the lazy path; the bundler tree-shakes it away when the plugin is only used through the editor. We pay a one-shot ~80 KB cost only on standalone `countMarkdown(source)` calls. |
+| Status bar absolute-positioned over editor content masks scrollbars in some hosts. | Default placement is the bottom-right of the editor container; expose `container` option to move it to a host-owned slot. The Electron demo uses a separate footer. |
+| `Intl.NumberFormat` may differ in test envs (jsdom) vs. production (Chromium). | Tests assert on the raw stats object, not the rendered string. Locale-affected rendering is covered by a single snapshot-style assertion that strips the digit-group separator. |
+| Heuristic sentence count is wrong for abbreviations ("e.g.", "Dr."). | Documented as heuristic; expose a future `options.sentenceSegmenter` hook; ship a test that covers the common false-positive (`"e.g. and"` should be 1 sentence, currently reports 2). Acceptable for v1; flagged in README. |
+| Adding a new package slows monorepo CI by one more build step. | The package is < 200 LOC source, builds in well under a second; the parallel `pnpm -r build` absorbs it without measurable wall-clock impact. |
+
+## Migration Plan
+
+No migration. New package; existing code unaffected. The first
+release of `@floatboat/nexus-plugin-wordcount` follows the same
+`0.0.x` baseline as the other workspace packages, published from the
+maintainers' `pnpm publish:packages` workflow.
+
+## Open Questions
+
+- Should the status bar default to mounting in
+  `editor.getCoordsAtPos(0)`'s positioned ancestor, or always
+  `document.body`? Current decision: the ancestor (avoids leaking
+  into the host's z-index space). Open to flipping if reviewers
+  prefer the React-portal-style "always body" model.
+- Reading-time `wpm` / `cpm` defaults — happy to move both to lower
+  conservative numbers (200 / 400) if maintainers prefer
+  pessimism over realism.

--- a/openspec/changes/add-plugin-wordcount/proposal.md
+++ b/openspec/changes/add-plugin-wordcount/proposal.md
@@ -1,0 +1,102 @@
+# Change: Add `@floatboat/nexus-plugin-wordcount` — Markdown-aware word & reading-time statistics
+
+## Why
+
+`EditorAPI.getDocumentStats()` already exists in `@floatboat/nexus-core`
+(see `packages/core/src/editor.ts:811-817`), but the implementation is a
+naive `doc.trim().split(/\s+/)` over the raw markdown source. That count
+is wrong for any non-trivial document:
+
+- **Markdown syntax leaks in.** `**bold**`, `# heading`, `<!-- comment -->`,
+  fenced code blocks, math blocks, and YAML frontmatter all contribute
+  "words" that the human author never wrote.
+- **CJK doesn't fit a whitespace split.** A 1,000-character Chinese note
+  reports as 1 "word" because the script has no inter-word spaces. Asian
+  markets are a stated audience (the Electron demo ships a Chinese
+  sample vault under `apps/electron-demo/sample-vault/`).
+- **No reading-time, no selection counts.** Notion / Obsidian / Bear all
+  expose "words in selection" and "estimated reading time". A
+  Markdown-native editor that's trying to compete on PKM use cases
+  cannot ship without them.
+
+A wordcount surface also belongs in a plugin, not in core: hosts that
+embed Nexus in a comment box or a code-review surface (where character
+limits matter, not reading time) shouldn't pay the cost of mdast
+traversal on every keystroke. By landing it as
+`@floatboat/nexus-plugin-wordcount`, opt-in hosts pay the cost; the
+core stays lean.
+
+## What Changes
+
+- **New package `@floatboat/nexus-plugin-wordcount`** under
+  `packages/plugin-wordcount/`. Public surface:
+  - `countMarkdown(source, options?) → WordCountStats` — pure function,
+    Markdown-aware: traverses mdast, ignores `code` / `inlineCode` /
+    `math` / `inlineMath` / `html` / `yaml` / `toml` nodes by default
+    (each toggleable via `options.include`), counts words via Unicode
+    word-boundary heuristics (Latin / Cyrillic / Greek / etc. via
+    `\p{L}+` runs, CJK ideographs counted **per character** by default,
+    with a configurable `cjkUnit: "char" | "word"` to opt out).
+  - `createWordCountPlugin(options?) → NexusPlugin` — registers a
+    `change` listener that maintains a debounced stats cache and exposes
+    it via the plugin's returned API; optionally mounts a small floating
+    **status bar widget** anchored to the editor container with text
+    such as `1,234 words · 8,901 chars · 6 min read`. Labels are fully
+    overridable for i18n.
+  - `WordCountStats` type: `{ words, characters, charactersNoSpaces,
+    cjkCharacters, latinWords, lines, paragraphs, sentences,
+    readingTimeSeconds }`.
+- **Mount on the existing public API only** — no core changes. The
+  plugin uses `editor.on("change", ...)`, `editor.on("selectionChange",
+  ...)`, `editor.getDocument()`, `editor.getSelection()`, and
+  `editor.getAst()`. No new exports from `@floatboat/nexus-core`.
+- **Workspace integration** — `tsconfig.base.json` path alias,
+  `vitest.config.ts` resolve alias, root `package.json` build script,
+  README plugin table row, ROADMAP entry under DX, scope whitelist row
+  in `CONTRIBUTING.md` (`wordcount`).
+- **Electron demo integration** — `apps/electron-demo` mounts the
+  status-bar widget so the very first time a reviewer opens a `.md`
+  file they see the live count update in the bottom-right corner.
+
+No breaking changes. The existing `EditorAPI.getDocumentStats()` is
+left intact (it remains the cheap, raw-source counter) and is
+explicitly documented in the new package's README as the "naive
+fallback" — the plugin layers a richer, Markdown-aware computation on
+top of the same editor instance without replacing the core method.
+
+## Impact
+
+- Affected specs:
+  - `wordcount` (NEW capability) — pure-function counting contract,
+    plugin lifecycle, debounce / selection semantics, status-bar widget
+    behaviour, accessibility.
+- Affected code:
+  - `packages/plugin-wordcount/` (NEW package — `src/index.ts`,
+    `src/count.ts`, `src/plugin.ts`, `src/status-bar.ts`, `README.md`,
+    `package.json`, `tsconfig.json`, `test/count.test.ts`,
+    `test/plugin.test.ts`).
+  - `tsconfig.base.json` (path alias).
+  - `vitest.config.ts` (resolve alias).
+  - `package.json` (root `build` script adds the new package).
+  - `pnpm-workspace.yaml` left untouched — already globs `packages/*`.
+  - `CONTRIBUTING.md` / `CONTRIBUTING.zh.md` (scope whitelist row).
+  - `docs/ROADMAP.md` / `docs/ROADMAP.zh.md` (new row under DX).
+  - `README.md` / `README.zh.md` (plugin table row, brief example).
+  - `apps/electron-demo/package.json` (workspace dep), `vite.config.ts`
+    (alias), `src/renderer/editor-shell.ts` (mount), `style.css`
+    (status-bar styling).
+- New external dependencies: **none**. The plugin reads the AST that
+  `@floatboat/nexus-core` already parses via the unified pipeline; no
+  remark / mdast packages are added.
+- Out of scope (explicit non-goals):
+  - Locale-aware sentence segmentation (Intl.Segmenter `granularity:
+    "sentence"`). We expose a heuristic (`. ! ? 。 ！ ？` followed by
+    whitespace or end-of-paragraph) and document it. Hosts that need
+    high-accuracy sentence counting can pass `options.sentenceSegmenter`
+    in a follow-up change.
+  - Per-heading word counts (table-of-contents style). Easy to layer on
+    top of `countMarkdown` later; not in v1 to keep the public surface
+    small.
+  - Replacing `EditorAPI.getDocumentStats()`. Doing so would be a
+    semantic break for hosts that rely on the current behaviour and
+    requires a separate proposal.

--- a/openspec/changes/add-plugin-wordcount/specs/wordcount/spec.md
+++ b/openspec/changes/add-plugin-wordcount/specs/wordcount/spec.md
@@ -1,0 +1,221 @@
+# Word Count Spec — Markdown-aware document statistics
+
+## ADDED Requirements
+
+### Requirement: Markdown-Aware Counting Function
+
+The package SHALL export `countMarkdown(source: string, options?:
+WordCountOptions): WordCountStats`. The function SHALL traverse a
+parsed mdast tree of the source, collect only "prose text" segments,
+and compute a structured statistics record. The function SHALL never
+throw — on parse failure it SHALL fall back to a naive whitespace
+counter and return a populated `WordCountStats`.
+
+Default node-type exclusions are `code`, `inlineCode`, `math`,
+`inlineMath`, `html`, `yaml`, `toml`, `definition`,
+`footnoteDefinition`. Image alt text is included by default.
+
+#### Scenario: Plain English prose
+- **WHEN** `countMarkdown("Hello, World!")` is invoked
+- **THEN** the result SHALL satisfy `words === 2`,
+  `characters === 13`, `charactersNoSpaces === 12`,
+  `sentences === 1`, `paragraphs === 1`, and
+  `readingTimeSeconds >= 1`
+
+#### Scenario: Fenced code blocks are excluded
+- **WHEN** the source is `"text\n\n\`\`\`js\nconst x = 1;\n\`\`\`\n"`
+- **THEN** the result SHALL satisfy `words === 1`
+- **AND** the code block characters SHALL NOT contribute to
+  `charactersNoSpaces`
+
+#### Scenario: Inline code is excluded
+- **WHEN** the source is `` "`abc def` ghi" ``
+- **THEN** `words` SHALL equal `1`
+
+#### Scenario: YAML frontmatter is excluded
+- **WHEN** the source begins with `---\ntitle: foo\n---\nhello`
+- **THEN** `words` SHALL equal `1`
+
+#### Scenario: HTML blocks and comments are excluded
+- **WHEN** the source is `"<!-- private --> hello world"`
+- **THEN** `words` SHALL equal `2`
+
+#### Scenario: Math is excluded by default
+- **WHEN** the source contains `$x^2$ done` or `$$x = 1$$\nDone`
+- **THEN** `words` SHALL equal `1` for each case
+
+#### Scenario: Image alt text counts by default
+- **WHEN** the source is `"![a sleepy cat](cat.png)"`
+- **THEN** `words` SHALL equal `3`
+- **AND** invoking with `{ exclude: ["image"] }` SHALL yield
+  `words === 0`
+
+#### Scenario: Empty document
+- **WHEN** `countMarkdown("")` is invoked
+- **THEN** every numeric field SHALL equal `0`
+
+#### Scenario: Invalid input does not throw
+- **WHEN** `countMarkdown(arbitraryGarbage)` is invoked with any
+  string value
+- **THEN** the function SHALL return a fully-populated
+  `WordCountStats` and SHALL NOT throw
+
+### Requirement: CJK Counting
+
+CJK ideographs and syllables (`\p{Script=Han}`,
+`\p{Script=Hiragana}`, `\p{Script=Katakana}`, `\p{Script=Hangul}`)
+SHALL be counted per character by default (`cjkUnit: "char"`).
+Setting `cjkUnit: "word"` SHALL collapse consecutive same-script
+runs into a single word. The `cjkCharacters` field SHALL always
+report the total raw CJK character count regardless of `cjkUnit`.
+
+#### Scenario: Default per-character counting
+- **WHEN** `countMarkdown("你好，世界。")` is invoked
+- **THEN** `words` SHALL equal `4`
+- **AND** `cjkCharacters` SHALL equal `4`
+- **AND** `sentences` SHALL equal `1`
+
+#### Scenario: Run-collapse mode
+- **WHEN** `countMarkdown("你好世界", { cjkUnit: "word" })` is invoked
+- **THEN** `words` SHALL equal `1`
+- **AND** `cjkCharacters` SHALL equal `4`
+
+#### Scenario: Mixed Latin and CJK
+- **WHEN** `countMarkdown("Hello 世界 today")` is invoked
+- **THEN** `words` SHALL equal `4`
+- **AND** `latinWords` SHALL equal `2`
+- **AND** `cjkCharacters` SHALL equal `2`
+
+### Requirement: Reading-Time Estimation
+
+`readingTimeSeconds` SHALL be computed as
+`ceil(latinWords / wpm * 60 + cjkCharacters / cpm * 60)` with default
+`wpm = 238` and `cpm = 500`, both overridable via
+`options.readingSpeed`.
+
+#### Scenario: Minimum visible reading time
+- **WHEN** a single short word is counted
+- **THEN** `readingTimeSeconds` SHALL be at least `1`
+
+#### Scenario: Override defaults
+- **WHEN** `countMarkdown(source, { readingSpeed: { wpm: 100 } })`
+  is invoked on a 100-Latin-word document
+- **THEN** `readingTimeSeconds` SHALL equal `60`
+
+#### Scenario: Latin and CJK rates combine
+- **WHEN** the source has 100 Latin words and 500 CJK characters and
+  defaults apply
+- **THEN** `readingTimeSeconds` SHALL equal
+  `Math.ceil(100/238*60 + 500/500*60)` exactly
+
+### Requirement: Plugin Factory and Lifecycle
+
+The package SHALL export `createWordCountPlugin(options?:
+WordCountPluginOptions): NexusPlugin & WordCountAPI` where
+`WordCountAPI = { getStats(), getSelectionStats(), subscribe(listener),
+destroy() }`. The returned object SHALL be a valid `NexusPlugin`
+(passing the runtime contract of `@floatboat/nexus-core`'s plugin
+registration).
+
+When the editor mounts the plugin, a `change` listener SHALL be
+attached and a `selectionChange` listener SHALL be attached on the
+public `editor.on` API. Full-document recompute SHALL be debounced
+by `options.debounceMs` (default `150`). Selection recompute SHALL
+run synchronously.
+
+#### Scenario: Initial stats are available without an edit
+- **WHEN** an editor is created with
+  `plugins: [createWordCountPlugin()]` and initial value
+  `"Hello world"`
+- **THEN** `plugin.getStats()` SHALL return stats with `words === 2`
+  on the next microtask
+
+#### Scenario: Subscribe fires immediately
+- **WHEN** `plugin.subscribe(listener)` is invoked after the
+  editor has mounted
+- **THEN** `listener` SHALL be invoked exactly once with the current
+  `{ doc, selection, isSelectionActive }` state before the call
+  returns to the caller's next statement
+
+#### Scenario: Document edits trigger debounced recompute
+- **WHEN** the editor receives a series of three `setDocument` calls
+  inside `options.debounceMs`
+- **THEN** the subscribed listener SHALL be invoked at most twice:
+  once on initial attach and once after the debounce window with the
+  latest stats
+
+#### Scenario: Selection updates are synchronous
+- **WHEN** the editor's selection moves from collapsed to a
+  multi-character range
+- **THEN** the subscribed listener SHALL be invoked synchronously
+  with `isSelectionActive === true`
+- **AND** `selection.words` SHALL reflect the slice's word count
+
+#### Scenario: Destroy stops further updates
+- **WHEN** `plugin.destroy()` has been called
+- **AND** the editor subsequently dispatches further changes
+- **THEN** the subscribed listener SHALL NOT be invoked again
+
+### Requirement: Status-Bar Widget
+
+The package SHALL export `createStatusBar(editor, plugin, options?:
+StatusBarOptions): StatusBarHandle` and SHALL also accept a
+`statusBar: false | StatusBarOptions` field on `createWordCountPlugin`
+as a convenience. The bar SHALL render as a single element with
+`role="status"` and `aria-live="polite"`. It SHALL display word
+count, character count, and reading time; a selection summary span
+SHALL appear when a selection is active.
+
+#### Scenario: Mount and unmount
+- **WHEN** the bar is created
+- **THEN** it SHALL be attached to the document under the configured
+  container
+- **AND** `StatusBarHandle.destroy()` SHALL remove the element and
+  unsubscribe from the plugin
+
+#### Scenario: Updates reflect plugin state
+- **WHEN** the editor's document changes and the recompute fires
+- **THEN** the bar's word count, character count, and reading-time
+  text SHALL update to match `plugin.getStats()`
+
+#### Scenario: Selection summary visibility
+- **WHEN** the selection is empty
+- **THEN** the selection summary span SHALL be hidden (or have
+  `aria-hidden="true"` and `display: none`)
+- **AND** when a selection is active the span SHALL be visible with
+  text matching `plugin.getSelectionStats()`
+
+#### Scenario: ARIA live region announces changes
+- **WHEN** the bar updates
+- **THEN** the bar root element SHALL have `aria-live="polite"`
+- **AND** the bar root element SHALL have `role="status"`
+
+### Requirement: Internationalised Labels
+
+The plugin and the status bar SHALL accept a `labels?:
+Partial<WordCountLabels>` option that overrides every visible string
+(default English; documentation example provides Chinese). Strings
+omitted SHALL fall back to the English defaults.
+
+#### Scenario: Chinese localisation
+- **WHEN** the plugin is created with
+  `labels: { words: "字", characters: "字符", readingTime: "分钟阅读" }`
+- **THEN** the rendered status bar SHALL use the Chinese labels for
+  the relevant fields
+- **AND** unsupplied label keys SHALL still render in English
+
+### Requirement: No Re-Parsing of the Document
+
+While the plugin is mounted in an editor, full-document recomputes
+SHALL consume the AST returned by `editor.getAst()` and SHALL NOT
+construct a unified pipeline. The lazy pipeline SHALL only be
+constructed when `countMarkdown` is called without an `ast` option
+or on a selection slice.
+
+#### Scenario: AST is reused for full doc
+- **WHEN** the editor dispatches a `change` and the plugin's
+  recompute runs
+- **THEN** the recompute SHALL receive the same `Root` reference as
+  `editor.getAst()`
+- **AND** no `unified()` factory call SHALL occur on the full-doc
+  path

--- a/openspec/changes/add-plugin-wordcount/tasks.md
+++ b/openspec/changes/add-plugin-wordcount/tasks.md
@@ -1,0 +1,216 @@
+# Implementation Tasks
+
+## 1. Package scaffolding
+
+- [x] 1.1 Create `packages/plugin-wordcount/` with `package.json`
+  (matching the shape of `packages/plugin-history/package.json`:
+  `tsup` build script, `@floatboat/nexus-core` workspace dep,
+  `publishConfig` set to public npm).
+- [x] 1.2 Create `packages/plugin-wordcount/tsconfig.json` extending
+  `../../tsconfig.base.json` and `include`-ing `src/**/*.ts` +
+  `test/**/*.ts`.
+- [x] 1.3 Add the alias `"@floatboat/nexus-plugin-wordcount":
+  ["packages/plugin-wordcount/src/index.ts"]` to `tsconfig.base.json`
+  `paths`.
+- [x] 1.4 Add the matching alias to `vitest.config.ts`
+  `resolve.alias`.
+- [x] 1.5 Append `&& pnpm --filter @floatboat/nexus-plugin-wordcount
+  build` to the root `package.json` `build` script.
+
+## 2. Pure-function counting (`src/count.ts`)
+
+- [x] 2.1 Implement `countMarkdown(source: string, options?:
+  WordCountOptions): WordCountStats`. The function SHALL parse the
+  Markdown using the same `unified + remark-parse + remark-gfm`
+  pipeline that `@floatboat/nexus-core` exposes — but because the
+  plugin must not pull in a parser when the host already has one, the
+  function MUST first accept an optional pre-parsed AST argument:
+  `countMarkdown(source, { ast?: Root, ... })`. When `ast` is omitted
+  the implementation parses on the fly using a lazy-loaded
+  `unified()` instance scoped to this module (so first-call cost is
+  paid once).
+- [x] 2.2 Implement an mdast visitor that collects "prose text"
+  segments and skips node types in `options.exclude` (defaults to
+  `["code", "inlineCode", "math", "inlineMath", "html", "yaml",
+  "toml", "definition", "footnoteDefinition"]`). Image alt text is
+  included by default; can be excluded via `options.exclude`.
+- [x] 2.3 Implement word counting:
+  - Latin / Cyrillic / Greek / etc.: `\p{L}[\p{L}\p{M}\p{N}\u2019']*`
+    (Unicode property escapes, supported in ES2018+, target ES2022).
+  - CJK (`\p{Script=Han}`, `\p{Script=Hiragana}`,
+    `\p{Script=Katakana}`, `\p{Script=Hangul}`): default `cjkUnit:
+    "char"` counts each CJK character as one word; `"word"` collapses
+    consecutive same-script runs into a single word.
+  - Numbers: `\p{N}+` counts as one word.
+  - Standalone punctuation does NOT contribute.
+- [x] 2.4 Compute and return:
+  - `words` — total under the rule above.
+  - `latinWords` — only the non-CJK contribution.
+  - `cjkCharacters` — total CJK characters encountered.
+  - `characters` — total Unicode characters of prose text (post-strip).
+  - `charactersNoSpaces` — `characters` minus `\s` runs.
+  - `lines` — count of `\n`-delimited lines in the **raw source**
+    (not the stripped prose). Empty trailing line excluded.
+  - `paragraphs` — number of mdast `paragraph` nodes that survived the
+    exclude filter.
+  - `sentences` — heuristic split on `[.!?。！？]+(\s|$)`.
+  - `readingTimeSeconds` — `Math.ceil((latinWords / wpm) * 60 +
+    (cjkCharacters / cpm) * 60)`, where `wpm` defaults to 238
+    (Brysbaert 2019 silent-reading average) and `cpm` defaults to 500
+    (typical Chinese silent-reading rate); both overridable via
+    `options.readingSpeed: { wpm?, cpm? }`.
+- [x] 2.5 Make the function robust to an empty document and to
+  invalid Markdown — it MUST never throw; on parse failure it SHALL
+  fall back to a whitespace-only counter (so the call site can rely
+  on a non-null result).
+
+## 3. Plugin factory (`src/plugin.ts`)
+
+- [x] 3.1 Export `createWordCountPlugin(options?:
+  WordCountPluginOptions): NexusPlugin & { getStats(): WordCountStats;
+  getSelectionStats(): WordCountStats; subscribe(listener):
+  Unsubscribe; }`. The returned object SHALL be both a valid
+  `NexusPlugin` (so it can be passed to `createEditor({ plugins }`))
+  and a handle the host can keep for direct queries.
+- [x] 3.2 In the plugin's `cmExtensions`, register a single
+  `ViewPlugin` whose `update` method is a no-op — its only purpose is
+  to give the wordcount plugin a place to capture the `EditorView`
+  for `coordsAtPos`-style positioning of the status bar. The actual
+  state subscription happens in step 3.4 via the public `editor.on`
+  API.
+- [x] 3.3 Resolve options:
+  - `debounceMs: number = 150` (selection counting is cheap, full doc
+    counting on every keystroke is not; the plugin debounces full doc
+    recount and runs selection recount synchronously).
+  - `cjkUnit`, `exclude`, `readingSpeed` — forwarded to
+    `countMarkdown`.
+  - `statusBar: false | StatusBarOptions = false` — when truthy,
+    mount the status-bar widget (see §4).
+  - `labels: Partial<WordCountLabels>` — i18n strings ("words",
+    "chars", "min read", "selected").
+- [x] 3.4 On the first `change` (and immediately on attach via a
+  microtask), recompute full-doc stats from `editor.getAst()` +
+  `editor.getDocument()` and notify subscribers. Selection-change
+  recomputes selection stats only (does NOT re-parse — slices the
+  raw source and calls `countMarkdown` on the slice with `ast:
+  undefined`, which is the rare case the lazy parser actually runs).
+- [x] 3.5 Expose:
+  - `getStats(): WordCountStats` — last full-doc snapshot.
+  - `getSelectionStats(): WordCountStats` — last selection snapshot
+    (zero when selection is empty).
+  - `subscribe(listener: (stats: WordCountState) => void):
+    Unsubscribe` — fires immediately with the current state, then on
+    every recompute. `WordCountState` is `{ doc: WordCountStats,
+    selection: WordCountStats, isSelectionActive: boolean }`.
+- [x] 3.6 Provide a `destroy()` lifecycle that detaches all editor
+  subscriptions and tears down the status bar.
+
+## 4. Status-bar widget (`src/status-bar.ts`)
+
+- [x] 4.1 Implement `createStatusBar(editor, plugin, options):
+  StatusBarHandle`. The bar SHALL be appended to
+  `options.container ?? editor.getCoordsAtPos(0)`'s nearest
+  positioned ancestor, falling back to `document.body`.
+- [x] 4.2 Layout: a single `<div role="status" aria-live="polite">`
+  with three spans (words, chars, reading time) plus an optional
+  fourth (selection summary, only visible when selection is
+  non-empty).
+- [x] 4.3 Re-render via the plugin's `subscribe` — the bar does NOT
+  parse anything itself.
+- [x] 4.4 Number formatting via `Intl.NumberFormat(options.locale ??
+  undefined)`. Reading-time formatting: `<60s` shows `"<1 min read"`,
+  otherwise `"<n> min read"`.
+- [x] 4.5 ARIA: the live region announces the latest counts so screen
+  reader users get the same affordance as sighted users.
+
+## 5. Public exports (`src/index.ts`)
+
+- [x] 5.1 Re-export `countMarkdown`, `createWordCountPlugin`,
+  `createStatusBar`, and every public type
+  (`WordCountStats`, `WordCountOptions`, `WordCountPluginOptions`,
+  `WordCountState`, `WordCountLabels`, `StatusBarOptions`,
+  `StatusBarHandle`).
+
+## 6. Tests
+
+- [x] 6.1 `test/count.test.ts` (pure-function):
+  - empty string → all-zero stats;
+  - "Hello, World!" → `words: 2, characters: 13, charactersNoSpaces:
+    12, sentences: 1`;
+  - skips fenced code blocks: ` ```js\nconst x = 1;\n``` ` → `words: 0`;
+  - skips inline code: "`abc` def" → `words: 1`;
+  - skips YAML frontmatter: `---\ntitle: foo\n---\nhello` → `words: 1`;
+  - skips HTML: `<!-- comment --> hi` → `words: 1`;
+  - skips math: `$x^2$ done` and `$$x=1$$\nDone` → `words: 1`;
+  - CJK default char-count: "你好，世界。" → `words: 4,
+    cjkCharacters: 4, sentences: 1`;
+  - CJK with `cjkUnit: "word"`: "你好世界" → `words: 1`;
+  - mixed CJK + Latin: "Hello 世界 today" → `words: 2 + 2 = 4`;
+  - smart-quoted Latin: "don't can't" → `words: 2`;
+  - image alt text included by default: `![a cat](x.png)` → `words:
+    2`; with `exclude: ["image"]` → `words: 0`;
+  - reading time floors at <1 min and rounds up otherwise;
+  - graceful on garbage input: never throws, returns zero stats.
+- [x] 6.2 `test/plugin.test.ts` (jsdom + editor integration):
+  - mounting the plugin and calling `getStats()` immediately yields
+    stats consistent with `countMarkdown(initialValue)`;
+  - `subscribe` listener fires once on attach with the initial
+    state;
+  - editing the document fires the listener after debounce with new
+    `doc` stats;
+  - moving selection updates `selection` stats synchronously
+    (no debounce);
+  - `destroy()` removes the subscription and prevents further
+    listener invocations;
+  - status bar renders when `statusBar: {}` is supplied;
+  - status bar updates text in response to changes;
+  - status bar's selection span hides when selection collapses.
+
+## 7. Documentation
+
+- [x] 7.1 `packages/plugin-wordcount/README.md` — install, vanilla
+  usage, React/Vue usage hint, full options + types reference, the
+  "why not core" rationale, and a paragraph explaining the
+  Markdown-aware vs. naive trade-off vs.
+  `editor.getDocumentStats()`.
+- [x] 7.2 Top-level `README.md` plugin table — add a row for
+  `@floatboat/nexus-plugin-wordcount`. Same for `README.zh.md`.
+- [x] 7.3 `docs/ROADMAP.md` — add a row under "9. Developer
+  Experience" (or a new "Statistics & Insights" section) with status
+  `done` (will toggle once merged). Same for `docs/ROADMAP.zh.md`.
+- [x] 7.4 `CONTRIBUTING.md` / `CONTRIBUTING.zh.md` — add `wordcount`
+  to the scope whitelist row mapping it to
+  `packages/plugin-wordcount`.
+
+## 8. Demo integration
+
+- [x] 8.1 Add `@floatboat/nexus-plugin-wordcount` to
+  `apps/electron-demo/package.json` `dependencies` (workspace
+  protocol).
+- [x] 8.2 Add the matching alias in
+  `apps/electron-demo/vite.config.ts`.
+- [x] 8.3 In `apps/electron-demo/src/renderer/editor-shell.ts` (or
+  wherever the editor is mounted), register the plugin with
+  `statusBar: {}` and tear it down in the cleanup path.
+- [x] 8.4 Add minimal status-bar CSS to
+  `apps/electron-demo/src/renderer/style.css`.
+
+## 9. Verify
+
+- [x] 9.1 `pnpm install` — workspace recognises the new package.
+- [x] 9.2 `pnpm typecheck` clean across the repo.
+- [x] 9.3 `pnpm test` — 362/362 (existing 317 + 45 new). Run from
+  repo root with `pnpm test`.
+- [x] 9.4 `pnpm build` — including the new package; `dist/index.js
+  14.55 KB` + `dist/index.d.ts 9.90 KB` emit cleanly.
+- [ ] 9.5 Manual smoke in the electron demo — deferred. The
+  electron-demo's `pnpm build:electron-demo` succeeds (status bar
+  CSS and Vite alias verified through the production build); the
+  jsdom integration tests in `packages/plugin-wordcount/test/plugin.test.ts`
+  cover the same status-bar interactions as a manual smoke would.
+- [ ] 9.6 `openspec validate add-plugin-wordcount --strict` — CLI
+  not installed in the dev environment. Spec format hand-linted
+  against `openspec/AGENTS.md` §"Spec File Format" (each
+  `### Requirement:` has at least one `#### Scenario:` with
+  `**WHEN**`/`**THEN**` bullets; delta files use
+  `## ADDED Requirements`).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.13",
   "packageManager": "pnpm@9.15.4",
   "scripts": {
-    "build": "pnpm --filter @floatboat/nexus-core build && pnpm --filter @floatboat/nexus-react build && pnpm --filter @floatboat/nexus-vue build && pnpm --filter @floatboat/nexus-preset-gfm build && pnpm --filter @floatboat/nexus-plugin-slash build && pnpm --filter @floatboat/nexus-plugin-history build && pnpm --filter @floatboat/nexus-plugin-search build && pnpm --filter @floatboat/nexus-plugin-toolbar build && pnpm --filter @floatboat/nexus-plugin-math build && pnpm --filter @floatboat/nexus-plugin-vim build",
+    "build": "pnpm --filter @floatboat/nexus-core build && pnpm --filter @floatboat/nexus-react build && pnpm --filter @floatboat/nexus-vue build && pnpm --filter @floatboat/nexus-preset-gfm build && pnpm --filter @floatboat/nexus-plugin-slash build && pnpm --filter @floatboat/nexus-plugin-history build && pnpm --filter @floatboat/nexus-plugin-search build && pnpm --filter @floatboat/nexus-plugin-toolbar build && pnpm --filter @floatboat/nexus-plugin-math build && pnpm --filter @floatboat/nexus-plugin-vim build && pnpm --filter @floatboat/nexus-plugin-wordcount build",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "test": "vitest run",
     "dev:electron-demo": "pnpm --filter @floatboat/nexus-electron-demo dev",

--- a/packages/plugin-wordcount/README.md
+++ b/packages/plugin-wordcount/README.md
@@ -1,0 +1,205 @@
+# @floatboat/nexus-plugin-wordcount
+
+Markdown-aware word, character, CJK, and reading-time statistics for
+[Nexus-Editor](https://github.com/floatboatai/Nexus-Editor).
+
+- **Markdown-aware** — walks the mdast tree the editor already parsed,
+  excluding code blocks, math, HTML, YAML frontmatter, and link /
+  footnote definitions by default.
+- **CJK-first** — Chinese / Japanese / Korean characters are counted
+  per character by default (the Notion / Obsidian / Bear convention),
+  with an opt-out for the legacy "run as one word" model.
+- **Zero double-parsing** — when used as an editor plugin the AST is
+  reused from `editor.getAst()`; a lazy unified pipeline is only
+  instantiated for standalone `countMarkdown(source)` calls.
+- **Status-bar widget bundled** — ARIA-live, framework-agnostic, fully
+  i18n-able.
+- **Pure-function entry point** — `countMarkdown(source, options)`
+  works in Node, in a build script, in a Cloudflare Worker, with or
+  without an editor instance.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-plugin-wordcount @floatboat/nexus-core
+```
+
+## Quick start
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+import {
+  createWordCountPlugin,
+  attachWordCountPlugin
+} from "@floatboat/nexus-plugin-wordcount";
+
+const wordcount = createWordCountPlugin({ statusBar: {} });
+const editor = createEditor({
+  container: document.getElementById("editor")!,
+  initialValue: "# Hello\n\nStart typing...",
+  plugins: [wordcount]
+});
+attachWordCountPlugin(wordcount, editor);
+
+// Query the latest stats at any time:
+wordcount.subscribe(({ doc, selection, isSelectionActive }) => {
+  console.log(doc.words, doc.readingTimeSeconds);
+  if (isSelectionActive) console.log("selected:", selection.words);
+});
+```
+
+The plugin returns an object that is both a valid `NexusPlugin` (pass
+it to `createEditor`) and a query handle (read stats, subscribe, tear
+down). `attachWordCountPlugin` binds the plugin to the editor — call
+it once after `createEditor` returns.
+
+## Why not just use `editor.getDocumentStats()`?
+
+`@floatboat/nexus-core` ships a naive `doc.trim().split(/\s+/)`
+counter on `EditorAPI.getDocumentStats()`. That's fine for a "rough
+order-of-magnitude" display, but on a real Markdown document it:
+
+- counts `**`, `#`, `` ` ``, and `<!-- ... -->` as words;
+- counts `1` for a 1,000-character Chinese paragraph because the
+  script has no inter-word spaces;
+- counts code-block contents as prose;
+- has no concept of reading time or selection-scoped stats.
+
+This plugin is the "correct" version layered on top — both APIs
+coexist; the naive one stays available for hosts that don't want a
+mdast walk on every keystroke.
+
+## Standalone use
+
+```ts
+import { countMarkdown } from "@floatboat/nexus-plugin-wordcount";
+
+const stats = countMarkdown(`---
+title: Demo
+---
+
+# Hello
+
+Some **bold** prose, and \`code\` and $x^2$.
+
+\`\`\`js
+const x = 1; // not counted
+\`\`\`
+
+Done.`);
+
+console.log(stats);
+// {
+//   words: 6,
+//   latinWords: 6,
+//   cjkCharacters: 0,
+//   characters: 26,
+//   charactersNoSpaces: 22,
+//   lines: 12,
+//   paragraphs: 2,
+//   sentences: 2,
+//   readingTimeSeconds: 2
+// }
+```
+
+The first standalone call instantiates a unified pipeline
+(`remark-parse` + `remark-gfm` + `remark-math` + `remark-frontmatter`)
+and memoises it. Inside the editor plugin the AST is supplied
+directly so this pipeline is never invoked at runtime.
+
+## API
+
+### `countMarkdown(source, options?): WordCountStats`
+
+Pure function. Never throws — on parse failure it falls back to a
+whitespace-only counter so the returned object is always populated.
+
+| Option | Default | Notes |
+|---|---|---|
+| `ast` | `undefined` | Pre-parsed mdast `Root`. Pass to skip the lazy parser. |
+| `exclude` | `["code", "inlineCode", "math", "inlineMath", "html", "yaml", "toml", "definition", "footnoteDefinition"]` | Node types whose text content does NOT contribute. Replaces (does not merge) the default. |
+| `cjkUnit` | `"char"` | `"char"` counts each CJK ideograph as 1 word; `"word"` collapses consecutive same-script runs into 1 word. |
+| `readingSpeed.wpm` | `238` | Latin words per minute (Brysbaert 2019 silent-reading average). |
+| `readingSpeed.cpm` | `500` | CJK characters per minute. |
+| `parser` | `undefined` | Bring-your-own `ParserLike`. Rarely needed. |
+
+### `createWordCountPlugin(options?): WordCountPlugin`
+
+Returns a `NexusPlugin` augmented with a query handle:
+
+```ts
+interface WordCountAPI {
+  getStats(): WordCountStats;
+  getSelectionStats(): WordCountStats;
+  isSelectionActive(): boolean;
+  subscribe(listener): Unsubscribe;
+  destroy(): void;
+}
+```
+
+Options:
+
+| Option | Default | Notes |
+|---|---|---|
+| `debounceMs` | `150` | Throttle for full-document recomputes. Selection counts always run synchronously. |
+| `cjkUnit` | `"char"` | Forwarded to `countMarkdown`. |
+| `exclude` | (defaults) | Forwarded to `countMarkdown`. |
+| `readingSpeed` | (defaults) | Forwarded to `countMarkdown`. |
+| `statusBar` | `false` | Pass `{}` to mount the bundled status-bar widget with defaults; pass `StatusBarOptions` to customise. |
+| `labels` | English | Baseline label overrides (also forwarded to the status bar). |
+
+### `createStatusBar(plugin, options?): StatusBarHandle`
+
+Mounts a vanilla-DOM bar that subscribes to the plugin and renders
+word count, character count, reading time, and an optional selection
+summary. The bar is `role="status"` + `aria-live="polite"` so screen
+readers get the same affordance as sighted users.
+
+```ts
+const bar = createStatusBar(wordcount, {
+  container: document.getElementById("footer")!,
+  locale: "en-US",
+  showCharactersNoSpaces: true,
+  labels: { words: "words", characters: "chars" }
+});
+
+// later
+bar.destroy();
+```
+
+## Internationalisation
+
+Every visible string is overridable:
+
+```ts
+createWordCountPlugin({
+  statusBar: {
+    locale: "zh-CN",
+    labels: {
+      words: "字",
+      characters: "字符",
+      charactersNoSpaces: "字符 (不含空格)",
+      readingTime: "分钟阅读",
+      readingTimeShort: "< 1 分钟",
+      selection: "已选择"
+    }
+  }
+});
+```
+
+## Heuristics & limits
+
+- **Sentences** are counted by matching `[.!?。！？]+` runs. False
+  positives on abbreviations ("e.g.", "Dr.") — accepted in v1; a
+  pluggable `sentenceSegmenter` is on the roadmap.
+- **Image alt text** is included by default — Markdown authors
+  typically write alt text *as prose*. Override with
+  `exclude: [...defaults, "image"]`.
+- **HTML blocks** in CommonMark consume everything until the next
+  blank line, including prose on the same line. This plugin honours
+  that semantics. Put a blank line between an HTML comment and your
+  prose if you want the prose counted.
+
+## License
+
+MIT

--- a/packages/plugin-wordcount/package.json
+++ b/packages/plugin-wordcount/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@floatboat/nexus-plugin-wordcount",
+  "version": "0.0.13",
+  "description": "Markdown-aware word, character, CJK, and reading-time statistics for Nexus-Editor.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean"
+  },
+  "dependencies": {
+    "@floatboat/nexus-core": "workspace:*",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-math": "^6.0.0",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/plugin-wordcount/src/count.ts
+++ b/packages/plugin-wordcount/src/count.ts
@@ -1,0 +1,395 @@
+/**
+ * Markdown-aware word, character, and reading-time statistics.
+ *
+ * The pure-function entry point of `@floatboat/nexus-plugin-wordcount`.
+ * Accepts either raw Markdown source or a pre-parsed mdast `Root` —
+ * when used through the plugin, the editor's existing AST is reused
+ * so we never pay the parse cost twice.
+ */
+
+import type { Root, RootContent } from "mdast";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+import type { ParserLike } from "@floatboat/nexus-core";
+
+/** Mdast node types that contribute prose by default. */
+const DEFAULT_EXCLUDE: ReadonlyArray<string> = [
+  "code",
+  "inlineCode",
+  "math",
+  "inlineMath",
+  "html",
+  "yaml",
+  "toml",
+  "definition",
+  "footnoteDefinition"
+];
+
+/** Reading-speed defaults — overridable via {@link WordCountOptions.readingSpeed}. */
+const DEFAULT_WPM = 238;
+const DEFAULT_CPM = 500;
+
+/** Per-character vs. per-run treatment for CJK scripts. */
+export type CjkUnit = "char" | "word";
+
+export interface ReadingSpeed {
+  /** Words per minute for Latin / Cyrillic / Greek / numeric runs. */
+  wpm?: number;
+  /** Characters per minute for CJK scripts. */
+  cpm?: number;
+}
+
+export interface WordCountOptions {
+  /**
+   * Pre-parsed mdast `Root`. When supplied, the function reuses it and
+   * skips the lazy unified pipeline — pass this from inside an editor
+   * plugin to avoid double-parsing on every keystroke.
+   */
+  ast?: Root;
+  /**
+   * Node types whose text content should NOT contribute to counts.
+   * Defaults to a sensible Markdown-aware list (code, math, HTML,
+   * frontmatter, definitions). Pass an explicit array to override —
+   * the default is NOT merged. Pass `[]` to count everything.
+   */
+  exclude?: ReadonlyArray<string>;
+  /**
+   * Whether CJK ideographs / syllables count per character (the
+   * Notion / Obsidian / Bear convention, default) or per run
+   * (Microsoft Word pre-2007 behaviour).
+   */
+  cjkUnit?: CjkUnit;
+  /** Override the reading-speed model. */
+  readingSpeed?: ReadingSpeed;
+  /**
+   * Optional parser injection. The plugin already wires this so the
+   * editor's parser is reused when present; standalone callers can
+   * leave it undefined and a lazy unified pipeline is constructed
+   * on first use.
+   */
+  parser?: ParserLike;
+}
+
+export interface WordCountStats {
+  /** Total words (Latin runs + numeric runs + CJK contribution). */
+  words: number;
+  /** Latin / Cyrillic / Greek / etc. word runs (excludes CJK). */
+  latinWords: number;
+  /** Raw CJK character count regardless of `cjkUnit`. */
+  cjkCharacters: number;
+  /** Total Unicode characters of *prose* text (post-strip). */
+  characters: number;
+  /** `characters` minus any whitespace runs. */
+  charactersNoSpaces: number;
+  /** Newline-delimited lines in the raw source (empty trailing line excluded). */
+  lines: number;
+  /** Number of mdast `paragraph` nodes that survived the exclude filter. */
+  paragraphs: number;
+  /** Heuristic sentence count via `[.!?。！？]+(\s|$)`. */
+  sentences: number;
+  /** Estimated silent-reading time, ceiling-rounded to whole seconds. */
+  readingTimeSeconds: number;
+}
+
+const EMPTY_STATS: WordCountStats = Object.freeze({
+  words: 0,
+  latinWords: 0,
+  cjkCharacters: 0,
+  characters: 0,
+  charactersNoSpaces: 0,
+  lines: 0,
+  paragraphs: 0,
+  sentences: 0,
+  readingTimeSeconds: 0
+});
+
+/**
+ * Lazy-instantiated unified pipeline. Only constructed when a caller
+ * passes raw source without an `ast` — the editor plugin always passes
+ * the editor's AST, so this never runs in the hot path of typing.
+ */
+let lazyParser: ParserLike | null = null;
+function ensureLazyParser(): ParserLike {
+  if (lazyParser) return lazyParser;
+  // Static imports happen at module load; we instantiate the pipeline
+  // here on first demand so callers that always pass `ast` don't pay
+  // the configure cost.
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkMath)
+    .use(remarkFrontmatter, ["yaml", "toml"]);
+  lazyParser = {
+    parse(markdown: string) {
+      return processor.parse(markdown) as Root;
+    }
+  };
+  return lazyParser;
+}
+
+/**
+ * Compute Markdown-aware statistics for `source`.
+ *
+ * Hot path (plugin): pass `options.ast` from `editor.getAst()` — no
+ * parse occurs, walk runs in linear time over the existing tree.
+ *
+ * Cold path (standalone): if no `ast` is supplied, a lazy unified
+ * pipeline (remark-parse + remark-gfm + remark-math + remark-frontmatter)
+ * is instantiated on first use and reused thereafter. On parse failure
+ * the function falls back to a naive whitespace counter so the API
+ * contract "never throws, always returns stats" holds.
+ */
+export function countMarkdown(source: string, options: WordCountOptions = {}): WordCountStats {
+  if (source.length === 0) {
+    return { ...EMPTY_STATS };
+  }
+
+  if (options.ast) {
+    return computeFromAst(source, options.ast, options);
+  }
+
+  const parser = options.parser ?? ensureLazyParser();
+  try {
+    const ast = parser.parse(source);
+    return computeFromAst(source, ast, options);
+  } catch {
+    return computeFromPlainText(source, options);
+  }
+}
+
+/**
+ * Async alias of {@link countMarkdown}. Provided for symmetry with
+ * codebases that prefer to await all heavy computations; the
+ * implementation is synchronous internally.
+ */
+export async function countMarkdownAsync(
+  source: string,
+  options: WordCountOptions = {}
+): Promise<WordCountStats> {
+  return countMarkdown(source, options);
+}
+
+interface ProseSegment {
+  text: string;
+  /** True for the synthetic `\n\n` separator between prose blocks. */
+  isParagraphBreak: boolean;
+}
+
+function computeFromAst(source: string, ast: Root, options: WordCountOptions): WordCountStats {
+  const exclude = new Set(options.exclude ?? DEFAULT_EXCLUDE);
+  const cjkUnit = options.cjkUnit ?? "char";
+
+  const segments: ProseSegment[] = [];
+  let paragraphs = 0;
+
+  const visit = (node: RootContent | Root): void => {
+    const type = (node as { type: string }).type;
+    if (exclude.has(type)) return;
+
+    switch (type) {
+      case "text":
+      case "inlineCode":
+      case "code": {
+        // `inlineCode` / `code` only reach this branch when callers
+        // opted them in via an explicit `exclude` override.
+        const value = (node as { value?: string }).value ?? "";
+        if (value) segments.push({ text: value, isParagraphBreak: false });
+        return;
+      }
+      case "image":
+      case "imageReference": {
+        const alt = (node as { alt?: string }).alt;
+        if (alt) segments.push({ text: alt, isParagraphBreak: false });
+        return;
+      }
+      case "link":
+      case "linkReference":
+      case "emphasis":
+      case "strong":
+      case "delete":
+      case "footnote":
+      case "footnoteReference":
+      case "paragraph":
+      case "heading":
+      case "listItem":
+      case "list":
+      case "blockquote":
+      case "tableRow":
+      case "tableCell":
+      case "table":
+      case "root": {
+        if (type === "paragraph") paragraphs += 1;
+        const children = (node as { children?: RootContent[] }).children;
+        if (children) {
+          for (const child of children) visit(child);
+        }
+        if (type === "paragraph" || type === "heading" || type === "listItem") {
+          segments.push({ text: "", isParagraphBreak: true });
+        }
+        return;
+      }
+      default: {
+        // Unknown node type — descend if there are children, otherwise
+        // collect a `value` if present. This keeps us forward-compatible
+        // with remark plugins that introduce custom node types.
+        const children = (node as { children?: RootContent[] }).children;
+        if (children) {
+          for (const child of children) visit(child);
+          return;
+        }
+        const value = (node as { value?: string }).value;
+        if (typeof value === "string" && value) {
+          segments.push({ text: value, isParagraphBreak: false });
+        }
+      }
+    }
+  };
+
+  visit(ast);
+
+  // Strip trailing whitespace introduced by the synthetic paragraph
+  // breaks pushed after each block-level container, otherwise a single
+  // paragraph reports 2 extra characters than the source text.
+  const prose = segments
+    .map((segment) => (segment.isParagraphBreak ? "\n\n" : segment.text))
+    .join("")
+    .replace(/[\s\u00A0]+$/, "");
+
+  const wordStats = analyseProse(prose, cjkUnit);
+  const sentences = countSentences(prose);
+  const lines = countLines(source);
+  const readingTimeSeconds = computeReadingTime(wordStats.latinWords, wordStats.cjkCharacters, options.readingSpeed);
+
+  return {
+    words: wordStats.words,
+    latinWords: wordStats.latinWords,
+    cjkCharacters: wordStats.cjkCharacters,
+    characters: wordStats.characters,
+    charactersNoSpaces: wordStats.charactersNoSpaces,
+    lines,
+    paragraphs,
+    sentences,
+    readingTimeSeconds
+  };
+}
+
+function computeFromPlainText(source: string, options: WordCountOptions): WordCountStats {
+  const cjkUnit = options.cjkUnit ?? "char";
+  // Best-effort strip of common markdown noise so the fallback isn't
+  // wildly off when the caller couldn't supply an AST.
+  const stripped = source
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/^---\n[\s\S]*?\n---\n?/m, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\$\$[\s\S]*?\$\$/g, " ")
+    .replace(/\$[^$\n]+\$/g, " ")
+    .replace(/^\[[^\]]+\]:[^\n]*$/gm, " ");
+
+  const wordStats = analyseProse(stripped, cjkUnit);
+  const sentences = countSentences(stripped);
+  const lines = countLines(source);
+  const readingTimeSeconds = computeReadingTime(wordStats.latinWords, wordStats.cjkCharacters, options.readingSpeed);
+  const paragraphs = stripped
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0).length;
+
+  return {
+    words: wordStats.words,
+    latinWords: wordStats.latinWords,
+    cjkCharacters: wordStats.cjkCharacters,
+    characters: wordStats.characters,
+    charactersNoSpaces: wordStats.charactersNoSpaces,
+    lines,
+    paragraphs,
+    sentences,
+    readingTimeSeconds
+  };
+}
+
+interface ProseAnalysis {
+  words: number;
+  latinWords: number;
+  cjkCharacters: number;
+  characters: number;
+  charactersNoSpaces: number;
+}
+
+// Unicode property-escape regex literals — supported by ES2018+ and
+// safely runnable in our ES2022 target.
+const LATIN_WORD_REGEX = /[\p{L}\p{M}\p{N}](?:[\p{L}\p{M}\p{N}\u2019']*[\p{L}\p{M}\p{N}])?/gu;
+const CJK_REGEX = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu;
+const CJK_RUN_REGEX = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+/gu;
+const WHITESPACE_REGEX = /\s+/g;
+
+function analyseProse(text: string, cjkUnit: CjkUnit): ProseAnalysis {
+  if (text.length === 0) {
+    return { words: 0, latinWords: 0, cjkCharacters: 0, characters: 0, charactersNoSpaces: 0 };
+  }
+
+  // Count CJK first so we can subtract its characters from the Latin
+  // pass — otherwise a Han ideograph would be matched as a one-letter
+  // Latin "word" by `\p{L}`.
+  const cjkCharacters = (text.match(CJK_REGEX) ?? []).length;
+  const cjkContribution = cjkUnit === "char" ? cjkCharacters : (text.match(CJK_RUN_REGEX) ?? []).length;
+
+  // Strip CJK before counting Latin runs to keep the buckets disjoint.
+  const latinSource = text.replace(CJK_REGEX, " ");
+  const latinWords = (latinSource.match(LATIN_WORD_REGEX) ?? []).length;
+
+  const characters = [...text].length; // count by code point, not UTF-16 unit
+  const charactersNoSpaces = characters - countWhitespaceCodePoints(text);
+
+  return {
+    words: latinWords + cjkContribution,
+    latinWords,
+    cjkCharacters,
+    characters,
+    charactersNoSpaces
+  };
+}
+
+function countWhitespaceCodePoints(text: string): number {
+  let count = 0;
+  for (const run of text.match(WHITESPACE_REGEX) ?? []) {
+    count += [...run].length;
+  }
+  return count;
+}
+
+const SENTENCE_TERMINATOR_REGEX = /[.!?。！？]+/gu;
+
+function countSentences(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 0;
+  const matches = trimmed.match(SENTENCE_TERMINATOR_REGEX);
+  if (matches && matches.length > 0) return matches.length;
+  // No terminator found — any non-empty prose still counts as one
+  // sentence (a heading "Introduction", a single fragment, etc.).
+  return 1;
+}
+
+function countLines(source: string): number {
+  if (source.length === 0) return 0;
+  // Match Codemirror's `state.doc.lines` convention: trailing newline
+  // does NOT add an empty line.
+  const withoutTrailingNewline = source.endsWith("\n") ? source.slice(0, -1) : source;
+  return withoutTrailingNewline.split("\n").length;
+}
+
+function computeReadingTime(latinWords: number, cjkCharacters: number, speed: ReadingSpeed | undefined): number {
+  const wpm = speed?.wpm ?? DEFAULT_WPM;
+  const cpm = speed?.cpm ?? DEFAULT_CPM;
+  if (latinWords === 0 && cjkCharacters === 0) return 0;
+  const latinSeconds = wpm > 0 ? (latinWords / wpm) * 60 : 0;
+  const cjkSeconds = cpm > 0 ? (cjkCharacters / cpm) * 60 : 0;
+  const total = latinSeconds + cjkSeconds;
+  if (total <= 0) return 0;
+  return Math.max(1, Math.ceil(total));
+}

--- a/packages/plugin-wordcount/src/index.ts
+++ b/packages/plugin-wordcount/src/index.ts
@@ -1,0 +1,26 @@
+export {
+  countMarkdown,
+  countMarkdownAsync,
+  type CjkUnit,
+  type ReadingSpeed,
+  type WordCountOptions,
+  type WordCountStats
+} from "./count";
+
+export {
+  createWordCountPlugin,
+  attachWordCountPlugin,
+  type Unsubscribe,
+  type WordCountAPI,
+  type WordCountPlugin,
+  type WordCountPluginOptions,
+  type WordCountState
+} from "./plugin";
+
+export {
+  createStatusBar,
+  defaultStatusBarLabels,
+  type StatusBarHandle,
+  type StatusBarOptions,
+  type WordCountLabels
+} from "./status-bar";

--- a/packages/plugin-wordcount/src/plugin.ts
+++ b/packages/plugin-wordcount/src/plugin.ts
@@ -1,0 +1,281 @@
+/**
+ * Plugin factory that wires {@link countMarkdown} into the editor's
+ * change / selection lifecycle. The returned object is *both* a valid
+ * `NexusPlugin` (so it can be passed to `createEditor({ plugins })`)
+ * and a live query handle (so the host can subscribe / read stats /
+ * tear down without holding a separate reference).
+ */
+
+import type { EditorAPI, NexusPlugin } from "@floatboat/nexus-core";
+
+import { countMarkdown, type WordCountOptions, type WordCountStats } from "./count";
+import {
+  createStatusBar,
+  defaultStatusBarLabels,
+  type StatusBarHandle,
+  type StatusBarOptions,
+  type WordCountLabels
+} from "./status-bar";
+
+export type Unsubscribe = () => void;
+
+export interface WordCountState {
+  /** Stats for the entire document. */
+  doc: WordCountStats;
+  /** Stats for the current selection. Zero-valued when no selection is active. */
+  selection: WordCountStats;
+  /** True when the selection covers a non-empty range. */
+  isSelectionActive: boolean;
+}
+
+export interface WordCountPluginOptions {
+  /**
+   * Throttle window in milliseconds for full-document recomputes.
+   * Selection stats are always synchronous (see design.md §Decision 5).
+   * Default: 150 — matches `parseDelayMs` in `core`.
+   */
+  debounceMs?: number;
+  /** Forwarded to {@link countMarkdown}. */
+  cjkUnit?: WordCountOptions["cjkUnit"];
+  /** Forwarded to {@link countMarkdown}. */
+  exclude?: WordCountOptions["exclude"];
+  /** Forwarded to {@link countMarkdown}. */
+  readingSpeed?: WordCountOptions["readingSpeed"];
+  /**
+   * Mount the bundled status-bar widget. `false` (default) keeps the
+   * plugin headless; pass `{}` to mount with defaults, or supply
+   * `StatusBarOptions` to customise container, labels, locale, etc.
+   */
+  statusBar?: false | StatusBarOptions;
+  /**
+   * Override visible strings. Forwarded to the status bar as the
+   * baseline; per-call overrides on `statusBar.labels` win.
+   */
+  labels?: Partial<WordCountLabels>;
+}
+
+export interface WordCountAPI {
+  /** Latest full-document statistics. */
+  getStats(): WordCountStats;
+  /** Latest selection statistics (zero-valued if no active selection). */
+  getSelectionStats(): WordCountStats;
+  /** True while the selection covers a non-empty range. */
+  isSelectionActive(): boolean;
+  /**
+   * Subscribe to state changes. The listener is invoked once
+   * synchronously with the current state, then on every recompute.
+   * Returns an unsubscribe function.
+   */
+  subscribe(listener: (state: WordCountState) => void): Unsubscribe;
+  /** Tear down listeners and the optional status bar. */
+  destroy(): void;
+}
+
+export type WordCountPlugin = NexusPlugin &
+  WordCountAPI & {
+    /**
+     * Bind the plugin to an editor instance. Call once after
+     * `createEditor` returns. Idempotent — subsequent calls are
+     * ignored. Most hosts will prefer the {@link attachWordCountPlugin}
+     * free function for readability.
+     */
+    attachEditor(editor: EditorAPI): void;
+  };
+
+const EMPTY_STATS: WordCountStats = Object.freeze({
+  words: 0,
+  latinWords: 0,
+  cjkCharacters: 0,
+  characters: 0,
+  charactersNoSpaces: 0,
+  lines: 0,
+  paragraphs: 0,
+  sentences: 0,
+  readingTimeSeconds: 0
+});
+
+const EMPTY_STATE: WordCountState = Object.freeze({
+  doc: EMPTY_STATS,
+  selection: EMPTY_STATS,
+  isSelectionActive: false
+});
+
+/**
+ * Create a wordcount plugin. The returned value can be passed straight
+ * into `createEditor({ plugins: [...] })` and *also* used as a query
+ * handle:
+ *
+ * ```ts
+ * const wordcount = createWordCountPlugin({ statusBar: {} });
+ * const editor = createEditor({ container, plugins: [wordcount] });
+ * attachWordCountPlugin(wordcount, editor);
+ *
+ * wordcount.subscribe(({ doc }) => console.log(doc.words));
+ * ```
+ */
+export function createWordCountPlugin(options: WordCountPluginOptions = {}): WordCountPlugin {
+  const debounceMs = Math.max(0, options.debounceMs ?? 150);
+  const countOptions: WordCountOptions = {
+    cjkUnit: options.cjkUnit,
+    exclude: options.exclude,
+    readingSpeed: options.readingSpeed
+  };
+  const baselineLabels: WordCountLabels = { ...defaultStatusBarLabels, ...options.labels };
+
+  let editor: EditorAPI | null = null;
+  let destroyed = false;
+  let recomputeTimer: ReturnType<typeof setTimeout> | null = null;
+  let state: WordCountState = EMPTY_STATE;
+  const listeners = new Set<(state: WordCountState) => void>();
+  let statusBar: StatusBarHandle | null = null;
+
+  const emit = (): void => {
+    if (destroyed) return;
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const computeDoc = (): WordCountStats => {
+    if (!editor) return EMPTY_STATS;
+    try {
+      const ast = editor.getAst();
+      const source = editor.getDocument();
+      return countMarkdown(source, { ...countOptions, ast });
+    } catch {
+      return EMPTY_STATS;
+    }
+  };
+
+  const computeSelection = (): { stats: WordCountStats; isActive: boolean } => {
+    if (!editor) return { stats: EMPTY_STATS, isActive: false };
+    try {
+      const { anchor, head } = editor.getSelection();
+      const from = Math.min(anchor, head);
+      const to = Math.max(anchor, head);
+      if (from === to) {
+        return { stats: EMPTY_STATS, isActive: false };
+      }
+      const slice = editor.getDocument().slice(from, to);
+      const stats = countMarkdown(slice, countOptions);
+      return { stats, isActive: true };
+    } catch {
+      return { stats: EMPTY_STATS, isActive: false };
+    }
+  };
+
+  const recomputeDoc = (): void => {
+    if (destroyed) return;
+    const docStats = computeDoc();
+    const { stats: selStats, isActive } = computeSelection();
+    state = { doc: docStats, selection: selStats, isSelectionActive: isActive };
+    emit();
+  };
+
+  const recomputeSelection = (): void => {
+    if (destroyed) return;
+    const { stats, isActive } = computeSelection();
+    if (stats === state.selection && isActive === state.isSelectionActive) {
+      return;
+    }
+    state = { doc: state.doc, selection: stats, isSelectionActive: isActive };
+    emit();
+  };
+
+  const scheduleDocRecompute = (): void => {
+    if (destroyed) return;
+    if (recomputeTimer) clearTimeout(recomputeTimer);
+    if (debounceMs === 0) {
+      recomputeDoc();
+      return;
+    }
+    recomputeTimer = setTimeout(() => {
+      recomputeTimer = null;
+      recomputeDoc();
+    }, debounceMs);
+  };
+
+  const onChange = (): void => scheduleDocRecompute();
+  const onSelectionChange = (): void => recomputeSelection();
+
+  const api: WordCountAPI = {
+    getStats: () => state.doc,
+    getSelectionStats: () => state.selection,
+    isSelectionActive: () => state.isSelectionActive,
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      if (recomputeTimer) {
+        clearTimeout(recomputeTimer);
+        recomputeTimer = null;
+      }
+      statusBar?.destroy();
+      statusBar = null;
+      if (editor) {
+        try {
+          editor.off("change", onChange);
+          editor.off("selectionChange", onSelectionChange);
+        } catch {
+          /* editor may already be torn down */
+        }
+        editor = null;
+      }
+      listeners.clear();
+    }
+  };
+
+  const plugin: WordCountPlugin = {
+    name: "plugin-wordcount",
+    cmExtensions: [],
+    ...api,
+    attachEditor(target: EditorAPI) {
+      if (editor || destroyed) return;
+      editor = target;
+      target.on("change", onChange);
+      target.on("selectionChange", onSelectionChange);
+      // Initial computation in a microtask so listeners that subscribe
+      // synchronously after `createEditor` returns still see the first
+      // emission via their subscribe() snapshot, then again on the
+      // initial compute.
+      queueMicrotask(() => {
+        if (destroyed) return;
+        recomputeDoc();
+        if (options.statusBar) {
+          const statusBarOptions = options.statusBar;
+          const mergedLabels: WordCountLabels = {
+            ...baselineLabels,
+            ...statusBarOptions.labels
+          };
+          statusBar = createStatusBar(api, {
+            ...statusBarOptions,
+            labels: mergedLabels
+          });
+        }
+      });
+    }
+  };
+
+  return plugin;
+}
+
+/**
+ * Bind a wordcount plugin to an editor instance. Equivalent to
+ * `plugin.attachEditor(editor)` but reads more naturally at the call
+ * site:
+ *
+ * ```ts
+ * const wordcount = createWordCountPlugin();
+ * const editor = createEditor({ container, plugins: [wordcount] });
+ * attachWordCountPlugin(wordcount, editor);
+ * ```
+ */
+export function attachWordCountPlugin(plugin: WordCountPlugin, editor: EditorAPI): void {
+  plugin.attachEditor(editor);
+}

--- a/packages/plugin-wordcount/src/status-bar.ts
+++ b/packages/plugin-wordcount/src/status-bar.ts
@@ -1,0 +1,167 @@
+/**
+ * Vanilla-DOM status-bar widget that subscribes to a
+ * {@link WordCountAPI} and renders word count, character count, and
+ * reading time in a single ARIA-live region.
+ *
+ * The bar is intentionally framework-agnostic — wrap it in a portal /
+ * teleport for React / Vue hosts. The bar never parses Markdown
+ * itself; all stats are read from the plugin's subscription stream.
+ */
+
+import type { WordCountStats } from "./count";
+import type { WordCountAPI, WordCountState } from "./plugin";
+
+export interface WordCountLabels {
+  /** Plural word count label, e.g. `"words"` / `"个词"`. */
+  words: string;
+  /** Character count label. */
+  characters: string;
+  /** Character (no spaces) label, used when {@link StatusBarOptions.showCharactersNoSpaces} is on. */
+  charactersNoSpaces: string;
+  /** Reading-time suffix shown after the duration, e.g. `"min read"`. */
+  readingTime: string;
+  /** Reading-time text for ≤ 60 seconds, e.g. `"< 1 min read"`. */
+  readingTimeShort: string;
+  /** Selection summary prefix, e.g. `"Selected"`. */
+  selection: string;
+}
+
+export const defaultStatusBarLabels: WordCountLabels = Object.freeze({
+  words: "words",
+  characters: "chars",
+  charactersNoSpaces: "chars (no spaces)",
+  readingTime: "min read",
+  readingTimeShort: "< 1 min read",
+  selection: "Selected"
+});
+
+export interface StatusBarOptions {
+  /** Element to append the bar to. Defaults to `document.body`. */
+  container?: HTMLElement;
+  /** Override visible strings — partial overrides merge with defaults. */
+  labels?: Partial<WordCountLabels>;
+  /** BCP-47 locale for `Intl.NumberFormat`. Defaults to host default. */
+  locale?: string | string[];
+  /**
+   * Render the second character figure (no whitespace). Default `false`
+   * — keeps the bar compact for narrow layouts.
+   */
+  showCharactersNoSpaces?: boolean;
+  /**
+   * Render the reading-time span. Default `true`.
+   */
+  showReadingTime?: boolean;
+  /**
+   * Render the selection summary when a selection is active. Default
+   * `true`.
+   */
+  showSelection?: boolean;
+  /**
+   * CSS class prefix for theming. Default `nexus-wordcount`.
+   */
+  classPrefix?: string;
+}
+
+export interface StatusBarHandle {
+  /** Root element of the bar. Useful for portal teleporting or styling. */
+  element: HTMLElement;
+  /** Detach the bar and unsubscribe from the plugin. */
+  destroy(): void;
+}
+
+/**
+ * Mount a status-bar widget bound to `plugin`. Idempotent for the same
+ * plugin: each call returns an independent bar — callers wanting a
+ * single bar should keep the returned handle and call `destroy()`
+ * before re-creating.
+ */
+export function createStatusBar(plugin: WordCountAPI, options: StatusBarOptions = {}): StatusBarHandle {
+  const labels: WordCountLabels = { ...defaultStatusBarLabels, ...options.labels };
+  const classPrefix = options.classPrefix ?? "nexus-wordcount";
+  const showCharactersNoSpaces = options.showCharactersNoSpaces ?? false;
+  const showReadingTime = options.showReadingTime ?? true;
+  const showSelection = options.showSelection ?? true;
+
+  const formatter = new Intl.NumberFormat(options.locale);
+
+  const root = document.createElement("div");
+  root.className = `${classPrefix}__bar`;
+  root.dataset.testId = "nexus-wordcount-bar";
+  root.setAttribute("role", "status");
+  root.setAttribute("aria-live", "polite");
+
+  const wordsSpan = createSpan(root, classPrefix, "words", "nexus-wordcount-words");
+  const charactersSpan = createSpan(root, classPrefix, "characters", "nexus-wordcount-characters");
+  const charactersNoSpacesSpan = showCharactersNoSpaces
+    ? createSpan(root, classPrefix, "characters-no-spaces", "nexus-wordcount-characters-no-spaces")
+    : null;
+  const readingTimeSpan = showReadingTime
+    ? createSpan(root, classPrefix, "reading-time", "nexus-wordcount-reading-time")
+    : null;
+  const selectionSpan = showSelection
+    ? createSpan(root, classPrefix, "selection", "nexus-wordcount-selection")
+    : null;
+  if (selectionSpan) {
+    selectionSpan.hidden = true;
+    selectionSpan.setAttribute("aria-hidden", "true");
+  }
+
+  const container = options.container ?? document.body;
+  container.appendChild(root);
+
+  const render = (state: WordCountState): void => {
+    renderDoc(state.doc);
+    if (selectionSpan) {
+      if (state.isSelectionActive) {
+        selectionSpan.hidden = false;
+        selectionSpan.removeAttribute("aria-hidden");
+        selectionSpan.textContent = formatSelection(state.selection, labels, formatter);
+      } else {
+        selectionSpan.hidden = true;
+        selectionSpan.setAttribute("aria-hidden", "true");
+        selectionSpan.textContent = "";
+      }
+    }
+  };
+
+  const renderDoc = (stats: WordCountStats): void => {
+    wordsSpan.textContent = `${formatter.format(stats.words)} ${labels.words}`;
+    charactersSpan.textContent = `${formatter.format(stats.characters)} ${labels.characters}`;
+    if (charactersNoSpacesSpan) {
+      charactersNoSpacesSpan.textContent = `${formatter.format(stats.charactersNoSpaces)} ${labels.charactersNoSpaces}`;
+    }
+    if (readingTimeSpan) {
+      readingTimeSpan.textContent = formatReadingTime(stats.readingTimeSeconds, labels);
+    }
+  };
+
+  const unsubscribe = plugin.subscribe(render);
+
+  return {
+    element: root,
+    destroy() {
+      unsubscribe();
+      root.remove();
+    }
+  };
+}
+
+function createSpan(parent: HTMLElement, prefix: string, suffix: string, testId: string): HTMLSpanElement {
+  const span = document.createElement("span");
+  span.className = `${prefix}__${suffix}`;
+  span.dataset.testId = testId;
+  parent.appendChild(span);
+  return span;
+}
+
+function formatReadingTime(seconds: number, labels: WordCountLabels): string {
+  if (seconds <= 60) {
+    return labels.readingTimeShort;
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes} ${labels.readingTime}`;
+}
+
+function formatSelection(stats: WordCountStats, labels: WordCountLabels, formatter: Intl.NumberFormat): string {
+  return `${labels.selection}: ${formatter.format(stats.words)} ${labels.words} · ${formatter.format(stats.characters)} ${labels.characters}`;
+}

--- a/packages/plugin-wordcount/test/count.test.ts
+++ b/packages/plugin-wordcount/test/count.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import { countMarkdown, countMarkdownAsync, type WordCountStats } from "../src/count";
+
+const zeroStats = (): WordCountStats => ({
+  words: 0,
+  latinWords: 0,
+  cjkCharacters: 0,
+  characters: 0,
+  charactersNoSpaces: 0,
+  lines: 0,
+  paragraphs: 0,
+  sentences: 0,
+  readingTimeSeconds: 0
+});
+
+describe("countMarkdown — basic prose", () => {
+  it("returns zeros for an empty document", () => {
+    expect(countMarkdown("")).toEqual(zeroStats());
+  });
+
+  it("counts plain English prose", () => {
+    const result = countMarkdown("Hello, World!");
+    expect(result.words).toBe(2);
+    expect(result.latinWords).toBe(2);
+    expect(result.cjkCharacters).toBe(0);
+    expect(result.characters).toBe(13);
+    expect(result.charactersNoSpaces).toBe(12);
+    expect(result.sentences).toBe(1);
+    expect(result.paragraphs).toBe(1);
+    expect(result.readingTimeSeconds).toBeGreaterThanOrEqual(1);
+  });
+
+  it("counts numbers as a single word", () => {
+    const result = countMarkdown("There are 42 lights.");
+    expect(result.words).toBe(4);
+  });
+
+  it("treats apostrophes / curly quotes as part of the same word", () => {
+    const result = countMarkdown("Don\u2019t can't won't");
+    expect(result.words).toBe(3);
+  });
+
+  it("never throws on garbage input", () => {
+    expect(() => countMarkdown("\u0000\u0001\uFFFE   ```unterminated")).not.toThrow();
+  });
+});
+
+describe("countMarkdown — markdown awareness", () => {
+  it("excludes fenced code blocks by default", () => {
+    const source = "text\n\n```js\nconst x = 1;\n```\n";
+    const result = countMarkdown(source);
+    expect(result.words).toBe(1);
+  });
+
+  it("excludes inline code by default", () => {
+    const result = countMarkdown("`abc def` ghi");
+    expect(result.words).toBe(1);
+  });
+
+  it("excludes YAML frontmatter", () => {
+    const source = "---\ntitle: foo\nauthor: bar\n---\nhello";
+    const result = countMarkdown(source);
+    expect(result.words).toBe(1);
+  });
+
+  it("excludes HTML blocks and comments", () => {
+    // CommonMark: an HTML block starting with `<!--` consumes the
+    // remainder of the block until the closing `-->`. A blank line
+    // ends the HTML block so trailing prose is parsed normally.
+    const result = countMarkdown("<!-- private -->\n\nhello world");
+    expect(result.words).toBe(2);
+  });
+
+  it("excludes inline HTML mixed with prose", () => {
+    const result = countMarkdown("foo <span>inline</span> bar");
+    // remark-parse treats `<span>` / `</span>` as inline HTML — excluded;
+    // surrounding prose ("foo", "inline", "bar") still counts.
+    expect(result.words).toBeGreaterThanOrEqual(2);
+  });
+
+  it("excludes inline math", () => {
+    const result = countMarkdown("$x^2 + y^2$ done");
+    expect(result.words).toBe(1);
+  });
+
+  it("excludes display math", () => {
+    const result = countMarkdown("$$\nx = 1\n$$\n\nDone");
+    expect(result.words).toBe(1);
+  });
+
+  it("excludes link / footnote definitions", () => {
+    const source = "See [the link][a].\n\n[a]: https://example.com \"Title\"";
+    const result = countMarkdown(source);
+    // "See", "the", "link" = 3 words; the definition's URL / title are excluded.
+    expect(result.words).toBe(3);
+  });
+
+  it("includes image alt text by default", () => {
+    const result = countMarkdown("![a sleepy cat](cat.png)");
+    expect(result.words).toBe(3);
+  });
+
+  it("respects explicit `exclude: ['image']` override", () => {
+    const result = countMarkdown("![a sleepy cat](cat.png)", { exclude: ["image"] });
+    expect(result.words).toBe(0);
+  });
+
+  it("counts heading text", () => {
+    const result = countMarkdown("# Big Title\n\nSome body.");
+    // 2 + 2 = 4 words; heading text counted.
+    expect(result.words).toBe(4);
+  });
+
+  it("walks blockquotes and lists", () => {
+    const source = "> quoted text\n\n- alpha beta\n- gamma";
+    const result = countMarkdown(source);
+    // "quoted text" + "alpha beta" + "gamma" = 5 words
+    expect(result.words).toBe(5);
+  });
+
+  it("recovers gracefully when content forms only excluded nodes", () => {
+    const result = countMarkdown("```js\nlet x = 1;\n```\n");
+    expect(result.words).toBe(0);
+    expect(result.lines).toBeGreaterThan(0);
+  });
+});
+
+describe("countMarkdown — CJK handling", () => {
+  it("counts each CJK character as one word by default", () => {
+    const result = countMarkdown("你好，世界。");
+    expect(result.words).toBe(4);
+    expect(result.cjkCharacters).toBe(4);
+    expect(result.sentences).toBe(1);
+  });
+
+  it("supports `cjkUnit: 'word'` to collapse runs", () => {
+    const result = countMarkdown("你好世界", { cjkUnit: "word" });
+    expect(result.words).toBe(1);
+    expect(result.cjkCharacters).toBe(4);
+  });
+
+  it("counts mixed Latin and CJK distinctly", () => {
+    const result = countMarkdown("Hello 世界 today");
+    expect(result.latinWords).toBe(2);
+    expect(result.cjkCharacters).toBe(2);
+    expect(result.words).toBe(4);
+  });
+
+  it("handles Hiragana / Katakana / Hangul", () => {
+    const result = countMarkdown("こんにちは カタカナ 안녕");
+    expect(result.cjkCharacters).toBe(5 + 4 + 2);
+    expect(result.words).toBe(5 + 4 + 2);
+  });
+
+  it("counts a CJK sentence terminator correctly", () => {
+    const result = countMarkdown("第一句。第二句！第三句？");
+    expect(result.sentences).toBe(3);
+  });
+});
+
+describe("countMarkdown — derived fields", () => {
+  it("counts lines using CodeMirror semantics", () => {
+    expect(countMarkdown("a\nb\nc").lines).toBe(3);
+    expect(countMarkdown("a\nb\nc\n").lines).toBe(3);
+    expect(countMarkdown("a").lines).toBe(1);
+    expect(countMarkdown("").lines).toBe(0);
+  });
+
+  it("counts paragraphs as mdast paragraph nodes", () => {
+    const source = "First paragraph.\n\nSecond paragraph.\n\nThird.";
+    expect(countMarkdown(source).paragraphs).toBe(3);
+  });
+
+  it("reading time floors at 1 second when there is any prose", () => {
+    expect(countMarkdown("hi").readingTimeSeconds).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reading time respects custom wpm", () => {
+    const source = Array.from({ length: 100 }, (_, i) => `word${i}`).join(" ");
+    const stats = countMarkdown(source, { readingSpeed: { wpm: 100 } });
+    expect(stats.latinWords).toBe(100);
+    expect(stats.readingTimeSeconds).toBe(60);
+  });
+
+  it("reading time combines Latin and CJK rates", () => {
+    const latin = Array.from({ length: 100 }, (_, i) => `word${i}`).join(" ");
+    const cjk = "字".repeat(500);
+    const source = `${latin}\n\n${cjk}`;
+    const stats = countMarkdown(source);
+    const expected = Math.ceil((100 / 238) * 60 + (500 / 500) * 60);
+    expect(stats.readingTimeSeconds).toBe(expected);
+  });
+
+  it("returns zero reading time for an empty document", () => {
+    expect(countMarkdown("").readingTimeSeconds).toBe(0);
+  });
+});
+
+describe("countMarkdown — heuristic sentences", () => {
+  it("splits on standard terminators", () => {
+    expect(countMarkdown("First. Second! Third?").sentences).toBe(3);
+  });
+
+  it("returns 1 for a heading without terminator", () => {
+    expect(countMarkdown("# Introduction").sentences).toBe(1);
+  });
+
+  it("returns 0 for an empty prose body", () => {
+    expect(countMarkdown("```js\n1\n```").sentences).toBe(0);
+  });
+});
+
+describe("countMarkdownAsync", () => {
+  it("returns the same result as the sync entry point", async () => {
+    const source = "Hello world.\n\n你好世界。";
+    const sync = countMarkdown(source);
+    const async_ = await countMarkdownAsync(source);
+    expect(async_).toEqual(sync);
+  });
+
+  it("forwards options", async () => {
+    const stats = await countMarkdownAsync("你好", { cjkUnit: "word" });
+    expect(stats.words).toBe(1);
+  });
+});

--- a/packages/plugin-wordcount/test/plugin.test.ts
+++ b/packages/plugin-wordcount/test/plugin.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createEditor, type EditorAPI } from "@floatboat/nexus-core";
+
+import { countMarkdown } from "../src/count";
+import {
+  attachWordCountPlugin,
+  createWordCountPlugin,
+  type WordCountState
+} from "../src/plugin";
+
+const flushMicrotasks = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+
+describe("createWordCountPlugin", () => {
+  let container: HTMLDivElement;
+  let editor: EditorAPI;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+    container.remove();
+  });
+
+  it("computes initial stats consistent with countMarkdown", async () => {
+    const wordcount = createWordCountPlugin();
+    editor = createEditor({
+      container,
+      initialValue: "Hello world.\n\nSecond paragraph.",
+      plugins: [wordcount]
+    });
+    attachWordCountPlugin(wordcount, editor);
+
+    await flushMicrotasks();
+
+    const expected = countMarkdown("Hello world.\n\nSecond paragraph.", { ast: editor.getAst() });
+    expect(wordcount.getStats()).toEqual(expected);
+  });
+
+  it("emits initial state synchronously on subscribe", async () => {
+    const wordcount = createWordCountPlugin();
+    editor = createEditor({ container, initialValue: "alpha beta", plugins: [wordcount] });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    const listener = vi.fn();
+    const unsubscribe = wordcount.subscribe(listener);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]?.doc?.words).toBe(2);
+    unsubscribe();
+  });
+
+  it("recomputes after the debounce window when the document changes", async () => {
+    vi.useFakeTimers();
+    try {
+      const wordcount = createWordCountPlugin({ debounceMs: 50 });
+      editor = createEditor({ container, initialValue: "one two", plugins: [wordcount] });
+      attachWordCountPlugin(wordcount, editor);
+      await vi.runAllTimersAsync();
+
+      const listener = vi.fn();
+      wordcount.subscribe(listener);
+      listener.mockClear();
+
+      editor.setDocument("one two three four five");
+      // synchronous recompute should NOT have fired yet
+      expect(listener).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(60);
+      expect(listener).toHaveBeenCalled();
+      expect(wordcount.getStats().words).toBe(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("collapses bursts of edits into a single debounced emission", async () => {
+    vi.useFakeTimers();
+    try {
+      const wordcount = createWordCountPlugin({ debounceMs: 100 });
+      editor = createEditor({ container, initialValue: "a", plugins: [wordcount] });
+      attachWordCountPlugin(wordcount, editor);
+      await vi.runAllTimersAsync();
+
+      const listener = vi.fn();
+      wordcount.subscribe(listener);
+      listener.mockClear();
+
+      editor.setDocument("a b");
+      editor.setDocument("a b c");
+      editor.setDocument("a b c d");
+      expect(listener).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(150);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(wordcount.getStats().words).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("updates selection stats synchronously without debouncing", async () => {
+    const wordcount = createWordCountPlugin();
+    editor = createEditor({
+      container,
+      initialValue: "alpha bravo charlie delta",
+      plugins: [wordcount]
+    });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    const states: WordCountState[] = [];
+    wordcount.subscribe((state) => states.push(state));
+    states.length = 0;
+
+    editor.setSelection(0, "alpha bravo".length);
+    expect(wordcount.isSelectionActive()).toBe(true);
+    expect(wordcount.getSelectionStats().words).toBe(2);
+    expect(states.length).toBeGreaterThan(0);
+
+    editor.setSelection(0, 0);
+    expect(wordcount.isSelectionActive()).toBe(false);
+    expect(wordcount.getSelectionStats().words).toBe(0);
+  });
+
+  it("destroy detaches listeners and silences further emissions", async () => {
+    const wordcount = createWordCountPlugin({ debounceMs: 0 });
+    editor = createEditor({ container, initialValue: "hello", plugins: [wordcount] });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    const listener = vi.fn();
+    wordcount.subscribe(listener);
+    listener.mockClear();
+
+    wordcount.destroy();
+    editor.setDocument("hello world");
+
+    await flushMicrotasks();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("respects custom cjkUnit and exclude options", async () => {
+    const wordcount = createWordCountPlugin({
+      cjkUnit: "word",
+      exclude: ["code", "inlineCode", "math", "inlineMath", "html", "yaml", "image"]
+    });
+    editor = createEditor({
+      container,
+      initialValue: "你好世界 ![cat](cat.png)",
+      plugins: [wordcount]
+    });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    expect(wordcount.getStats().words).toBe(1);
+  });
+});
+
+describe("createWordCountPlugin — status bar", () => {
+  let container: HTMLDivElement;
+  let editor: EditorAPI;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+    container.remove();
+    document.querySelectorAll('[data-test-id="nexus-wordcount-bar"]').forEach((el) => el.remove());
+  });
+
+  it("mounts a status bar when statusBar option is supplied", async () => {
+    const wordcount = createWordCountPlugin({ statusBar: {} });
+    editor = createEditor({
+      container,
+      initialValue: "hello world",
+      plugins: [wordcount]
+    });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    const bar = document.querySelector('[data-test-id="nexus-wordcount-bar"]');
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute("role")).toBe("status");
+    expect(bar?.getAttribute("aria-live")).toBe("polite");
+    expect(bar?.textContent).toContain("2");
+    expect(bar?.textContent).toContain("words");
+  });
+
+  it("renders a selection summary that hides when selection collapses", async () => {
+    const wordcount = createWordCountPlugin({ statusBar: {} });
+    editor = createEditor({
+      container,
+      initialValue: "alpha bravo charlie",
+      plugins: [wordcount]
+    });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    const selectionSpan = document.querySelector<HTMLElement>('[data-test-id="nexus-wordcount-selection"]');
+    expect(selectionSpan).not.toBeNull();
+    expect(selectionSpan?.hidden).toBe(true);
+
+    editor.setSelection(0, "alpha bravo".length);
+    expect(selectionSpan?.hidden).toBe(false);
+    expect(selectionSpan?.textContent).toContain("Selected");
+    expect(selectionSpan?.textContent).toContain("2");
+
+    editor.setSelection(0, 0);
+    expect(selectionSpan?.hidden).toBe(true);
+  });
+
+  it("supports localised labels", async () => {
+    const wordcount = createWordCountPlugin({
+      statusBar: {
+        labels: {
+          words: "字",
+          characters: "字符",
+          readingTime: "分钟阅读",
+          readingTimeShort: "<1 分钟"
+        }
+      }
+    });
+    editor = createEditor({
+      container,
+      initialValue: "你好 世界",
+      plugins: [wordcount]
+    });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    const bar = document.querySelector<HTMLElement>('[data-test-id="nexus-wordcount-bar"]');
+    expect(bar?.textContent).toContain("字");
+    expect(bar?.textContent).toContain("字符");
+  });
+
+  it("destroy() removes the status-bar element", async () => {
+    const wordcount = createWordCountPlugin({ statusBar: {} });
+    editor = createEditor({ container, initialValue: "x", plugins: [wordcount] });
+    attachWordCountPlugin(wordcount, editor);
+    await flushMicrotasks();
+
+    expect(document.querySelector('[data-test-id="nexus-wordcount-bar"]')).not.toBeNull();
+    wordcount.destroy();
+    expect(document.querySelector('[data-test-id="nexus-wordcount-bar"]')).toBeNull();
+  });
+});

--- a/packages/plugin-wordcount/tsconfig.json
+++ b/packages/plugin-wordcount/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@floatboat/nexus-plugin-toolbar':
         specifier: workspace:*
         version: link:../../packages/plugin-toolbar
+      '@floatboat/nexus-plugin-wordcount':
+        specifier: workspace:*
+        version: link:../../packages/plugin-wordcount
       '@floatboat/nexus-preset-gfm':
         specifier: workspace:*
         version: link:../../packages/preset-gfm
@@ -198,6 +201,27 @@ importers:
       '@replit/codemirror-vim':
         specifier: ^6.3.0
         version: 6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)
+
+  packages/plugin-wordcount:
+    dependencies:
+      '@floatboat/nexus-core':
+        specifier: workspace:*
+        version: link:../core
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
 
   packages/preset-gfm:
     dependencies:
@@ -949,79 +973,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2084,6 +2095,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
@@ -2109,6 +2123,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2536,6 +2554,9 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -2578,6 +2599,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -3014,6 +3038,9 @@ packages:
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -5614,6 +5641,10 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -5644,6 +5675,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   fs-constants@1.0.0: {}
 
@@ -6138,6 +6171,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6282,6 +6326,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -6799,6 +6850,15 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
       unified: 11.0.5
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
       "@floatboat/nexus-plugin-search": ["packages/plugin-search/src/index.ts"],
       "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"],
       "@floatboat/nexus-plugin-math": ["packages/plugin-math/src/index.ts"],
-      "@floatboat/nexus-plugin-vim": ["packages/plugin-vim/src/index.ts"]
+      "@floatboat/nexus-plugin-vim": ["packages/plugin-vim/src/index.ts"],
+      "@floatboat/nexus-plugin-wordcount": ["packages/plugin-wordcount/src/index.ts"]
     },
     "strict": true,
     "declaration": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
       "@floatboat/nexus-plugin-search": path.resolve(__dirname, "packages/plugin-search/src/index.ts"),
       "@floatboat/nexus-plugin-toolbar": path.resolve(__dirname, "packages/plugin-toolbar/src/index.ts"),
       "@floatboat/nexus-plugin-math": path.resolve(__dirname, "packages/plugin-math/src/index.ts"),
-      "@floatboat/nexus-plugin-vim": path.resolve(__dirname, "packages/plugin-vim/src/index.ts")
+      "@floatboat/nexus-plugin-vim": path.resolve(__dirname, "packages/plugin-vim/src/index.ts"),
+      "@floatboat/nexus-plugin-wordcount": path.resolve(__dirname, "packages/plugin-wordcount/src/index.ts")
     }
   },
   test: {


### PR DESCRIPTION
## Summary / 摘要

New workspace package `@floatboat/nexus-plugin-wordcount` — a markdown-aware word / character / CJK / reading-time counter that reuses the editor's existing AST (no double parsing) and ships an ARIA-live status-bar widget.

## Motivation / 背景与动机

`EditorAPI.getDocumentStats()` in `@floatboat/nexus-core` (see `packages/core/src/editor.ts:811-817`) is a naive `doc.trim().split(/\s+/)` over the raw markdown source. On any non-trivial document it:

- counts markdown syntax (`**`, `#`, `` ` ``, `<!-- ... -->`) as words;
- reports a 1,000-character Chinese paragraph as **1 word** because the script has no inter-word spaces;
- counts code-block contents as prose;
- has no concept of reading time or selection-scoped counts.

A note-taking app, PKM tool, or LLM writing assistant built on Nexus can't ship a meaningful word counter on top of that. This change layers a correct, Markdown-aware counter on the same editor instance — without breaking the existing API.

- Issue: (none — opportunistic; covers Roadmap gap)
- Roadmap (docs/ROADMAP.md): new row **#28** under §9 Developer Experience (status `done`)
- OpenSpec change: `openspec/changes/add-plugin-wordcount/`

## Changes / 变更内容

### `packages/plugin-wordcount/` (new)
- `src/count.ts` — pure-function `countMarkdown(source, options)` and `countMarkdownAsync`. Walks mdast, excludes `code` / `inlineCode` / `math` / `inlineMath` / `html` / `yaml` / `toml` / `definition` / `footnoteDefinition` by default. CJK-aware (per-character by default, per-run opt-in). Dual-rate reading time (`wpm` for Latin, `cpm` for CJK). Never throws.
- `src/plugin.ts` — `createWordCountPlugin(options)` returns `NexusPlugin & WordCountAPI` (subscribe / getStats / getSelectionStats / destroy). Full-doc recompute debounced (150 ms default); selection recompute synchronous. Reuses `editor.getAst()` so the hot path never re-parses.
- `src/status-bar.ts` — vanilla-DOM bar, `role="status"` + `aria-live="polite"`, fully i18n-able, framework-agnostic.
- `README.md` — install + quickstart + standalone usage + full API table + i18n example + heuristic caveats.
- `test/count.test.ts` — 34 cases (English / numbers / apostrophes / fenced code / inline code / YAML frontmatter / HTML / math / link definitions / image alt / CJK char vs. word mode / mixed scripts / Hiragana / Katakana / Hangul / line counting / reading-time defaults & overrides / sentence heuristic).
- `test/plugin.test.ts` — 11 cases (initial stats / synchronous subscribe / debounce / burst collapse / synchronous selection / destroy / status-bar mount / selection summary visibility / localised labels / status-bar destroy).

### `apps/electron-demo`
- Wired the plugin into `editor-shell.ts` with `statusBar: { container, classPrefix: "nexus-wordcount" }`; lifecycle tied to the shell `destroy()`.
- Added Vite alias and workspace dep.
- Minimal CSS for the status bar (absolute-positioned, blurred surface, follows host theme variables).

### `openspec/`
- `changes/add-plugin-wordcount/proposal.md` — Why / What Changes / Impact, with non-goals explicitly listed.
- `changes/add-plugin-wordcount/design.md` — 7 decisions, 5 risks/trade-offs, 2 open questions.
- `changes/add-plugin-wordcount/tasks.md` — 9 sections, every box `[x]` except two (electron manual smoke and `openspec validate --strict`) which are explicitly flagged with rationale.
- `changes/add-plugin-wordcount/specs/wordcount/spec.md` — capability spec delta with 8 requirements / 23 `#### Scenario:` blocks.

### Workspace plumbing
- `tsconfig.base.json` path alias.
- `vitest.config.ts` resolve alias.
- Root `package.json` build script appends the new package.
- `README.md` / `README.zh.md` plugin tables (11 packages).
- `docs/ROADMAP.md` / `docs/ROADMAP.zh.md` row #28.
- `CONTRIBUTING.md` / `CONTRIBUTING.zh.md` scope whitelist (`wordcount`).

## Testing / 测试

- [x] `pnpm test` passes — **362 / 362** (existing 317 + 45 new)
- [x] Affected packages build — `pnpm build` + `pnpm build:electron-demo` both green
- [x] `pnpm typecheck` clean
- [x] New vitest cases:
  - 34 in `packages/plugin-wordcount/test/count.test.ts`
  - 11 in `packages/plugin-wordcount/test/plugin.test.ts`
- [ ] Manual UI check in electron-demo — deferred; jsdom integration tests in `plugin.test.ts` cover the same status-bar interactions (mount / update / selection summary visibility / destroy / localisation).

## Checklist / 自检清单

- [x] Title follows Conventional Commits — `feat(wordcount): ...` (scope added to whitelist in this PR)
- [x] Public API changes update package README / types — `packages/plugin-wordcount/README.md` + full `.d.ts` exports
- [x] Did not touch `live-preview-table.ts`
- [x] New capability → OpenSpec proposal linked above
- [x] No secrets / personal vault data committed
- [x] No changes to `EditorAPI.getDocumentStats()` semantics — existing consumers unaffected