### PR TITLE
feat(core): improve markdown list editing keymap

### DIFF
--- a/packages/core/src/markdown-keymap.ts
+++ b/packages/core/src/markdown-keymap.ts
@@ -1,39 +1,84 @@
-import { EditorSelection, Prec, type EditorState, type Extension, type SelectionRange } from "@codemirror/state";
+import {
+  EditorSelection,
+  Prec,
+  findClusterBreak,
+  type EditorState,
+  type Extension,
+  type SelectionRange,
+} from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 
 const LIST_RE = /^(\s*)([-*+]|\d+[.)]) /;
 const CHECKBOX_RE = /^\[([ xX])\] /;
-const BLOCKQUOTE_RE = /^(\s*>+ ?)/;
+const BLOCKQUOTE_RE = /^(\s*(?:> ?)+)/;
+const LIST_INDENT = "  ";
+
+type IndentDirection = "indent" | "outdent";
+
+interface ParsedListLine {
+  quotePrefix: string;
+  indent: string;
+  markerPrefix: string;
+  contentOffset: number;
+}
+
+interface Continuation {
+  prefix: string;
+  content: string;
+  exitOffset: number;
+}
+
+/** Split a line into quote/list parts while preserving nested quote markers. */
+function parseListLine(text: string): ParsedListLine | null {
+  const quoteMatch = BLOCKQUOTE_RE.exec(text);
+  const quotePrefix = quoteMatch?.[1] ?? "";
+  const content = text.slice(quotePrefix.length);
+  const listMatch = LIST_RE.exec(content);
+  if (!listMatch) return null;
+
+  const afterMarker = content.slice(listMatch[0].length);
+  const checkboxPrefix = CHECKBOX_RE.exec(afterMarker)?.[0] ?? "";
+  return {
+    quotePrefix,
+    indent: listMatch[1],
+    markerPrefix: listMatch[0] + checkboxPrefix,
+    contentOffset: quotePrefix.length + listMatch[0].length + checkboxPrefix.length,
+  };
+}
 
 /** The markdown continuation prefix for the line, or null when the line is plain text. */
-function continuationFor(text: string): { prefix: string; content: string } | null {
-  const listMatch = LIST_RE.exec(text);
+function continuationFor(text: string): Continuation | null {
+  const quoteMatch = BLOCKQUOTE_RE.exec(text);
+  const quotePrefix = quoteMatch?.[1] ?? "";
+  const content = text.slice(quotePrefix.length);
+  const listMatch = LIST_RE.exec(content);
+
   if (listMatch) {
     const indent = listMatch[1];
     const marker = listMatch[2];
-    const afterMarker = text.slice(listMatch[0].length);
-
+    const afterMarker = content.slice(listMatch[0].length);
     const cbMatch = CHECKBOX_RE.exec(afterMarker);
-    const content = cbMatch ? afterMarker.slice(cbMatch[0].length) : afterMarker;
+    const itemContent = cbMatch ? afterMarker.slice(cbMatch[0].length) : afterMarker;
 
-    // Increment ordered-list numbers
     let nextMarker = marker;
     const numMatch = marker.match(/^(\d+)([.)])/);
     if (numMatch) {
       nextMarker = `${parseInt(numMatch[1]) + 1}${numMatch[2]}`;
     }
 
-    const prefix = cbMatch ? `${indent}${nextMarker} [ ] ` : `${indent}${nextMarker} `;
-    return { prefix, content };
+    const listPrefix = cbMatch
+      ? `${indent}${nextMarker} [ ] `
+      : `${indent}${nextMarker} `;
+    return {
+      prefix: quotePrefix + listPrefix,
+      content: itemContent,
+      exitOffset: quotePrefix.length,
+    };
   }
 
-  const quoteMatch = BLOCKQUOTE_RE.exec(text);
-  if (quoteMatch) {
-    const prefix = quoteMatch[1];
-    return { prefix, content: text.slice(prefix.length) };
-  }
-
-  return null;
+  return quotePrefix
+    ? { prefix: quotePrefix, content, exitOffset: 0 }
+    : null;
 }
 
 function isContinuable(state: EditorState, range: SelectionRange): boolean {
@@ -53,14 +98,10 @@ export function handleMarkdownEnter(view: EditorView): boolean {
   const { state } = view;
   if (!state.selection.ranges.some((range) => isContinuable(state, range))) return false;
 
-  // Lines already emptied by an "exit list/quote" range: a second cursor on
-  // the same line must become a no-op — its deletion would overlap the first.
   const exitedLines = new Set<number>();
-
   view.dispatch(
     state.changeByRange((range) => {
       if (!range.empty) {
-        // Default Enter semantics for a non-empty range: replace it with a newline.
         return {
           changes: { from: range.from, to: range.to, insert: "\n" },
           range: EditorSelection.cursor(range.from + 1),
@@ -69,7 +110,6 @@ export function handleMarkdownEnter(view: EditorView): boolean {
 
       const line = state.doc.lineAt(range.head);
       const continuation = continuationFor(line.text);
-
       if (!continuation) {
         return {
           changes: { from: range.head, insert: "\n" },
@@ -77,15 +117,13 @@ export function handleMarkdownEnter(view: EditorView): boolean {
         };
       }
 
-      // Empty item → exit the list / blockquote by clearing the line.
       if (!continuation.content.trim()) {
-        if (exitedLines.has(line.from)) {
-          return { range };
-        }
+        if (exitedLines.has(line.from)) return { range };
         exitedLines.add(line.from);
+        const from = line.from + continuation.exitOffset;
         return {
-          changes: { from: line.from, to: line.to, insert: "" },
-          range: EditorSelection.cursor(line.from),
+          changes: { from, to: line.to, insert: "" },
+          range: EditorSelection.cursor(from),
         };
       }
 
@@ -98,6 +136,117 @@ export function handleMarkdownEnter(view: EditorView): boolean {
   return true;
 }
 
+/** Indent or outdent every selected Markdown list line in one transaction. */
+export function handleMarkdownListIndent(
+  view: EditorView,
+  direction: IndentDirection
+): boolean {
+  const { state } = view;
+  const changes: Array<{ from: number; to?: number; insert: string }> = [];
+  const changedLines = new Set<number>();
+
+  for (const range of state.selection.ranges) {
+    const fromLine = state.doc.lineAt(range.from);
+    const selectionEnd = range.empty ? range.to : Math.max(range.from, range.to - 1);
+    const toLine = state.doc.lineAt(selectionEnd);
+
+    for (let lineNumber = fromLine.number; lineNumber <= toLine.number; lineNumber++) {
+      const line = state.doc.line(lineNumber);
+      if (changedLines.has(line.from)) continue;
+
+      const parsed = parseListLine(line.text);
+      if (!parsed) continue;
+      const indentFrom = line.from + parsed.quotePrefix.length;
+
+      if (direction === "indent") {
+        changes.push({ from: indentFrom, insert: LIST_INDENT });
+        changedLines.add(line.from);
+      } else if (parsed.indent) {
+        const removeLength = Math.min(LIST_INDENT.length, parsed.indent.length);
+        changes.push({ from: indentFrom, to: indentFrom + removeLength, insert: "" });
+        changedLines.add(line.from);
+      }
+    }
+  }
+
+  if (changes.length === 0) return false;
+  changes.sort((a, b) => a.from - b.from);
+  view.dispatch({ changes });
+  return true;
+}
+
+function listBackspaceChange(
+  state: EditorState,
+  range: SelectionRange
+): { from: number; to: number; cursor: number } | null {
+  if (!range.empty) return null;
+
+  const line = state.doc.lineAt(range.head);
+  const parsed = parseListLine(line.text);
+  if (!parsed || range.head !== line.from + parsed.contentOffset) return null;
+
+  const indentFrom = line.from + parsed.quotePrefix.length;
+  if (parsed.indent) {
+    const removeLength = Math.min(LIST_INDENT.length, parsed.indent.length);
+    return {
+      from: indentFrom,
+      to: indentFrom + removeLength,
+      cursor: range.head - removeLength,
+    };
+  }
+
+  return {
+    from: indentFrom,
+    to: indentFrom + parsed.markerPrefix.length,
+    cursor: indentFrom,
+  };
+}
+
+/**
+ * Normalize list prefixes on Backspace while preserving multi-cursor edits.
+ * Unhandled ranges receive normal single-character Backspace behavior when
+ * another cursor triggers list-boundary handling.
+ */
+export function handleMarkdownListBackspace(view: EditorView): boolean {
+  const { state } = view;
+  if (!state.selection.ranges.some((range) => listBackspaceChange(state, range))) return false;
+
+  view.dispatch(
+    state.changeByRange((range) => {
+      const listChange = listBackspaceChange(state, range);
+      if (listChange) {
+        return {
+          changes: { from: listChange.from, to: listChange.to, insert: "" },
+          range: EditorSelection.cursor(listChange.cursor),
+        };
+      }
+
+      if (!range.empty) {
+        return {
+          changes: { from: range.from, to: range.to, insert: "" },
+          range: EditorSelection.cursor(range.from),
+        };
+      }
+      if (range.head === 0) return { range };
+
+      const line = state.doc.lineAt(range.head);
+      const from = range.head === line.from
+        ? range.head - 1
+        : line.from + findClusterBreak(line.text, range.head - line.from, false);
+      return {
+        changes: { from, to: range.head, insert: "" },
+        range: EditorSelection.cursor(from),
+      };
+    })
+  );
+  return true;
+}
+
 export function markdownKeymap(): Extension {
-  return Prec.high(keymap.of([{ key: "Enter", run: handleMarkdownEnter }]));
+  return Prec.high(keymap.of([
+    { key: "Enter", run: handleMarkdownEnter },
+    { key: "Backspace", run: handleMarkdownListBackspace },
+    { key: "Tab", run: (view) => handleMarkdownListIndent(view, "indent") },
+    { key: "Shift-Tab", run: (view) => handleMarkdownListIndent(view, "outdent") },
+  ]));
 }

--- a/packages/core/test/markdown-keymap.test.ts
+++ b/packages/core/test/markdown-keymap.test.ts
@@ -2,7 +2,11 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
 
-import { handleMarkdownEnter } from "../src/markdown-keymap";
+import {
+  handleMarkdownEnter,
+  handleMarkdownListBackspace,
+  handleMarkdownListIndent
+} from "../src/markdown-keymap";
 
 function createView(doc: string, cursor?: number): EditorView {
   const view = new EditorView({
@@ -91,6 +95,60 @@ describe("markdown keymap", () => {
     view.destroy();
   });
 
+  it("continues nested blockquotes with spaced markers", () => {
+    const view = createView("> > nested quote", 16);
+    const handled = handleMarkdownEnter(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> > nested quote\n> > ");
+    view.destroy();
+  });
+
+  it("continues unordered lists inside blockquotes", () => {
+    const view = createView("> - quoted item", 15);
+    const handled = handleMarkdownEnter(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> - quoted item\n> - ");
+    view.destroy();
+  });
+
+  it("continues ordered lists inside blockquotes", () => {
+    const view = createView("> 1. quoted item", 16);
+    const handled = handleMarkdownEnter(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> 1. quoted item\n> 2. ");
+    view.destroy();
+  });
+
+  it("continues task lists inside blockquotes", () => {
+    const view = createView("> - [x] quoted task", 19);
+    const handled = handleMarkdownEnter(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> - [x] quoted task\n> - [ ] ");
+    view.destroy();
+  });
+
+  it("continues lists inside nested blockquotes with spaced markers", () => {
+    const view = createView("> > - nested item", 17);
+    const handled = handleMarkdownEnter(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> > - nested item\n> > - ");
+    view.destroy();
+  });
+
+  it("exits quoted lists while preserving the blockquote prefix", () => {
+    const view = createView("> - item\n> - ", 12);
+    const handled = handleMarkdownEnter(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> - item\n> ");
+    view.destroy();
+  });
+
   // ── No-op cases ──
 
   it("does not trigger on plain text lines", () => {
@@ -112,6 +170,162 @@ describe("markdown keymap", () => {
     const handled = handleMarkdownEnter(view);
 
     expect(handled).toBe(false);
+    view.destroy();
+  });
+
+  // ── List indentation ──
+
+  it("indents the current list item", () => {
+    const view = createView("- item", 2);
+    const handled = handleMarkdownListIndent(view, "indent");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("  - item");
+    view.destroy();
+  });
+
+  it("outdents the current nested list item", () => {
+    const view = createView("  - item", 4);
+    const handled = handleMarkdownListIndent(view, "outdent");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("- item");
+    view.destroy();
+  });
+
+  it("does not outdent top-level list items", () => {
+    const view = createView("- item", 2);
+    const handled = handleMarkdownListIndent(view, "outdent");
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.toString()).toBe("- item");
+    view.destroy();
+  });
+
+  it("indents lists inside blockquotes after the quote marker", () => {
+    const view = createView("> - item", 4);
+    const handled = handleMarkdownListIndent(view, "indent");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe(">   - item");
+    view.destroy();
+  });
+
+  it("outdents nested lists inside blockquotes while preserving the quote marker", () => {
+    const view = createView(">   - item", 6);
+    const handled = handleMarkdownListIndent(view, "outdent");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> - item");
+    view.destroy();
+  });
+
+  it("indents selected list items across multiple lines", () => {
+    const doc = "- one\n- two\nplain";
+    const view = new EditorView({
+      state: EditorState.create({
+        doc,
+        selection: { anchor: 0, head: "- one\n- two".length }
+      })
+    });
+    const handled = handleMarkdownListIndent(view, "indent");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("  - one\n  - two\nplain");
+    view.destroy();
+  });
+
+  it("outdents selected nested list items across multiple lines", () => {
+    const doc = "  - one\n  - two\nplain";
+    const view = new EditorView({
+      state: EditorState.create({
+        doc,
+        selection: { anchor: 0, head: "  - one\n  - two".length }
+      })
+    });
+    const handled = handleMarkdownListIndent(view, "outdent");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("- one\n- two\nplain");
+    view.destroy();
+  });
+
+  it("does not indent plain text lines", () => {
+    const view = createView("plain text", 5);
+    const handled = handleMarkdownListIndent(view, "indent");
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.toString()).toBe("plain text");
+    view.destroy();
+  });
+
+  // ── List backspace ──
+
+  it("removes a top-level list marker at the content start", () => {
+    const view = createView("- item", 2);
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("item");
+    view.destroy();
+  });
+
+  it("outdents a nested list item at the content start", () => {
+    const view = createView("  - item", 4);
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("- item");
+    view.destroy();
+  });
+
+  it("removes a task-list marker at the task content start", () => {
+    const view = createView("- [x] task", 6);
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("task");
+    view.destroy();
+  });
+
+  it("removes a quoted top-level list marker while preserving the quote", () => {
+    const view = createView("> - item", 4);
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> item");
+    view.destroy();
+  });
+
+  it("outdents a quoted nested list item at the content start", () => {
+    const view = createView(">   - item", 6);
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("> - item");
+    view.destroy();
+  });
+
+  it("does not handle Backspace away from the list content start", () => {
+    const view = createView("- item", 4);
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.toString()).toBe("- item");
+    view.destroy();
+  });
+
+  it("does not handle Backspace with a non-empty selection", () => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "- item",
+        selection: { anchor: 2, head: 6 }
+      })
+    });
+    const handled = handleMarkdownListBackspace(view);
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.toString()).toBe("- item");
     view.destroy();
   });
 });

--- a/packages/core/test/multi-cursor.test.ts
+++ b/packages/core/test/multi-cursor.test.ts
@@ -9,6 +9,10 @@ import {
   handleMarkdownEnter,
   selectNextOccurrence,
 } from "../src/index";
+import {
+  handleMarkdownListBackspace,
+  handleMarkdownListIndent,
+} from "../src/markdown-keymap";
 
 function createTestEditor(initialValue: string, multiCursor = true) {
   const container = document.createElement("div");
@@ -335,6 +339,50 @@ describe("markdown Enter with multiple cursors", () => {
 
     expect(handleMarkdownEnter(view)).toBe(false);
     expect(editor.getDocument()).toBe("plain\ntext");
+    editor.destroy();
+  });
+
+  it("continues quoted list markers at every cursor", () => {
+    const { editor, view } = createTestEditor("> - a\n> 1. b");
+    editor.setSelections([{ anchor: 5 }, { anchor: 12 }]);
+
+    expect(handleMarkdownEnter(view)).toBe(true);
+
+    expect(editor.getDocument()).toBe("> - a\n> - \n> 1. b\n> 2. ");
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 10, head: 10 },
+      { anchor: 23, head: 23 },
+    ]);
+    editor.destroy();
+  });
+});
+
+describe("markdown list editing with multiple cursors", () => {
+  it("indents plain and quoted list items in one transaction", () => {
+    const { editor, view } = createTestEditor("- a\n> - b");
+    editor.setSelections([{ anchor: 2 }, { anchor: 8 }]);
+
+    expect(handleMarkdownListIndent(view, "indent")).toBe(true);
+
+    expect(editor.getDocument()).toBe("  - a\n>   - b");
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 4, head: 4 },
+      { anchor: 12, head: 12 },
+    ]);
+    editor.destroy();
+  });
+
+  it("applies list-boundary Backspace at every cursor", () => {
+    const { editor, view } = createTestEditor("  - a\n> - b");
+    editor.setSelections([{ anchor: 4 }, { anchor: 10 }]);
+
+    expect(handleMarkdownListBackspace(view)).toBe(true);
+
+    expect(editor.getDocument()).toBe("- a\n> b");
+    expect(editor.getSelections().ranges).toEqual([
+      { anchor: 2, head: 2 },
+      { anchor: 6, head: 6 },
+    ]);
     editor.destroy();
   });
 });


### PR DESCRIPTION
## Summary / 摘要

Improve Markdown list editing keymap behavior for quoted lists, indentation, and list-boundary Backspace handling.

## Motivation / 背景与动机

Markdown list editing should behave consistently in plain lists, blockquotes, nested blockquotes, and task lists. Previously, pressing Enter inside a quoted list preserved only the blockquote marker and dropped the list marker, which interrupted normal list authoring.

- Issue: N/A
- Roadmap (docs/ROADMAP.md): N/A
- OpenSpec change: N/A

## Changes / 变更内容

- `packages/core`:
  - Continue unordered, ordered, and task-list markers inside blockquotes on Enter.
  - Preserve nested blockquote prefixes such as `> > ` during Enter continuation.
  - Add Tab / Shift-Tab handling for Markdown list indentation and outdentation.
  - Support multi-line list indentation and outdentation.
  - Add Backspace handling at list content boundaries to outdent nested items or remove top-level list markers.
  - Add regression tests for quoted lists, task lists, nested blockquotes, indentation, outdentation, Backspace, and no-op cases.

- `packages/plugin-*`: N/A
- `apps/electron-demo`: N/A
- `openspec/`: N/A

## Testing / 测试

- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - `packages/core/test/markdown-keymap.test.ts`
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

Verified with:

```bash
git diff --check
corepack pnpm vitest run packages/core/test/markdown-keymap.test.ts
corepack pnpm test
corepack pnpm -r exec tsc --noEmit
corepack pnpm --filter @floatboat/nexus-core build
corepack pnpm -r --filter "./packages/*" build