### PR TITLE
feat(search): add opt-in search query history

### DIFF
--- a/openspec/changes/add-search-query-history/proposal.md
+++ b/openspec/changes/add-search-query-history/proposal.md
@@ -1,0 +1,32 @@
+# Change: Add Search Query History
+
+## Why
+
+Roadmap #16 ("Command / search history") calls for persisted history across `plugin-search` and `plugin-slash`. This change delivers the first stage: opt-in search query history for `@floatboat/nexus-plugin-search`, so users can recall prior searches without changing default editor behavior.
+
+## What Changes
+
+- Add an opt-in search query history capability to `createSearchPlugin()`.
+- Record submitted non-empty search queries after trimming whitespace.
+- De-duplicate repeated queries and move the newest submission to the front.
+- Respect a configurable `maxEntries` cap, dropping the oldest entries first.
+- Support host-injected storage for persistence.
+- Avoid implicit writes to global `localStorage`; hosts must explicitly provide persistence.
+- Treat unavailable storage, thrown storage operations, and invalid JSON as recoverable.
+- Add ArrowUp / ArrowDown recall inside the search input when history is enabled and entries exist.
+- Preserve existing search behavior when history is disabled.
+
+## Non-Goals
+
+- No `plugin-slash` command history in this PR.
+- No persisted recently-used slash command ordering in this PR.
+- No repo-wide storage adapter or `EditorConfig` storage API in this PR.
+- No Electron demo search-bar rewrite in this PR.
+
+## Impact
+
+- Affected specs: `plugins`
+- Affected code:
+  - `packages/plugin-search/src/index.ts`
+  - `packages/plugin-search/test/plugin-search.test.ts`
+- Affected roadmap: first-stage implementation for Roadmap #16 only. Slash command history remains a follow-up.

--- a/openspec/changes/add-search-query-history/specs/plugins/spec.md
+++ b/openspec/changes/add-search-query-history/specs/plugins/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Search Query History Scope
+
+`@floatboat/nexus-plugin-search` SHALL provide an opt-in search query history capability as the first stage of Roadmap #16 ("Command / search history"). This change SHALL cover only search queries submitted through the search panel. Slash command history and persisted recently-used slash command ordering SHALL remain follow-up work outside this PR.
+
+#### Scenario: Search-only first stage
+- **WHEN** a host enables search query history on `createSearchPlugin()`
+- **THEN** the search panel SHALL record and recall search queries
+- **AND** `@floatboat/nexus-plugin-slash` behavior SHALL remain unchanged
+
+#### Scenario: Slash history remains a follow-up
+- **WHEN** a reviewer evaluates this change against Roadmap #16
+- **THEN** the proposal SHALL identify `plugin-slash` command history and recently-used command persistence as non-goals
+- **AND** those behaviors SHALL NOT be required for this PR to be complete
+
+### Requirement: Opt-In Backward Compatibility
+
+Search query history SHALL be disabled by default. When disabled, the search panel SHALL preserve existing search input, match navigation, replacement, case-sensitive, regexp, and whole-word behavior.
+
+#### Scenario: Default search behavior is unchanged
+- **WHEN** a host creates `createSearchPlugin()` without history options
+- **AND** the user submits a query from the search input
+- **THEN** the editor SHALL navigate matches as before
+- **AND** no history storage SHALL be read or written
+
+#### Scenario: Search options are preserved
+- **GIVEN** search query history is enabled
+- **AND** the user toggles case-sensitive, regexp, or whole-word options
+- **WHEN** the user recalls a query from history
+- **THEN** the recalled query SHALL NOT reset those options
+
+### Requirement: Host-Injected Persistence
+
+Search query history SHALL support host-injected storage for persistence. The plugin SHALL NOT implicitly write to global `localStorage`; persistent storage must be provided explicitly by the host.
+
+#### Scenario: Host storage persists history
+- **GIVEN** the host enables search query history with storage that supports `getItem` and `setItem`
+- **WHEN** the user submits a valid search query
+- **THEN** the plugin SHALL write the updated query list to the configured storage key
+
+#### Scenario: No implicit global localStorage writes
+- **WHEN** a host creates `createSearchPlugin()` without a host-injected history storage
+- **THEN** the plugin SHALL NOT write search history to global `localStorage`
+- **AND** the editor SHALL continue to operate normally
+
+### Requirement: Query Retention Rules
+
+Search query history SHALL record submitted non-empty queries after trimming whitespace. Repeated queries SHALL be de-duplicated and moved to the front. The retained list SHALL respect `maxEntries`, dropping the oldest entries when the cap is exceeded.
+
+#### Scenario: Trim and record a query
+- **WHEN** the user submits the query `"  alpha  "`
+- **THEN** the stored history SHALL contain `"alpha"`
+
+#### Scenario: Ignore blank queries
+- **WHEN** the user submits a query containing only whitespace
+- **THEN** no query SHALL be added to history
+
+#### Scenario: Repeated query moves to front
+- **GIVEN** history contains `["beta", "alpha"]`
+- **WHEN** the user submits `"alpha"`
+- **THEN** history SHALL become `["alpha", "beta"]`
+
+#### Scenario: Max entries drops the oldest query
+- **GIVEN** `maxEntries` is `2`
+- **WHEN** the user submits `"alpha"`, `"beta"`, and `"gamma"` in that order
+- **THEN** history SHALL contain `["gamma", "beta"]`
+
+### Requirement: Storage Failure Resilience
+
+Search query history SHALL treat unavailable storage, thrown `getItem` / `setItem` calls, and invalid JSON as recoverable conditions. These failures SHALL NOT crash the editor or block the search panel from continuing to work.
+
+#### Scenario: Invalid JSON is ignored
+- **GIVEN** host storage returns invalid JSON for the configured history key
+- **WHEN** the user opens the search panel and submits a new query
+- **THEN** the editor SHALL NOT throw
+- **AND** the plugin SHALL continue with an empty in-memory history before recording the new query
+
+#### Scenario: Storage getItem throws
+- **GIVEN** host storage throws while reading history
+- **WHEN** the user opens the search panel
+- **THEN** the editor SHALL NOT throw
+- **AND** search behavior SHALL remain usable
+
+#### Scenario: Storage setItem throws
+- **GIVEN** host storage throws while writing history
+- **WHEN** the user submits a valid search query
+- **THEN** the editor SHALL NOT throw
+- **AND** search behavior SHALL remain usable
+
+### Requirement: Keyboard History Recall
+
+When history is enabled and at least one entry exists, ArrowUp and ArrowDown in the search input SHALL recall previous and next history entries. When history is disabled or empty, these keys SHALL NOT be swallowed by the search panel history handler.
+
+#### Scenario: Arrow keys restore history entries
+- **GIVEN** search query history contains `["gamma", "beta", "alpha"]`
+- **WHEN** the search input is focused and the user presses ArrowUp
+- **THEN** the search input SHALL show `"gamma"`
+- **WHEN** the user presses ArrowDown after moving through history
+- **THEN** the search input SHALL move toward newer input according to the history cursor
+
+#### Scenario: Empty history does not consume arrow keys
+- **GIVEN** search query history is enabled but contains no entries
+- **WHEN** the search input is focused and the user presses ArrowUp or ArrowDown
+- **THEN** the history handler SHALL NOT prevent the event default
+
+#### Scenario: Disabled history does not consume arrow keys
+- **GIVEN** search query history is disabled
+- **WHEN** the search input is focused and the user presses ArrowUp or ArrowDown
+- **THEN** the history handler SHALL NOT prevent the event default

--- a/openspec/changes/add-search-query-history/tasks.md
+++ b/openspec/changes/add-search-query-history/tasks.md
@@ -1,0 +1,23 @@
+## 1. OpenSpec and Test-First Setup
+
+- [x] 1.1 Create OpenSpec change `add-search-query-history`.
+- [x] 1.2 Define the first-stage `plugin-search` scope and `plugin-slash` non-goals.
+- [x] 1.3 Add red tests for query history behavior before implementation.
+
+## 2. Plugin Search Implementation
+
+- [x] 2.1 Add a public, typed search history option to `createSearchPlugin()`.
+- [x] 2.2 Add host-injected storage support without implicit global `localStorage` writes.
+- [x] 2.3 Load stored history defensively, treating missing/invalid storage as empty history.
+- [x] 2.4 Record submitted search queries after trimming and ignoring blank values.
+- [x] 2.5 De-duplicate repeated queries by moving the newest entry to the front.
+- [x] 2.6 Enforce `maxEntries` by dropping oldest entries.
+- [x] 2.7 Wire ArrowUp / ArrowDown recall in the search input without stealing keys when no history is available.
+- [x] 2.8 Preserve case-sensitive, regexp, whole-word, replace, and navigation behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run the targeted `plugin-search` Vitest suite and confirm the new tests pass.
+- [ ] 3.2 Run `pnpm test`.
+- [x] 3.3 Run `pnpm build`.
+- [ ] 3.4 Run `pnpm exec openspec validate add-search-query-history --strict` if the OpenSpec CLI is available.

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -27,6 +27,18 @@ export interface SearchOptions {
   caseSensitive?: boolean;
 }
 
+export interface SearchHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface SearchHistoryOptions {
+  storage?: SearchHistoryStorage;
+  storageKey?: string;
+  maxEntries?: number;
+}
+
 export interface SearchPluginOptions {
   /**
    * Render the search panel above the editor content. Defaults to true.
@@ -40,6 +52,10 @@ export interface SearchPluginOptions {
    * Highlight viewport matches for the current selection.
    */
   highlightSelectionMatches?: boolean;
+  /**
+   * Opt-in search query history. Pass storage explicitly to persist entries.
+   */
+  history?: boolean | SearchHistoryOptions;
   labels?: Partial<SearchPluginLabels>;
 }
 
@@ -74,6 +90,141 @@ const DEFAULT_LABELS: SearchPluginLabels = {
   replaceAll: "Replace all",
   close: "Close"
 };
+
+const DEFAULT_SEARCH_HISTORY_KEY = "nexus.search.history";
+const DEFAULT_SEARCH_HISTORY_MAX_ENTRIES = 20;
+
+type SearchHistoryDirection = "previous" | "next";
+
+function resolveMaxEntries(maxEntries: number | undefined): number {
+  if (maxEntries === undefined || !Number.isFinite(maxEntries)) {
+    return DEFAULT_SEARCH_HISTORY_MAX_ENTRIES;
+  }
+  return Math.max(0, Math.floor(maxEntries));
+}
+
+function normalizeHistoryEntries(value: unknown, maxEntries: number): string[] {
+  if (!Array.isArray(value) || maxEntries <= 0) {
+    return [];
+  }
+
+  const entries: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+
+    const query = item.trim();
+    if (!query || entries.includes(query)) continue;
+
+    entries.push(query);
+    if (entries.length >= maxEntries) break;
+  }
+
+  return entries;
+}
+
+class SearchHistoryController {
+  private readonly enabled: boolean;
+  private readonly storage?: SearchHistoryStorage;
+  private readonly storageKey: string;
+  private readonly maxEntries: number;
+  private entries: string[] = [];
+  private loaded = false;
+  private cursor: number | null = null;
+  private draft = "";
+
+  constructor(options: boolean | SearchHistoryOptions | undefined) {
+    this.enabled = options !== undefined && options !== false;
+    const config = typeof options === "object" ? options : undefined;
+    this.storage = config?.storage;
+    this.storageKey = config?.storageKey?.trim() || DEFAULT_SEARCH_HISTORY_KEY;
+    this.maxEntries = resolveMaxEntries(config?.maxEntries);
+  }
+
+  record(query: string): void {
+    if (!this.enabled) return;
+
+    const normalized = query.trim();
+    if (!normalized) return;
+
+    this.ensureLoaded();
+    this.entries = [normalized, ...this.entries.filter((entry) => entry !== normalized)].slice(
+      0,
+      this.maxEntries
+    );
+    this.resetCursor();
+    this.save();
+  }
+
+  recall(direction: SearchHistoryDirection, currentValue: string): string | null {
+    if (!this.enabled) return null;
+
+    this.ensureLoaded();
+    if (this.entries.length === 0) return null;
+
+    if (direction === "previous") {
+      if (this.cursor === null) {
+        this.draft = currentValue;
+        this.cursor = 0;
+      } else if (this.cursor < this.entries.length - 1) {
+        this.cursor += 1;
+      }
+
+      return this.entries[this.cursor];
+    }
+
+    if (this.cursor === null) return null;
+
+    if (this.cursor > 0) {
+      this.cursor -= 1;
+      return this.entries[this.cursor];
+    }
+
+    const draft = this.draft;
+    this.resetCursor();
+    return draft;
+  }
+
+  resetCursor(): void {
+    this.cursor = null;
+    this.draft = "";
+  }
+
+  private ensureLoaded(): void {
+    if (this.loaded) return;
+
+    this.loaded = true;
+    if (!this.storage) return;
+
+    let raw: string | null;
+    try {
+      raw = this.storage.getItem(this.storageKey);
+    } catch {
+      this.entries = [];
+      return;
+    }
+
+    if (!raw) {
+      this.entries = [];
+      return;
+    }
+
+    try {
+      this.entries = normalizeHistoryEntries(JSON.parse(raw), this.maxEntries);
+    } catch {
+      this.entries = [];
+    }
+  }
+
+  private save(): void {
+    if (!this.storage) return;
+
+    try {
+      this.storage.setItem(this.storageKey, JSON.stringify(this.entries));
+    } catch {
+      // Host storage is optional; search behavior should continue if it fails.
+    }
+  }
+}
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -325,6 +476,7 @@ class NexusSearchPanel implements Panel {
   private readonly regexpField: HTMLInputElement;
   private readonly wholeWordField: HTMLInputElement;
   private readonly labels: SearchPluginLabels;
+  private readonly history: SearchHistoryController;
   private readonly replaceRow?: HTMLDivElement;
   private readonly replaceToggle?: IconButtonElements;
   private replaceExpanded = false;
@@ -332,11 +484,13 @@ class NexusSearchPanel implements Panel {
   constructor(
     private readonly view: EditorView,
     readonly top: boolean,
-    labels: Partial<SearchPluginLabels> | undefined
+    labels: Partial<SearchPluginLabels> | undefined,
+    history: SearchHistoryController
   ) {
     this.query = getSearchQuery(view.state);
     const resolvedLabels = resolveLabels(view, labels);
     this.labels = resolvedLabels;
+    this.history = history;
 
     this.searchField = this.createTextField(
       "markdown-search-input",
@@ -376,10 +530,14 @@ class NexusSearchPanel implements Panel {
     navigationGroup.className = "nexus-search-button-group";
     navigationGroup.append(
       createIconButton("markdown-search-prev", "prev", resolvedLabels.previous, "previous", () =>
-        findPrevious(view)
+        this.submitSearch(() => findPrevious(view))
       ),
-      createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () => findNext(view)),
-      createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () => selectMatches(view))
+      createIconButton("markdown-search-next", "next", resolvedLabels.next, "next", () =>
+        this.submitSearch(() => findNext(view))
+      ),
+      createIconButton("markdown-search-all", "select", resolvedLabels.all, "all", () =>
+        this.submitSearch(() => selectMatches(view))
+      )
     );
 
     const searchRowChildren: HTMLElement[] = [
@@ -457,8 +615,14 @@ class NexusSearchPanel implements Panel {
     if (mainField) {
       input.setAttribute("main-field", "true");
     }
-    input.addEventListener("input", () => this.commit());
-    input.addEventListener("change", () => this.commit());
+    input.addEventListener("input", () => {
+      if (mainField) this.history.resetCursor();
+      this.commit();
+    });
+    input.addEventListener("change", () => {
+      if (mainField) this.history.resetCursor();
+      this.commit();
+    });
     input.addEventListener("keyup", () => this.commit());
     return input;
   }
@@ -489,6 +653,12 @@ class NexusSearchPanel implements Panel {
     }
   }
 
+  private submitSearch(runSearchCommand: () => void): void {
+    this.commit();
+    this.history.record(this.searchField.value);
+    runSearchCommand();
+  }
+
   private setReplaceExpanded(expanded: boolean, focusReplace = false): void {
     if (!this.replaceRow || !this.replaceToggle) return;
 
@@ -505,6 +675,10 @@ class NexusSearchPanel implements Panel {
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
+    if (this.handleHistoryKeyDown(event)) {
+      return;
+    }
+
     if (runScopeHandlers(this.view, event, "search-panel")) {
       event.preventDefault();
       return;
@@ -512,8 +686,7 @@ class NexusSearchPanel implements Panel {
 
     if (event.key === "Enter" && event.target === this.searchField) {
       event.preventDefault();
-      this.commit();
-      (event.shiftKey ? findPrevious : findNext)(this.view);
+      this.submitSearch(() => (event.shiftKey ? findPrevious : findNext)(this.view));
       return;
     }
 
@@ -522,6 +695,23 @@ class NexusSearchPanel implements Panel {
       this.commit();
       replaceNext(this.view);
     }
+  }
+
+  private handleHistoryKeyDown(event: KeyboardEvent): boolean {
+    if (event.target !== this.searchField || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) {
+      return false;
+    }
+
+    const recalled = this.history.recall(
+      event.key === "ArrowUp" ? "previous" : "next",
+      this.searchField.value
+    );
+    if (recalled === null) return false;
+
+    event.preventDefault();
+    this.searchField.value = recalled;
+    this.commit();
+    return true;
   }
 
   private setQuery(query: SearchQuery): void {
@@ -535,12 +725,13 @@ class NexusSearchPanel implements Panel {
 }
 
 export function createSearchPlugin(options: SearchPluginOptions = {}): NexusPlugin {
+  const history = new SearchHistoryController(options.history);
   const cmExtensions = [
     search({
       top: options.top ?? true,
       caseSensitive: options.caseSensitive ?? false,
       literal: true,
-      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels)
+      createPanel: (view) => new NexusSearchPanel(view, options.top ?? true, options.labels, history)
     }),
     keymap.of(searchKeymap)
   ];

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -1,10 +1,170 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createEditor } from "@floatboat/nexus-core";
 import {
   createSearchPlugin,
   findSearchMatches,
   replaceAllMatches
 } from "../src/index";
+
+const HISTORY_KEY = "nexus:test-search-history";
+
+function createEmptyRect(): DOMRect {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  };
+}
+
+function createRectList(): DOMRectList {
+  const rect = createEmptyRect();
+  return {
+    0: rect,
+    length: 1,
+    item: (index: number) => (index === 0 ? rect : null),
+    [Symbol.iterator]: function* () {
+      yield rect;
+    }
+  } as DOMRectList;
+}
+
+if (typeof Range !== "undefined" && !Range.prototype.getClientRects) {
+  Object.defineProperty(Range.prototype, "getClientRects", {
+    configurable: true,
+    value: () => createRectList()
+  });
+}
+
+if (typeof Range !== "undefined" && !Range.prototype.getBoundingClientRect) {
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => createEmptyRect()
+  });
+}
+
+interface MemoryHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  readHistory(): string[];
+  readRaw(): string | null;
+}
+
+function createMemoryHistoryStorage(initialRaw?: string): MemoryHistoryStorage {
+  const values = new Map<string, string>();
+  if (initialRaw !== undefined) {
+    values.set(HISTORY_KEY, initialRaw);
+  }
+
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    readHistory() {
+      const raw = values.get(HISTORY_KEY);
+      return raw ? JSON.parse(raw) : [];
+    },
+    readRaw() {
+      return values.get(HISTORY_KEY) ?? null;
+    }
+  };
+}
+
+function historyOptions(
+  options: {
+    storage?: Pick<MemoryHistoryStorage, "getItem" | "setItem">;
+    maxEntries?: number;
+  } = {}
+): Parameters<typeof createSearchPlugin>[0] {
+  return {
+    history: {
+      storage: options.storage,
+      storageKey: HISTORY_KEY,
+      maxEntries: options.maxEntries
+    }
+  } as Parameters<typeof createSearchPlugin>[0];
+}
+
+function openSearchPanel(container: HTMLElement): HTMLInputElement {
+  const content = container.querySelector<HTMLElement>(".cm-content");
+  expect(content).not.toBeNull();
+
+  content?.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "f",
+      code: "KeyF",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+  );
+  if (!container.querySelector('[data-test-id="markdown-search-bar"]')) {
+    content?.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+    );
+  }
+
+  const input = container.querySelector<HTMLInputElement>('[data-test-id="markdown-search-input"]');
+  expect(input).not.toBeNull();
+  return input!;
+}
+
+function setupSearchPanel(options: Parameters<typeof createSearchPlugin>[0] = {}) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const editor = createEditor({
+    container,
+    initialValue: "alpha beta gamma alpha",
+    plugins: [createSearchPlugin(options)]
+  });
+  const input = openSearchPanel(container);
+
+  return {
+    editor,
+    container,
+    input,
+    destroy() {
+      editor.destroy();
+      container.remove();
+    }
+  };
+}
+
+function submitSearch(input: HTMLInputElement, value: string): KeyboardEvent {
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+  const event = new KeyboardEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    bubbles: true,
+    cancelable: true
+  });
+  input.dispatchEvent(event);
+  return event;
+}
+
+function pressInputArrow(input: HTMLInputElement, key: "ArrowUp" | "ArrowDown"): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    code: key,
+    bubbles: true,
+    cancelable: true
+  });
+  input.dispatchEvent(event);
+  return event;
+}
 
 describe("@floatboat/nexus-plugin-search", () => {
   it("finds all case-insensitive matches in a document", () => {
@@ -166,6 +326,188 @@ describe("@floatboat/nexus-plugin-search", () => {
 
     editor.destroy();
     container.remove();
+  });
+
+  it("keeps existing Enter navigation when search history is disabled", () => {
+    const harness = setupSearchPanel({ history: false } as Parameters<typeof createSearchPlugin>[0]);
+
+    submitSearch(harness.input, "beta");
+
+    const selection = harness.editor.getSelection();
+    expect(Math.min(selection.anchor, selection.head)).toBe(6);
+    expect(Math.max(selection.anchor, selection.head)).toBe(10);
+
+    harness.destroy();
+  });
+
+  it("records submitted queries after trimming whitespace", () => {
+    const storage = createMemoryHistoryStorage();
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    submitSearch(harness.input, "  alpha  ");
+
+    expect(storage.readHistory()).toEqual(["alpha"]);
+
+    harness.destroy();
+  });
+
+  it("does not record blank submitted queries", () => {
+    const storage = createMemoryHistoryStorage(JSON.stringify(["alpha"]));
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    submitSearch(harness.input, "   ");
+
+    expect(storage.readRaw()).toBe(JSON.stringify(["alpha"]));
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    harness.destroy();
+  });
+
+  it("deduplicates repeated queries and moves the newest submission to the front", () => {
+    const storage = createMemoryHistoryStorage(JSON.stringify(["beta", "alpha"]));
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    submitSearch(harness.input, "alpha");
+
+    expect(storage.readHistory()).toEqual(["alpha", "beta"]);
+
+    harness.destroy();
+  });
+
+  it("drops the oldest query when maxEntries is exceeded", () => {
+    const storage = createMemoryHistoryStorage();
+    const harness = setupSearchPanel(historyOptions({ storage, maxEntries: 2 }));
+
+    submitSearch(harness.input, "alpha");
+    submitSearch(harness.input, "beta");
+    submitSearch(harness.input, "gamma");
+
+    expect(storage.readHistory()).toEqual(["gamma", "beta"]);
+
+    harness.destroy();
+  });
+
+  it("ignores invalid stored JSON and continues writing new history", () => {
+    const storage = createMemoryHistoryStorage("not json");
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    expect(() => submitSearch(harness.input, "alpha")).not.toThrow();
+    expect(storage.readRaw()).toBe(JSON.stringify(["alpha"]));
+
+    harness.destroy();
+  });
+
+  it("does not crash when history storage getItem throws", () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error("read failed");
+      }),
+      setItem: vi.fn()
+    };
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    expect(() => pressInputArrow(harness.input, "ArrowUp")).not.toThrow();
+    expect(storage.getItem).toHaveBeenCalledWith(HISTORY_KEY);
+    expect(() => submitSearch(harness.input, "beta")).not.toThrow();
+    const selection = harness.editor.getSelection();
+    expect(Math.min(selection.anchor, selection.head)).toBe(6);
+    expect(Math.max(selection.anchor, selection.head)).toBe(10);
+
+    harness.destroy();
+  });
+
+  it("does not crash when history storage setItem throws", () => {
+    const storage = {
+      getItem: vi.fn(() => "[]"),
+      setItem: vi.fn(() => {
+        throw new Error("write failed");
+      })
+    };
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    expect(() => submitSearch(harness.input, "beta")).not.toThrow();
+    expect(storage.setItem).toHaveBeenCalled();
+    const selection = harness.editor.getSelection();
+    expect(Math.min(selection.anchor, selection.head)).toBe(6);
+    expect(Math.max(selection.anchor, selection.head)).toBe(10);
+
+    harness.destroy();
+  });
+
+  it("recalls search history with ArrowUp and ArrowDown in the search input", () => {
+    const storage = createMemoryHistoryStorage(JSON.stringify(["gamma", "beta", "alpha"]));
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    pressInputArrow(harness.input, "ArrowUp");
+    expect(harness.input.value).toBe("gamma");
+
+    pressInputArrow(harness.input, "ArrowUp");
+    expect(harness.input.value).toBe("beta");
+
+    pressInputArrow(harness.input, "ArrowDown");
+    expect(harness.input.value).toBe("gamma");
+
+    harness.destroy();
+  });
+
+  it("does not swallow ArrowUp or ArrowDown when search history is empty", () => {
+    const storage = createMemoryHistoryStorage(JSON.stringify([]));
+    const harness = setupSearchPanel(historyOptions({ storage }));
+
+    const up = pressInputArrow(harness.input, "ArrowUp");
+    const down = pressInputArrow(harness.input, "ArrowDown");
+
+    expect(up.defaultPrevented).toBe(false);
+    expect(down.defaultPrevented).toBe(false);
+
+    harness.destroy();
+  });
+
+  it("does not swallow ArrowUp or ArrowDown when search history is disabled", () => {
+    const harness = setupSearchPanel({ history: false } as Parameters<typeof createSearchPlugin>[0]);
+
+    const up = pressInputArrow(harness.input, "ArrowUp");
+    const down = pressInputArrow(harness.input, "ArrowDown");
+
+    expect(up.defaultPrevented).toBe(false);
+    expect(down.defaultPrevented).toBe(false);
+
+    harness.destroy();
+  });
+
+  it("recalls history without changing case, regexp, or whole-word options", () => {
+    const storage = createMemoryHistoryStorage(JSON.stringify(["alpha"]));
+    const harness = setupSearchPanel(historyOptions({ storage }));
+    const caseField = harness.container.querySelector<HTMLInputElement>(
+      '[data-test-id="markdown-search-case-toggle"]'
+    );
+    const regexpField = harness.container.querySelector<HTMLInputElement>(
+      '[data-test-id="markdown-search-regexp-toggle"]'
+    );
+    const wholeWordField = harness.container.querySelector<HTMLInputElement>(
+      '[data-test-id="markdown-search-word-toggle"]'
+    );
+    expect(caseField).not.toBeNull();
+    expect(regexpField).not.toBeNull();
+    expect(wholeWordField).not.toBeNull();
+
+    caseField!.checked = true;
+    regexpField!.checked = true;
+    wholeWordField!.checked = true;
+    caseField!.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+    regexpField!.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+    wholeWordField!.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+    harness.input.value = "draft";
+    harness.input.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+
+    pressInputArrow(harness.input, "ArrowUp");
+
+    expect(harness.input.value).toBe("alpha");
+    expect(caseField!.checked).toBe(true);
+    expect(regexpField!.checked).toBe(true);
+    expect(wholeWordField!.checked).toBe(true);
+
+    harness.destroy();
   });
 
   it("falls back to default tooltip labels when localized labels are blank", () => {


### PR DESCRIPTION
## Summary / 摘要

Adds the first-stage implementation for Roadmap item 16, **Command / search history**, by introducing opt-in search query history for the search plugin.

This PR intentionally covers only the `plugin-search` side of Roadmap item 16. Slash command history and persisted recently-used slash command ordering are left as follow-up work so that this PR stays focused and reviewable.

## Motivation / 背景与动机

* Issue: N/A
* Roadmap (`docs/ROADMAP.md`): Roadmap item 16, `Command / search history`
* OpenSpec change: `openspec/changes/add-search-query-history`

Search history is useful for repeated find/replace workflows, but it should not be forced on every host application. Search queries may contain document-specific or sensitive content, so persistence should be opt-in and host-controlled instead of implicitly writing to global `localStorage`.

This change adds a low-intrusion history layer to `plugin-search` while preserving the existing default behavior of `createSearchPlugin()`.

## Changes / 变更内容

* `packages/core`:

  * No changes.

* `packages/plugin-*`:

  * `packages/plugin-search`:

    * Add `history?: boolean | SearchHistoryOptions` to `createSearchPlugin()`.
    * Keep `createSearchPlugin()` fully backward-compatible when history is not enabled.
    * Support in-memory query history with `history: true`.
    * Support host-injected localStorage-like persistence through an explicit `storage` option.
    * Avoid implicit writes to global `localStorage`.
    * Record submitted non-empty queries after trimming whitespace.
    * De-duplicate repeated queries by moving the newest submission to the front.
    * Respect configurable `maxEntries`.
    * Safely recover from invalid stored JSON.
    * Safely handle storage `getItem` / `setItem` failures without breaking search.
    * Add ArrowUp / ArrowDown query recall in the search input.
    * Avoid swallowing ArrowUp / ArrowDown when history is disabled or empty.
    * Preserve existing search options such as case-sensitive, regexp, and whole-word matching during recall.
  * `packages/plugin-slash`:

    * No changes. Slash command history remains follow-up work.

* `apps/electron-demo`:

  * No changes.

* `openspec/`:

  * Add `openspec/changes/add-search-query-history`.
  * Document this PR as the `plugin-search` first slice of Roadmap item 16.
  * Keep `plugin-slash` command history as a non-goal / follow-up for this PR.

## Testing / 测试

* [x] Affected package Vitest suite:

  * `pnpm exec vitest run packages/plugin-search/test/plugin-search.test.ts`
  * Passed: `19/19`

* [x] Type check:

  * `pnpm typecheck`
  * Passed

* [x] Build:

  * `pnpm build`
  * Passed

* [x] Diff check:

  * `git diff --check`
  * Passed, with only Git LF-to-CRLF warnings

* [ ] Full test suite:

  * `pnpm test`
  * Current result: fails only in `apps/electron-demo/test/sample-vault.test.ts`
  * The failing assertions are sample-vault / path separator fixture assertions on Windows, such as `/` vs `\` path mismatches.
  * This PR does not modify `apps/electron-demo/**`.
  * The targeted `plugin-search` test suite passes.

* [ ] OpenSpec CLI validation:

  * `pnpm exec openspec validate add-search-query-history --strict`
  * Could not run because the `openspec` command is not available in this workspace.

* [ ] Manual UI check in electron-demo:

  * Not performed. The change is covered by focused `plugin-search` UI behavior tests.

## Checklist / 自检清单

* [x] Title follows Conventional Commits.
* [x] Public API changes update types.
* [x] New capability is covered by OpenSpec proposal.
* [x] Added focused Vitest coverage for the affected plugin.
* [x] Default behavior remains backward-compatible when `history` is disabled.
* [x] No implicit writes to global `localStorage`.
* [x] No changes to `packages/plugin-slash/**`.
* [x] No changes to `apps/electron-demo/**`.
* [x] No secrets or personal vault data committed.
* [x] Did not touch `packages/core/src/live-preview-table.ts`.

## Screenshots / Recordings · 截图或录屏

N/A. This change adds search panel behavior covered by Vitest interaction tests.
