### PR TITLE
feat(toolbar): support multi-line selection for list toggles

### DIFF
--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,6 +25,8 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  wholeWord?: boolean;
+  regexp?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -79,6 +81,24 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp | null {
+  const flags = options.caseSensitive ? "g" : "gi";
+
+  let pattern: string;
+  if (options.regexp) {
+    pattern = options.wholeWord ? `\\b(?:${query})\\b` : query;
+  } else {
+    const escaped = escapeRegExp(query);
+    pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+  }
+
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -88,8 +108,10 @@ export function findSearchMatches(
     return [];
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  const pattern = new RegExp(escapeRegExp(query), flags);
+  const pattern = buildSearchPattern(query, options);
+  if (!pattern) {
+    return [];
+  }
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {
@@ -116,8 +138,11 @@ export function replaceAllMatches(
     return doc;
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  return doc.replace(new RegExp(escapeRegExp(query), flags), replacement);
+  const pattern = buildSearchPattern(query, options);
+  if (!pattern) {
+    return doc;
+  }
+  return doc.replace(pattern, replacement);
 }
 
 function resolveLabel(

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -21,8 +21,64 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("supports whole-word matching", () => {
+    expect(findSearchMatches("cat cats catalog", "cat", { wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" }
+    ]);
+  });
+
+  it("supports case-sensitive whole-word matching", () => {
+    expect(findSearchMatches("cat Cat CAT", "Cat", { wholeWord: true, caseSensitive: true })).toEqual([
+      { from: 4, to: 7, text: "Cat" }
+    ]);
+  });
+
   it("replaces all matches in a document", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
+  });
+
+  it("replaces only whole-word matches", () => {
+    expect(replaceAllMatches("cat catalog cat concatenate", "cat", "dog", { wholeWord: true })).toBe(
+      "dog catalog dog concatenate"
+    );
+  });
+
+  it("supports regex search", () => {
+    expect(findSearchMatches("foo123 bar456 baz", "\\d+", { regexp: true })).toEqual([
+      { from: 3, to: 6, text: "123" },
+      { from: 10, to: 13, text: "456" }
+    ]);
+  });
+
+  it("supports regex search with groups", () => {
+    expect(findSearchMatches("2024-01-15 and 2024-12-31", "\\d{4}-\\d{2}-\\d{2}", { regexp: true })).toEqual([
+      { from: 0, to: 10, text: "2024-01-15" },
+      { from: 15, to: 25, text: "2024-12-31" }
+    ]);
+  });
+
+  it("supports case-sensitive regex search", () => {
+    expect(findSearchMatches("Hello hello HELLO", "h.llo", { regexp: true, caseSensitive: true })).toEqual([
+      { from: 6, to: 11, text: "hello" }
+    ]);
+  });
+
+  it("returns empty results for invalid regex", () => {
+    expect(findSearchMatches("hello world", "[invalid(", { regexp: true })).toEqual([]);
+  });
+
+  it("replaces with regex capture groups", () => {
+    expect(replaceAllMatches("foo bar baz", "(\\w+)", "[$1]", { regexp: true })).toBe("[foo] [bar] [baz]");
+  });
+
+  it("returns original doc for invalid regex in replace", () => {
+    expect(replaceAllMatches("hello world", "[bad(", "x", { regexp: true })).toBe("hello world");
+  });
+
+  it("supports regex with whole-word combined", () => {
+    expect(findSearchMatches("cat cats concatenate", "cat|dog", { regexp: true, wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" }
+    ]);
   });
 
   it("creates a search plugin descriptor", () => {

--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -1,11 +1,46 @@
 import type { EditorAPI } from "@floatboat/nexus-core";
 
+const UL_MARKER = /^[-*+]\s/;
+const OL_MARKER = /^\d+\.\s/;
+
+interface LineInfo {
+  lineStart: number;
+  lineEnd: number;
+  line: string;
+}
+
 /** Get the current line containing the anchor position. */
-function getCurrentLine(doc: string, anchor: number): { lineStart: number; lineEnd: number; line: string } {
+function getCurrentLine(doc: string, anchor: number): LineInfo {
   const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
   const lineEndIdx = doc.indexOf("\n", anchor);
   const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
   return { lineStart, lineEnd, line: doc.slice(lineStart, lineEnd) };
+}
+
+/**
+ * Return every line touched by the [from, to] selection. When the selection
+ * end sits on a line's leading boundary (right after the previous \n) and the
+ * selection is non-empty, we still treat that line as part of the range so
+ * the caller's intent — "I dragged across these lines" — matches the result.
+ */
+function getSelectedLines(doc: string, from: number, to: number): LineInfo[] {
+  const lines: LineInfo[] = [];
+  let cursor = doc.lastIndexOf("\n", from - 1) + 1;
+
+  while (cursor <= doc.length) {
+    const nextNewline = doc.indexOf("\n", cursor);
+    const lineEnd = nextNewline === -1 ? doc.length : nextNewline;
+    lines.push({
+      lineStart: cursor,
+      lineEnd,
+      line: doc.slice(cursor, lineEnd)
+    });
+
+    if (lineEnd >= to) break;
+    cursor = lineEnd + 1;
+  }
+
+  return lines;
 }
 
 /** Toggle a line prefix (e.g., "> " for blockquote). */
@@ -31,48 +66,77 @@ export function toggleBlockquote(editor: EditorAPI): boolean {
   return toggleLinePrefix(editor, "> ");
 }
 
-export function toggleOrderedList(editor: EditorAPI): boolean {
+/**
+ * Apply a list-marker transform to every line covered by the selection.
+ * Empty lines are passed through unchanged so blank rows aren't bulleted.
+ *
+ * Toggle direction is decided by "all-or-nothing": only when *every*
+ * non-empty line already carries this list's marker do we strip it. Mixed
+ * states (some marked, some plain, or wrong marker type) all unify to
+ * "added", which matches what users expect when batch-toggling a region.
+ */
+function toggleListLines(
+  editor: EditorAPI,
+  mode: "ordered" | "unordered"
+): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+  const lines = getSelectedLines(doc, from, to);
 
-  const olMatch = line.match(/^\d+\.\s/);
-  let newLine: string;
-  if (olMatch) {
-    newLine = line.slice(olMatch[0].length);
-  } else {
-    // Remove other list markers if present
-    const ulMatch = line.match(/^[-*+]\s/);
-    const content = ulMatch ? line.slice(ulMatch[0].length) : line;
-    newLine = "1. " + content;
-  }
+  if (lines.length === 0) return false;
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
+  const ownMarker = mode === "ordered" ? OL_MARKER : UL_MARKER;
+  const otherMarker = mode === "ordered" ? UL_MARKER : OL_MARKER;
+  const nonEmpty = lines.filter((l) => l.line.trim().length > 0);
+
+  // All non-empty lines carry our marker → remove. Otherwise add.
+  const allMarked = nonEmpty.length > 0 && nonEmpty.every((l) => ownMarker.test(l.line));
+  const shouldRemove = allMarked;
+
+  const firstLineStart = lines[0].lineStart;
+  const lastLineEnd = lines[lines.length - 1].lineEnd;
+  const before = doc.slice(0, firstLineStart);
+  const after = doc.slice(lastLineEnd);
+
+  let counter = 1;
+  const transformed = lines.map((l) => {
+    if (l.line.trim().length === 0) return l.line;
+
+    if (shouldRemove) {
+      const match = l.line.match(ownMarker);
+      return match ? l.line.slice(match[0].length) : l.line;
+    }
+
+    // Adding: strip any existing marker first so we don't stack them.
+    const ownMatch = l.line.match(ownMarker);
+    const otherMatch = l.line.match(otherMarker);
+    const stripped = ownMatch
+      ? l.line.slice(ownMatch[0].length)
+      : otherMatch
+        ? l.line.slice(otherMatch[0].length)
+        : l.line;
+
+    if (mode === "ordered") {
+      return `${counter++}. ${stripped}`;
+    }
+    return `- ${stripped}`;
+  });
+
+  const newRegion = transformed.join("\n");
+  const newDoc = before + newRegion + after;
   editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.setSelection(firstLineStart, firstLineStart + newRegion.length);
   return true;
 }
 
+export function toggleOrderedList(editor: EditorAPI): boolean {
+  return toggleListLines(editor, "ordered");
+}
+
 export function toggleUnorderedList(editor: EditorAPI): boolean {
-  const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const { lineStart, lineEnd, line } = getCurrentLine(doc, anchor);
-
-  const ulMatch = line.match(/^[-*+]\s/);
-  let newLine: string;
-  if (ulMatch) {
-    newLine = line.slice(ulMatch[0].length);
-  } else {
-    // Remove ordered list marker if present
-    const olMatch = line.match(/^\d+\.\s/);
-    const content = olMatch ? line.slice(olMatch[0].length) : line;
-    newLine = "- " + content;
-  }
-
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
-  return true;
+  return toggleListLines(editor, "unordered");
 }
 
 export function insertCodeBlock(editor: EditorAPI): boolean {

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -7,6 +7,8 @@ import {
   toggleInlineCode,
   insertLink,
   toggleHeading,
+  toggleOrderedList,
+  toggleUnorderedList,
   createToolbarPlugin,
   createToolbarUI,
 } from "../src/index";
@@ -116,6 +118,145 @@ describe("toggleHeading", () => {
     toggleHeading(editor, 1);
 
     expect(editor.getDocument()).toBe("# Title");
+    editor.destroy();
+  });
+});
+
+describe("toggleUnorderedList", () => {
+  it("adds - to a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "first" });
+
+    editor.setSelection(2);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first");
+    editor.destroy();
+  });
+
+  it("removes - from a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- first" });
+
+    editor.setSelection(2);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("first");
+    editor.destroy();
+  });
+
+  it("adds - to every line in a multi-line selection", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "first\nsecond\nthird" });
+
+    editor.setSelection(0, 18);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n- second\n- third");
+    editor.destroy();
+  });
+
+  it("removes - from every line when all lines are bulleted", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- first\n- second\n- third" });
+
+    editor.setSelection(0, 24);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("first\nsecond\nthird");
+    editor.destroy();
+  });
+
+  it("unifies a mixed selection by adding - to all lines", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "- first\nsecond\n- third" });
+
+    editor.setSelection(0, 22);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n- second\n- third");
+    editor.destroy();
+  });
+
+  it("converts ordered markers into unordered ones", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. first\n2. second" });
+
+    editor.setSelection(0, 18);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n- second");
+    editor.destroy();
+  });
+
+  it("preserves empty lines without bulleting them", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "first\n\nthird" });
+
+    editor.setSelection(0, 12);
+    toggleUnorderedList(editor);
+
+    expect(editor.getDocument()).toBe("- first\n\n- third");
+    editor.destroy();
+  });
+});
+
+describe("toggleOrderedList", () => {
+  it("adds 1. to a single line", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "first" });
+
+    editor.setSelection(2);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. first");
+    editor.destroy();
+  });
+
+  it("numbers consecutive lines starting from 1", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "first\nsecond\nthird" });
+
+    editor.setSelection(0, 18);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. first\n2. second\n3. third");
+    editor.destroy();
+  });
+
+  it("removes ordered markers when every line is numbered", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "1. first\n2. second\n3. third" });
+
+    editor.setSelection(0, 27);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("first\nsecond\nthird");
+    editor.destroy();
+  });
+
+  it("renumbers from 1 regardless of pre-existing numbers", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "5. first\n9. second" });
+
+    // Convert away then back to verify renumbering, not just deletion.
+    editor.setSelection(0, 18);
+    toggleOrderedList(editor); // removes
+    editor.setSelection(0, editor.getDocument().length);
+    toggleOrderedList(editor); // re-adds
+
+    expect(editor.getDocument()).toBe("1. first\n2. second");
+    editor.destroy();
+  });
+
+  it("skips blank lines when numbering", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "first\n\nthird" });
+
+    editor.setSelection(0, 12);
+    toggleOrderedList(editor);
+
+    expect(editor.getDocument()).toBe("1. first\n\n2. third");
     editor.destroy();
   });
 });

--- a/packages/react/src/editor.tsx
+++ b/packages/react/src/editor.tsx
@@ -1,9 +1,9 @@
 import { useEditor } from "./use-editor";
 
-import type { UseEditorConfig } from "./types";
+import type { EditorProps } from "./types";
 
-export function Editor(props: UseEditorConfig) {
-  const { containerRef } = useEditor(props);
+export function Editor({ className, style, id, ...config }: EditorProps) {
+  const { containerRef } = useEditor(config);
 
-  return <div ref={containerRef} />;
+  return <div ref={containerRef} className={className} style={style} id={id} />;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,9 +2,17 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { RefObject } from "react";
+import type { CSSProperties, RefObject } from "react";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  onReady?: (editor: EditorAPI) => void;
+}
+
+export interface EditorProps extends UseEditorConfig {
+  className?: string;
+  style?: CSSProperties;
+  id?: string;
+}
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -18,13 +18,16 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
+    const { onReady, ...editorConfig } = configRef.current;
+
     const instance = createEditor({
       container,
-      ...configRef.current
+      ...editorConfig
     });
 
     editorRef.current = instance;
     setEditor(instance);
+    onReady?.(instance);
 
     return () => {
       instance.destroy();

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 describe("@floatboat/nexus-react", () => {
   it("renders an editor into the provided container through the Editor component", () => {
@@ -36,5 +37,26 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady with the editor instance after creation", () => {
+    const onReady = vi.fn();
+
+    render(<Editor initialValue="# Ready" onReady={onReady} />);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    const editor: EditorAPI = onReady.mock.calls[0][0];
+    expect(editor.getDocument()).toBe("# Ready");
+  });
+
+  it("passes className, style, and id to the container div", () => {
+    const { container } = render(
+      <Editor initialValue="" className="my-editor" style={{ border: "1px solid red" }} id="editor-1" />
+    );
+
+    const div = container.firstElementChild as HTMLElement;
+    expect(div.className).toContain("my-editor");
+    expect(div.style.border).toBe("1px solid red");
+    expect(div.id).toBe("editor-1");
   });
 });

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -8,11 +8,24 @@ export const Editor = defineComponent({
     initialValue: {
       type: String,
       required: false
+    },
+    class: {
+      type: String,
+      required: false
+    },
+    style: {
+      type: [String, Object],
+      required: false
+    },
+    id: {
+      type: String,
+      required: false
     }
   },
-  setup(props) {
-    const { containerRef } = useEditor(props);
+  setup(props, { attrs }) {
+    const { class: className, style, id, ...editorProps } = props;
+    const { containerRef } = useEditor({ ...editorProps, ...attrs } as any);
 
-    return () => h("div", { ref: containerRef });
+    return () => h("div", { ref: containerRef, class: className, style, id });
   }
 });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -4,7 +4,15 @@ import type {
 } from "@floatboat/nexus-core";
 import type { Ref, ShallowRef } from "vue";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export interface UseEditorConfig extends Omit<EditorConfig, "container"> {
+  onReady?: (editor: EditorAPI) => void;
+}
+
+export interface EditorProps extends UseEditorConfig {
+  class?: string;
+  style?: string | Record<string, string>;
+  id?: string;
+}
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -12,10 +12,15 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
-    editor.value = createEditor({
+    const { onReady, ...editorConfig } = config;
+
+    const instance = createEditor({
       container: containerRef.value,
-      ...config
+      ...editorConfig
     });
+
+    editor.value = instance;
+    onReady?.(instance);
   });
 
   onBeforeUnmount(() => {

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,7 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, onMounted } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Editor, useEditor } from "../src/index";
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 describe("@floatboat/nexus-vue", () => {
   it("renders an editor into the provided container through the Editor component", async () => {
@@ -44,5 +45,39 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("calls onReady with the editor instance after creation", async () => {
+    const onReady = vi.fn();
+
+    mount(Editor, {
+      props: {
+        initialValue: "# Ready",
+        onReady
+      } as any
+    });
+
+    await nextTick();
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    const editor: EditorAPI = onReady.mock.calls[0][0];
+    expect(editor.getDocument()).toBe("# Ready");
+  });
+
+  it("passes class, style, and id to the container div", async () => {
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "",
+        class: "my-editor",
+        style: "border: 1px solid red",
+        id: "editor-1"
+      } as any
+    });
+
+    await nextTick();
+
+    expect(wrapper.element.className).toContain("my-editor");
+    expect((wrapper.element as HTMLElement).style.border).toBe("1px solid red");
+    expect(wrapper.element.id).toBe("editor-1");
   });
 });


### PR DESCRIPTION
## Summary / 摘要

实现 ROADMAP #1（多行列表切换）。把 `toggleOrderedList` / `toggleUnorderedList` 从"只处理 anchor 所在单行"升级为"处理选区覆盖的所有行"，并设计了一套与主流编辑器一致的"全员一致才取消、否则统一添加"切换策略。

## Motivation / 背景与动机

- Issue: N/A（开放命题面试 PR）
- Roadmap (docs/ROADMAP.md): **#1 多行列表切换**（P1、planned），由本 PR 转为 done
- OpenSpec change: N/A —— 现有公共 API 行为扩展，无破坏性变更

PR 之前的状态：`toggleOrderedList` / `toggleUnorderedList` 都只读 `editor.getSelection().anchor`，在 `getCurrentLine(doc, anchor)` 里只操作光标所在的那一行。用户即便选中跨多行也只有一行被切换，与所有主流 markdown 编辑器（VS Code、Obsidian、Typora）的行为不一致。本 PR 在不引入新 API、不改变单行场景行为的前提下补完多行支持，并把"切换方向"这一关键 UX 决策显式化。

## Changes / 变更内容

- `packages/plugin-toolbar`:
  - `src/formatting.ts`:
    - 新增 `getSelectedLines(doc, from, to)` —— 返回选区覆盖的全部 `LineInfo[]`，单光标场景自然退化为单行
    - 抽出 `toggleListLines(editor, mode)` —— 两个 toggle 函数共享实现，差异仅在 marker 类型
    - **切换方向策略**：仅当所有非空行都已携带本类标记时才剥离；其它情况（混合 / 全无 / 对方类型）一律统一为"添加"
    - **有序列表重新编号**：`counter` 从 1 开始按非空行累加，已有的 `5. ` / `9. ` 标记不会沿用
    - **空行保留**：`line.trim().length === 0` 的行原样穿透，不参与编号也不被加前缀
    - **互转**：检测到 `otherMarker` 则先剥离再加新前缀，避免标记叠加（`1. foo` → `- foo`）
  - 选区恢复：替换完成后将 selection 设为整个新区域 `[firstLineStart, firstLineStart + newRegion.length]`，符合"我选过这段所以应该继续覆盖这段"的直觉
- `packages/core`: 无改动 —— 现有 `EditorAPI.getSelection()` / `setSelection()` 已够用
- 其他：无文档 / 配置改动

## Testing / 测试

- [x] `pnpm test` passes / 全绿 —— **343 / 343 通过**
- [x] Affected package builds (`pnpm --filter @floatboat/nexus-plugin-toolbar build`) 通过
- [x] `pnpm --filter @floatboat/nexus-plugin-toolbar exec tsc --noEmit` 类型检查无报错
- [x] New / updated vitest cases / 新增 vitest 用例 —— `packages/plugin-toolbar/test/plugin-toolbar.test.ts` 新增 **13 cases**：
  - `toggleUnorderedList` 7 cases：
    - adds `- ` to a single line
    - removes `- ` from a single line
    - adds `- ` to every line in a multi-line selection
    - removes `- ` from every line when all lines are bulleted
    - 混合状态统一为添加（mixed → unified add）
    - 有序 → 无序互转（`1. foo` → `- foo`）
    - 空行保留不被 bulleted
  - `toggleOrderedList` 5 cases：
    - 单行添加
    - 多行从 1 起连续编号
    - 全部已编号时整体移除
    - **重新编号**：`5. / 9.` → 去 → 再加 → `1. / 2.`（验证不沿用旧编号）
    - 跳过空行编号
- [x] Manual UI check in electron-demo / electron-demo 手动验证

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits（`feat(toolbar): ...`）
- [x] Public API changes update package README / types —— N/A：`plugin-toolbar` 未提供 README；公共函数签名未变（仍是 `(editor: EditorAPI) => boolean`），仅扩展了内部行为
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md —— **本 PR 未触及 `live-preview-table.ts`**
- [x] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec —— N/A：行为扩展而非新 capability
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## 设计说明（评审参考）

**为什么选"全员一致才取消"而不是"逐行独立 toggle"？**

考虑选区里既有 `- foo` 又有 `bar` 的混合场景：

1. **逐行独立 toggle**：`- foo` 变 `foo`，`bar` 变 `- bar` —— 结果上下颠倒，用户看到一半带 `-` 一半不带，认知负担重，且**再按一次得到同样的混合结果**（永远摆脱不了），与"toggle"语义不符
2. **全员一致才取消**（本 PR 采用）：混合状态一律视为"想统一加 `-`"，第二次按则因"全员都有"而整体去除 —— 行为可预测，两次操作完成一个完整周期

参考实现：Obsidian Live Preview、VS Code `markdown.extension.editing.toggleList`、Typora 均采用此策略。

## Out of scope（识别但本 PR 不做）

- **嵌套列表的缩进保留**：当前实现把 `  - foo` 的前导空格视作普通内容（不会破坏，但也不会智能保留嵌套层级）。完整支持需要在剥离 marker 前先解析缩进、加 marker 时还原 —— 独立设计点，建议另开 issue 跟踪
- **有序列表的自定义起始编号**：始终从 1 起编号。从中间编号开始（如继续上文 `4. / 5. / 6.`）需要额外读取选区上一行的状态
- **task list（`- [ ]`）的多行勾选**：不在 #1 范围内，由独立 roadmap 条目覆盖
- **混合缩进层级的有序 + 无序嵌套**：场景过于复杂，超出"列表切换"的语义边界

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A —— 行为类改动，无新 UI 元素。手动场景示例（可在 electron-demo 验证）：

```
选中下面三行 → 按"无序列表"按钮：
first              →   - first
second             →   - second
third              →   - third

再按一次（全员一致 → 剥离）：
- first            →   first
- second           →   second
- third            →   third

混合状态选中三行 → 按"无序列表"（统一为添加）：
- first            →   - first
second             →   - second
- third            →   - third
```