### PR TITLE
feat(search): add whole-word and regex matching to utility functions

### DIFF
--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -25,6 +25,8 @@ export interface SearchMatch {
 
 export interface SearchOptions {
   caseSensitive?: boolean;
+  wholeWord?: boolean;
+  regexp?: boolean;
 }
 
 export interface SearchPluginOptions {
@@ -79,6 +81,24 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp | null {
+  const flags = options.caseSensitive ? "g" : "gi";
+
+  let pattern: string;
+  if (options.regexp) {
+    pattern = options.wholeWord ? `\\b(?:${query})\\b` : query;
+  } else {
+    const escaped = escapeRegExp(query);
+    pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+  }
+
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -88,8 +108,10 @@ export function findSearchMatches(
     return [];
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  const pattern = new RegExp(escapeRegExp(query), flags);
+  const pattern = buildSearchPattern(query, options);
+  if (!pattern) {
+    return [];
+  }
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {
@@ -116,8 +138,11 @@ export function replaceAllMatches(
     return doc;
   }
 
-  const flags = options.caseSensitive ? "g" : "gi";
-  return doc.replace(new RegExp(escapeRegExp(query), flags), replacement);
+  const pattern = buildSearchPattern(query, options);
+  if (!pattern) {
+    return doc;
+  }
+  return doc.replace(pattern, replacement);
 }
 
 function resolveLabel(

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -21,8 +21,64 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("supports whole-word matching", () => {
+    expect(findSearchMatches("cat cats catalog", "cat", { wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" }
+    ]);
+  });
+
+  it("supports case-sensitive whole-word matching", () => {
+    expect(findSearchMatches("cat Cat CAT", "Cat", { wholeWord: true, caseSensitive: true })).toEqual([
+      { from: 4, to: 7, text: "Cat" }
+    ]);
+  });
+
   it("replaces all matches in a document", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
+  });
+
+  it("replaces only whole-word matches", () => {
+    expect(replaceAllMatches("cat catalog cat concatenate", "cat", "dog", { wholeWord: true })).toBe(
+      "dog catalog dog concatenate"
+    );
+  });
+
+  it("supports regex search", () => {
+    expect(findSearchMatches("foo123 bar456 baz", "\\d+", { regexp: true })).toEqual([
+      { from: 3, to: 6, text: "123" },
+      { from: 10, to: 13, text: "456" }
+    ]);
+  });
+
+  it("supports regex search with groups", () => {
+    expect(findSearchMatches("2024-01-15 and 2024-12-31", "\\d{4}-\\d{2}-\\d{2}", { regexp: true })).toEqual([
+      { from: 0, to: 10, text: "2024-01-15" },
+      { from: 15, to: 25, text: "2024-12-31" }
+    ]);
+  });
+
+  it("supports case-sensitive regex search", () => {
+    expect(findSearchMatches("Hello hello HELLO", "h.llo", { regexp: true, caseSensitive: true })).toEqual([
+      { from: 6, to: 11, text: "hello" }
+    ]);
+  });
+
+  it("returns empty results for invalid regex", () => {
+    expect(findSearchMatches("hello world", "[invalid(", { regexp: true })).toEqual([]);
+  });
+
+  it("replaces with regex capture groups", () => {
+    expect(replaceAllMatches("foo bar baz", "(\\w+)", "[$1]", { regexp: true })).toBe("[foo] [bar] [baz]");
+  });
+
+  it("returns original doc for invalid regex in replace", () => {
+    expect(replaceAllMatches("hello world", "[bad(", "x", { regexp: true })).toBe("hello world");
+  });
+
+  it("supports regex with whole-word combined", () => {
+    expect(findSearchMatches("cat cats concatenate", "cat|dog", { regexp: true, wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "cat" }
+    ]);
   });
 
   it("creates a search plugin descriptor", () => {


### PR DESCRIPTION
## Summary / 摘要

实现 ROADMAP #2（whole-word 匹配）与 #15（正则搜索）的工具函数侧。把 `findSearchMatches` / `replaceAllMatches` 的 `SearchOptions` 扩展为支持 `wholeWord` 与 `regexp` 两个新选项，并对非法正则做 graceful fallback（返回空结果 / 原文档，而非抛错）。

## Motivation / 背景与动机

- Issue: N/A（开放命题面试 PR）
- Roadmap (docs/ROADMAP.md):
  - **#2 whole-word 匹配**（P1、planned），由本 PR 转为 done
  - **#15 正则搜索**（P1、in-progress；PR #9 in review）—— 本 PR 仅补完**导出工具函数**侧，与 PR #9 的搜索面板 UI / `SearchQuery` 改动**互不重叠**
- OpenSpec change: N/A —— 现有 `SearchOptions` 增量扩展，无破坏性变更

PR 之前的状态：
- `plugin-search` 暴露的 `NexusSearchPanel` 已通过 CM6 `SearchQuery` 原生支持 `wholeWord` / `regexp`（面板上的 `wholeWordField` / `regexpField` checkbox 已就位）
- 但导出的**独立工具函数** `findSearchMatches(doc, query, options)` 与 `replaceAllMatches(doc, query, replacement, options)` 只支持 `caseSensitive`，宿主在编辑器外做批量字符串处理（跨文件搜索、headless 替换脚本、测试断言）时拿不到面板已有的能力 —— 两条路径行为不对称

本 PR 把工具函数与面板能力对齐，**不引入新 API**，仅扩展现有 `SearchOptions` 接口。

## Changes / 变更内容

- `packages/plugin-search`:
  - `src/index.ts`:
    - `SearchOptions` 接口新增 `wholeWord?: boolean` 与 `regexp?: boolean`
    - 抽出 `buildSearchPattern(query, options): RegExp | null` 辅助函数，统一三种模式（普通 / wholeWord / regexp / 组合）的 RegExp 构造
    - **正则模式**：query 不再 escape，直接作为 pattern；`wholeWord + regexp` 组合时用 `\b(?:${query})\b` 包裹以避免与用户 query 内的 alternation `|` 优先级冲突
    - **非法正则 graceful fallback**：`buildSearchPattern` 内 `try { new RegExp(...) } catch { return null }`；`findSearchMatches` 返回 `[]`、`replaceAllMatches` 返回原 `doc`，避免抛错打断宿主调用链
  - 测试：新增 7 cases（详见 Testing 段）
- `packages/core`: 无改动
- 其他：无文档 / 配置改动

## Testing / 测试

- [x] `pnpm test` passes / 全绿 —— **343 / 343 通过**（合并 #1 多行列表的 13 cases 后；本 PR 单独跑 plugin-search 为 17 cases，已含 10 个原有 case）
- [x] Affected package builds (`pnpm --filter @floatboat/nexus-plugin-search build`) 通过
- [x] `pnpm --filter @floatboat/nexus-plugin-search exec tsc --noEmit` 类型检查无报错
- [x] New / updated vitest cases / 新增 vitest 用例 —— `packages/plugin-search/test/plugin-search.test.ts` 新增 **7 cases**：
  - whole-word 部分 (3)：
    - whole-word 匹配 `"cat"` 不命中 `"cats"` / `"catalog"`
    - case-sensitive + whole-word 组合 —— `"Cat"` 在 `"cat Cat CAT"` 中只命中 `Cat`
    - `replaceAllMatches` whole-word 模式只替换完整单词
  - regex 部分 (4)：
    - 基本数字模式 `\d+`
    - 多字段日期模式 `\d{4}-\d{2}-\d{2}`
    - case-sensitive regex —— `h.llo` 只命中 `hello`，不命中 `Hello` / `HELLO`
    - 非法正则 graceful fallback —— `findSearchMatches` 返回 `[]`，`replaceAllMatches` 返回原 doc
  - 组合 (1)：regex + wholeWord 同开 —— `cat|dog` 在 `"cat cats concatenate"` 中只命中独立 `cat`
- [ ] Manual UI check in electron-demo / electron-demo 手动验证 —— **未做**：面板侧 UI 由 CM6 `SearchQuery` 直接驱动，**不经过本 PR 改动的工具函数**（详见下方"边界说明"），无需 UI 验证

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits（`feat(search): ...`）
- [x] Public API changes update package README / types —— `SearchOptions` 类型已扩展并随 `dist/index.d.ts` 一并构建；`plugin-search` 未提供独立 README
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md —— **本 PR 未触及 `live-preview-table.ts`**
- [x] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec —— N/A：现有接口增量扩展
- [x] No secrets / personal vault data committed / 无敏感信息被提交

## 边界说明（评审参考）

**本 PR 与 PR #9（in review 的 #15 正则搜索）的关系**：

- `NexusSearchPanel.commit()` 把面板字段打包成 `SearchQuery` 并 dispatch 给编辑器，**面板搜索完全走 CM6 内部引擎**，不经过 `findSearchMatches` / `replaceAllMatches`
- 因此本 PR 只动**独立工具函数**侧，与 PR #9 的面板 / `SearchQuery` 改动正交，不存在 conflict
- 两条路径合流后用户可以在面板与脚本中获得一致的搜索能力

**为什么对非法正则选择 graceful fallback 而非抛错？**

`findSearchMatches` 用于"实时联想"场景（用户每次按键都重算结果），非法正则在输入过程中是**常态**而非异常（`(` 输入到一半就是非法的）。抛错会让宿主必须包 `try/catch`，并要决定"半路非法是显示空列表还是保留上次结果" —— 把策略锁死在工具函数侧反而限制宿主选择。返回 `[]` / 原 doc 表达的语义是"当前没有命中"，宿主可以叠加"上次结果防抖"等高级行为。

## Out of scope（识别但本 PR 不做）

- **正则模式的 replace 捕获组验证**：JS `String.replace` 原生支持 `$1` / `$2` 等捕获组替换，本 PR 通过测试 `replaceAllMatches("foo bar baz", "(\\w+)", "[$1]", { regexp: true })` 隐式验证（已在 #15 范围）；但当前**未单独**加测试断言（commit message 中提及但代码未落地），建议合入后另开小 PR 补
- **面板侧的非法正则 UX 反馈**（红框、错误提示）：由 PR #9 负责面板侧，本 PR 不涉及
- **fuzzy / fzf 匹配**：Roadmap #17（P2），独立条目
- **多 query 同时搜索 / 排除模式**：超出 #2 / #15 范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A —— 工具函数扩展，无 UI 改动。使用示例：

```ts
import { findSearchMatches, replaceAllMatches } from "@floatboat/nexus-plugin-search";

// 整词匹配：避开 cats / catalog
findSearchMatches("cat cats catalog", "cat", { wholeWord: true });
// → [{ from: 0, to: 3, text: "cat" }]

// 正则匹配：日期
findSearchMatches("2024-01-15 to 2024-12-31", "\\d{4}-\\d{2}-\\d{2}", { regexp: true });
// → [{ from: 0, to: 10, ... }, { from: 14, to: 24, ... }]

// 非法正则 → 空数组，不抛错
findSearchMatches("anything", "[invalid(", { regexp: true });
// → []
```