### PR TITLE
feat(slash): add opt-in recent command ordering

### DIFF
--- a/openspec/changes/add-slash-recent-command-history/proposal.md
+++ b/openspec/changes/add-slash-recent-command-history/proposal.md
@@ -1,0 +1,39 @@
+# Change: Add Opt-In Slash Recent Command Ordering
+
+## Why
+
+Roadmap item 16 covers command and search history across separate packages. PR 71 delivered the independent first-stage `plugin-search` search query history work; this change is the `plugin-slash` follow-up and intentionally stays independent from that implementation.
+
+Slash menus should not restore prior `/query` text. For `plugin-slash`, the useful history behavior is to remember commands the user actually confirmed and, when explicitly enabled, show recently used commands earlier the next time the slash menu opens.
+
+## What Changes
+
+- Add an opt-in recently-used command ordering mode to `plugin-slash`.
+- Enable history with a minimal `history: true` flag or a `history: { storage, storageKey, maxEntries }` options object; omitting history or passing `false` keeps it disabled.
+- Record confirmed slash command ids, dedupe repeated ids to the front, and cap the stored list with `maxEntries`.
+- Reorder empty-query slash menu results by recent command usage when history is enabled.
+- Support session-only history when enabled without storage.
+- Support optional host-injected localStorage-like storage for persistence.
+- Ignore invalid stored JSON, storage read/write failures, and stale or unknown command ids without breaking the menu.
+- Keep disabled/default behavior fully backward compatible: registration order, keyboard navigation, Enter confirm, and click confirm remain unchanged.
+
+## Non-Goals
+
+- No slash query history and no `/query` input recall.
+- No core-level slash ranking refactor.
+- No `plugin-search` changes; PR 71 remains independent.
+- No electron demo changes.
+- No global `localStorage` writes by default.
+- No new dependencies.
+
+## Impact
+
+- Affected specs: `plugins`
+- Affected code expected in a future implementation phase:
+  - `packages/plugin-slash/src/menu-ui.ts`
+  - `packages/plugin-slash/src/index.ts` only for public type/export surface if needed
+  - `packages/plugin-slash/test/menu-ui.test.ts`
+- Explicitly out of scope:
+  - `packages/plugin-search/**`
+  - `apps/electron-demo/**`
+  - `packages/core/**`

--- a/openspec/changes/add-slash-recent-command-history/specs/plugins/spec.md
+++ b/openspec/changes/add-slash-recent-command-history/specs/plugins/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Slash Recent Command History Is Opt-In
+
+`plugin-slash` SHALL keep recently-used slash command ordering disabled by default. Hosts MUST explicitly enable slash command history before the menu may record command confirmations or reorder commands by recency. History MAY be enabled with a boolean `true` flag for session-only ordering or with an options object for host-injected storage settings; omitting history or passing `false` SHALL keep history disabled.
+
+#### Scenario: Default menu order remains registration order
+- **WHEN** a host creates the slash menu without history options
+- **AND** the slash menu opens for an empty query
+- **THEN** commands SHALL render in the same order supplied by the editor state
+- **AND** no command history SHALL be recorded when a command is confirmed
+
+#### Scenario: Enabled menu may reorder by command recency
+- **WHEN** a host explicitly enables slash command history
+- **AND** the user confirms a slash command
+- **THEN** subsequent empty-query slash menus MAY place that command before commands without more recent usage
+
+### Requirement: Slash History Tracks Commands, Not Queries
+
+`plugin-slash` history SHALL record confirmed slash command ids only. It MUST NOT store slash query strings and MUST NOT restore prior `/query` input when the menu opens.
+
+#### Scenario: Query text is not recalled
+- **WHEN** history is enabled
+- **AND** the user types `/hea` and confirms the `heading` command
+- **THEN** the stored history SHALL contain the confirmed command id
+- **AND** opening a later slash menu SHALL NOT restore `hea` or any previous slash query text
+
+### Requirement: Disabled History Preserves Existing Interaction Semantics
+
+When history is disabled, `plugin-slash` SHALL preserve existing menu ordering and interaction behavior for keyboard navigation, Enter confirmation, and click confirmation.
+
+#### Scenario: Keyboard behavior is unchanged when disabled
+- **WHEN** history is disabled
+- **AND** the slash menu opens with commands `[a, b, c]`
+- **THEN** `ArrowDown` SHALL move the highlight from `a` to `b`
+- **AND** `ArrowUp` from `a` SHALL wrap to `c`
+- **AND** `Enter` SHALL confirm the highlighted command from the original rendered order
+
+#### Scenario: Click behavior is unchanged when disabled
+- **WHEN** history is disabled
+- **AND** the slash menu renders commands `[a, b, c]`
+- **THEN** clicking the rendered `b` item SHALL confirm command `b`
+
+### Requirement: Recent Ordering Applies To Empty Query Menus
+
+When history is enabled, `plugin-slash` SHALL apply recently-used command ordering to empty-query menus. Commands with more recent usage SHALL appear before commands without more recent usage, while commands not present in history SHALL retain their existing relative order.
+
+#### Scenario: Recently confirmed command moves to front
+- **WHEN** history is enabled
+- **AND** the menu opens for an empty query with commands `[a, b, c]`
+- **AND** the user confirms command `c`
+- **THEN** the next empty-query menu SHALL render `[c, a, b]`
+
+#### Scenario: Non-history commands keep relative order
+- **WHEN** stored history contains `[c]`
+- **AND** the empty-query command list is `[a, b, c, d]`
+- **THEN** the rendered order SHALL be `[c, a, b, d]`
+
+### Requirement: Reordered Menus Confirm The Rendered Active Command
+
+When history reorders visible commands, `plugin-slash` SHALL keep the rendered command list, highlight state, Enter confirmation, and click confirmation aligned. Confirmation MUST execute the command represented by the currently highlighted or clicked rendered item, not a command from the same index in the original editor state order.
+
+#### Scenario: Enter confirms reordered active item
+- **WHEN** history is enabled and orders commands as `[c, a, b]`
+- **AND** the user presses `Enter` while `c` is highlighted
+- **THEN** command `c` SHALL be confirmed
+- **AND** command `a` SHALL NOT be confirmed because it occupied index `0` in the original command list
+
+#### Scenario: Click confirms clicked reordered item
+- **WHEN** history is enabled and renders commands as `[c, a, b]`
+- **AND** the user clicks the rendered `a` item
+- **THEN** command `a` SHALL be confirmed
+- **AND** command `b` SHALL NOT be confirmed because it occupied the same original index before reordering
+
+### Requirement: Host-Injected Storage Only
+
+Persistent slash command history SHALL use only a host-injected localStorage-like storage object. `plugin-slash` MUST NOT write to global `localStorage` by default.
+
+#### Scenario: Enabled history without storage is session-only
+- **WHEN** history is enabled without a storage object
+- **AND** the user confirms command `b`
+- **THEN** the current menu instance SHALL be able to prioritize `b` during the same session
+- **AND** no global `localStorage` write SHALL occur
+
+#### Scenario: Explicit storage seeds command ordering
+- **WHEN** history is enabled with host-injected storage
+- **AND** storage contains command ids `["c", "a"]`
+- **THEN** an empty-query menu with commands `[a, b, c]` SHALL render `[c, a, b]`
+
+### Requirement: Storage Failures Are Non-Fatal
+
+`plugin-slash` SHALL treat storage as best-effort. Invalid JSON, `getItem` exceptions, and `setItem` exceptions MUST NOT throw out of menu open, render, navigation, or confirmation paths.
+
+#### Scenario: Invalid JSON is ignored
+- **WHEN** history is enabled with storage
+- **AND** the stored history value is invalid JSON
+- **THEN** opening the slash menu SHALL NOT throw
+- **AND** later confirming a command SHALL be able to write a valid history value if storage accepts writes
+
+#### Scenario: getItem throw is ignored
+- **WHEN** history is enabled with storage whose `getItem` throws
+- **THEN** opening the slash menu SHALL NOT throw
+- **AND** the menu SHALL render commands using normal non-history ordering
+
+#### Scenario: setItem throw is ignored
+- **WHEN** history is enabled with storage whose `setItem` throws
+- **AND** the user confirms a command
+- **THEN** confirmation SHALL NOT throw
+- **AND** the command SHALL still execute through the normal confirmation path
+
+### Requirement: Unknown Command Ids Are Ignored
+
+When applying stored or session command history, `plugin-slash` SHALL ignore command ids that are not present in the current visible command list.
+
+#### Scenario: Stale command ids do not render phantom items
+- **WHEN** stored history contains `["removed", "c"]`
+- **AND** the current empty-query command list is `[a, b, c]`
+- **THEN** the rendered order SHALL be `[c, a, b]`
+- **AND** no item for `removed` SHALL be rendered
+
+### Requirement: History Dedupes To Front And Supports maxEntries
+
+When command history records a confirmed command id, it SHALL remove any existing occurrence of that id, insert it at the front, and trim the stored list to `maxEntries`.
+
+#### Scenario: Repeated command moves to front once
+- **WHEN** current history is `["b", "c", "a"]`
+- **AND** the user confirms command `c`
+- **THEN** history SHALL become `["c", "b", "a"]`
+- **AND** `c` SHALL appear only once
+
+#### Scenario: maxEntries trims older ids
+- **WHEN** `maxEntries` is `2`
+- **AND** current history is `["b", "a"]`
+- **AND** the user confirms command `c`
+- **THEN** history SHALL become `["c", "b"]`
+- **AND** command `a` SHALL be dropped from history

--- a/openspec/changes/add-slash-recent-command-history/tasks.md
+++ b/openspec/changes/add-slash-recent-command-history/tasks.md
@@ -1,0 +1,18 @@
+# Implementation Tasks
+
+## 1. Phase 1 - OpenSpec and Red Tests
+
+- [x] 1.1 Create `openspec/changes/add-slash-recent-command-history/proposal.md`.
+- [x] 1.2 Create `openspec/changes/add-slash-recent-command-history/specs/plugins/spec.md`.
+- [x] 1.3 Add failing `plugin-slash` tests for opt-in recently-used command ordering.
+- [x] 1.4 Run the targeted `plugin-slash` menu UI test and confirm failures are limited to the unimplemented history behavior.
+
+## 2. Future Implementation
+
+- [x] 2.1 Add opt-in `plugin-slash` menu history options without changing default behavior.
+- [x] 2.2 Track recently confirmed slash command ids in session memory when history is enabled.
+- [x] 2.3 Read and write optional host-injected localStorage-like storage defensively.
+- [x] 2.4 Reorder visible commands for empty-query menus while keeping highlight, Enter confirm, and click confirm aligned with the rendered order.
+- [x] 2.5 Ignore stale or unknown command ids and enforce dedupe-to-front plus `maxEntries`.
+- [x] 2.6 Keep `packages/plugin-search/**`, `apps/electron-demo/**`, and `packages/core/**` unchanged.
+- [x] 2.7 Re-run the targeted `plugin-slash` tests and ensure the new red tests pass without regressing existing behavior.

--- a/packages/plugin-slash/src/command-history.ts
+++ b/packages/plugin-slash/src/command-history.ts
@@ -1,0 +1,119 @@
+import type { SlashCommandDef } from "@floatboat/nexus-core";
+
+export interface SlashCommandHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface SlashCommandHistoryOptions {
+  storage?: SlashCommandHistoryStorage;
+  storageKey?: string;
+  maxEntries?: number;
+}
+
+export type SlashCommandHistoryConfig = boolean | SlashCommandHistoryOptions;
+
+export const DEFAULT_SLASH_COMMAND_HISTORY_KEY = "nexus.slash.commandHistory";
+const DEFAULT_MAX_ENTRIES = 20;
+
+export interface SlashCommandHistoryController {
+  reorder(commands: SlashCommandDef[], query: string): SlashCommandDef[];
+  record(commandId: string): void;
+}
+
+function normalizeMaxEntries(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_MAX_ENTRIES;
+  if (!Number.isFinite(value)) return DEFAULT_MAX_ENTRIES;
+  return Math.max(0, Math.floor(value));
+}
+
+function normalizeHistory(raw: unknown, maxEntries: number): string[] {
+  if (!Array.isArray(raw) || maxEntries <= 0) return [];
+
+  const seen = new Set<string>();
+  const entries: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") continue;
+    if (seen.has(item)) continue;
+    seen.add(item);
+    entries.push(item);
+    if (entries.length >= maxEntries) break;
+  }
+  return entries;
+}
+
+export function createSlashCommandHistory(
+  config: SlashCommandHistoryConfig | undefined
+): SlashCommandHistoryController | null {
+  if (!config) return null;
+
+  const options = typeof config === "boolean" ? {} : config;
+  const storage = options.storage;
+  const storageKey = options.storageKey ?? DEFAULT_SLASH_COMMAND_HISTORY_KEY;
+  const maxEntries = normalizeMaxEntries(options.maxEntries);
+
+  let loaded = false;
+  let history: string[] = [];
+
+  function load(): void {
+    if (loaded) return;
+    loaded = true;
+    if (!storage) return;
+
+    try {
+      const value = storage.getItem(storageKey);
+      if (value === null) return;
+      history = normalizeHistory(JSON.parse(value), maxEntries);
+    } catch {
+      history = [];
+    }
+  }
+
+  function save(): void {
+    if (!storage) return;
+
+    try {
+      storage.setItem(storageKey, JSON.stringify(history));
+    } catch {
+      // Storage is best-effort; command execution must continue.
+    }
+  }
+
+  return {
+    reorder(commands: SlashCommandDef[], query: string): SlashCommandDef[] {
+      if (query !== "") return commands;
+
+      load();
+      if (history.length === 0) return commands;
+
+      const byId = new Map<string, SlashCommandDef>();
+      for (const command of commands) {
+        if (!byId.has(command.id)) byId.set(command.id, command);
+      }
+
+      const used = new Set<string>();
+      const recent: SlashCommandDef[] = [];
+      for (const id of history) {
+        const command = byId.get(id);
+        if (!command || used.has(id)) continue;
+        recent.push(command);
+        used.add(id);
+      }
+
+      if (recent.length === 0) return commands;
+      return recent.concat(commands.filter((command) => !used.has(command.id)));
+    },
+
+    record(commandId: string): void {
+      if (maxEntries <= 0) return;
+
+      load();
+      history = [commandId, ...history.filter((id) => id !== commandId)].slice(
+        0,
+        maxEntries
+      );
+      save();
+    },
+  };
+}

--- a/packages/plugin-slash/src/index.ts
+++ b/packages/plugin-slash/src/index.ts
@@ -42,4 +42,7 @@ export {
   type SlashMenuUI,
   type SlashMenuUIOptions,
   type SlashMenuCommandContext,
+  type SlashCommandHistoryConfig,
+  type SlashCommandHistoryOptions,
+  type SlashCommandHistoryStorage,
 } from "./menu-ui";

--- a/packages/plugin-slash/src/menu-ui.ts
+++ b/packages/plugin-slash/src/menu-ui.ts
@@ -1,4 +1,16 @@
 import type { EditorAPI, SlashCommandDef, SlashMenuState } from "@floatboat/nexus-core";
+import {
+  createSlashCommandHistory,
+  type SlashCommandHistoryConfig,
+  type SlashCommandHistoryOptions,
+  type SlashCommandHistoryStorage,
+} from "./command-history";
+
+export type {
+  SlashCommandHistoryConfig,
+  SlashCommandHistoryOptions,
+  SlashCommandHistoryStorage,
+};
 
 export interface SlashMenuCommandContext {
   /**
@@ -43,6 +55,11 @@ export interface SlashMenuUIOptions {
    * the menu opens below the caret. Default: `4`.
    */
   offset?: number;
+  /**
+   * Opt-in recently-used command ordering. `true` enables session-only
+   * history; an options object may provide host-injected storage.
+   */
+  history?: SlashCommandHistoryConfig;
 }
 
 export interface SlashMenuUI {
@@ -73,6 +90,7 @@ export function createSlashMenuUI(
   const offset = options.offset ?? DEFAULT_OFFSET;
   const container = options.container ?? document.body;
   const menuId = generateId(prefix);
+  const commandHistory = createSlashCommandHistory(options.history);
 
   // ── DOM scaffolding ──────────────────────────────────────────────
   const root = document.createElement("div");
@@ -90,6 +108,7 @@ export function createSlashMenuUI(
 
   // ── Mutable state ────────────────────────────────────────────────
   let currentState: SlashMenuState | null = null;
+  let visibleCommands: SlashCommandDef[] = [];
   let highlight = 0;
   // Items reused across renders to keep CSS transitions / focus rings
   // stable (rebuilding the list every keystroke would flicker active
@@ -240,7 +259,10 @@ export function createSlashMenuUI(
 
   function show(): void {
     if (!currentState) return;
-    renderItems(currentState.commands);
+    visibleCommands = commandHistory
+      ? commandHistory.reorder(currentState.commands, currentState.query)
+      : currentState.commands;
+    renderItems(visibleCommands);
     applyHighlight();
     reposition();
   }
@@ -256,7 +278,7 @@ export function createSlashMenuUI(
 
   function confirm(): void {
     if (!isMenuOpen() || !currentState) return;
-    const cmds = currentState.commands;
+    const cmds = visibleCommands;
     if (cmds.length === 0 || highlight < 0 || highlight >= cmds.length) {
       // Nothing valid to run; treat as dismiss so a stray Enter doesn't
       // leave the menu visible.
@@ -286,7 +308,10 @@ export function createSlashMenuUI(
     // flash on slow paint paths.
     hide();
     currentState = null;
+    visibleCommands = [];
     prevIsOpen = false;
+
+    commandHistory?.record(cmd.id);
 
     if (options.onCommand) {
       options.onCommand(cmd, ctx);
@@ -310,6 +335,7 @@ export function createSlashMenuUI(
     currentState = state;
 
     if (!isMenuOpen()) {
+      visibleCommands = [];
       hide();
       return;
     }
@@ -335,7 +361,7 @@ export function createSlashMenuUI(
     if (!isMenuOpen()) return;
     if (isComposing) return;
 
-    const len = currentState?.commands.length ?? 0;
+    const len = visibleCommands.length;
 
     switch (e.key) {
       case "ArrowDown":
@@ -451,6 +477,7 @@ export function createSlashMenuUI(
       if (root.parentNode) root.parentNode.removeChild(root);
       itemEls = [];
       currentState = null;
+      visibleCommands = [];
     },
   };
 }

--- a/packages/plugin-slash/test/menu-ui.test.ts
+++ b/packages/plugin-slash/test/menu-ui.test.ts
@@ -51,6 +51,16 @@ function items(menu: SlashMenuUI): HTMLElement[] {
   );
 }
 
+function itemIds(menu: SlashMenuUI): string[] {
+  return items(menu).map((item) => item.dataset.slashCommandId ?? "");
+}
+
+function itemById(menu: SlashMenuUI, id: string): HTMLElement {
+  const item = items(menu).find((candidate) => candidate.dataset.slashCommandId === id);
+  if (!item) throw new Error(`Missing slash command item: ${id}`);
+  return item;
+}
+
 function activeItem(menu: SlashMenuUI): HTMLElement | null {
   return menu.element.querySelector<HTMLElement>(`.${PREFIX}-menu__item.is-active`);
 }
@@ -66,6 +76,43 @@ const baseCommands: SlashCommandDef[] = [
   { id: "h2", title: "Heading 2", keywords: ["h2"] },
   { id: "bold", title: "Bold", keywords: ["strong"] },
 ];
+
+interface SlashHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+type SlashHistoryOptions =
+  | boolean
+  | {
+      storage?: SlashHistoryStorage;
+      storageKey?: string;
+      maxEntries?: number;
+    };
+
+function withHistory(history: SlashHistoryOptions): Parameters<typeof createSlashMenuUI>[1] {
+  return { history } as unknown as Parameters<typeof createSlashMenuUI>[1];
+}
+
+function createMemoryStorage(initial: string | null = null) {
+  let value = initial;
+  return {
+    getItem: vi.fn((_key: string) => value),
+    setItem: vi.fn((_key: string, next: string) => {
+      value = next;
+    }),
+    get value() {
+      return value;
+    },
+  };
+}
+
+function lastStoredIds(storage: ReturnType<typeof createMemoryStorage>): string[] {
+  const calls = storage.setItem.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  return JSON.parse(lastCall?.[1] ?? "[]") as string[];
+}
 
 describe("createSlashMenuUI lifecycle", () => {
   let h: Harness;
@@ -301,6 +348,207 @@ describe("createSlashMenuUI command execution", () => {
     open(h.editor, "");
     items(h.menu)[2].dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
     expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+  });
+});
+
+describe("createSlashMenuUI recent command ordering", () => {
+  let h: Harness;
+  afterEach(() => h?.destroy());
+
+  it("keeps empty query order in registration order when history is disabled", () => {
+    h = setup(baseCommands);
+    open(h.editor, "");
+    expect(itemIds(h.menu)).toEqual(["h1", "h2", "bold"]);
+  });
+
+  it("moves a recently used command to the front for the current session when enabled without storage", () => {
+    h = setup(baseCommands, withHistory(true));
+
+    open(h.editor, "");
+    items(h.menu)[2].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    open(h.editor, "");
+
+    expect(itemIds(h.menu)).toEqual(["bold", "h1", "h2"]);
+  });
+
+  it("reads host-injected storage and reorders the empty query menu", () => {
+    const storage = createMemoryStorage(JSON.stringify(["bold", "h1"]));
+    h = setup(
+      baseCommands,
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    open(h.editor, "");
+
+    expect(storage.getItem).toHaveBeenCalledWith("test-slash-history");
+    expect(itemIds(h.menu)).toEqual(["bold", "h1", "h2"]);
+  });
+
+  it("writes confirmed commands to storage with dedupe-to-front and maxEntries", () => {
+    const storage = createMemoryStorage(JSON.stringify(["h2", "bold", "h1"]));
+    h = setup(
+      baseCommands,
+      withHistory({
+        storage,
+        storageKey: "test-slash-history",
+        maxEntries: 2,
+      })
+    );
+
+    open(h.editor, "");
+    itemById(h.menu, "bold").dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true })
+    );
+
+    expect(storage.setItem).toHaveBeenCalled();
+    expect(lastStoredIds(storage)).toEqual(["bold", "h2"]);
+  });
+
+  it("ignores unknown stored command ids", () => {
+    const storage = createMemoryStorage(JSON.stringify(["missing", "bold"]));
+    h = setup(
+      baseCommands,
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    open(h.editor, "");
+
+    expect(itemIds(h.menu)).toEqual(["bold", "h1", "h2"]);
+    expect(items(h.menu).some((item) => item.dataset.slashCommandId === "missing")).toBe(false);
+  });
+
+  it("ignores invalid JSON and later writes valid command history", () => {
+    const storage = createMemoryStorage("{not-json");
+    h = setup(
+      baseCommands,
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    expect(() => open(h.editor, "")).not.toThrow();
+    items(h.menu)[2].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(storage.setItem).toHaveBeenCalled();
+    expect(lastStoredIds(storage)).toEqual(["bold"]);
+  });
+
+  it("does not crash when storage getItem throws", () => {
+    const storage: SlashHistoryStorage = {
+      getItem: vi.fn(() => {
+        throw new Error("storage unavailable");
+      }),
+      setItem: vi.fn(),
+    };
+    h = setup(
+      baseCommands,
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    expect(() => open(h.editor, "")).not.toThrow();
+    expect(storage.getItem).toHaveBeenCalledWith("test-slash-history");
+    expect(itemIds(h.menu)).toEqual(["h1", "h2", "bold"]);
+  });
+
+  it("does not crash when storage setItem throws", () => {
+    const run = vi.fn();
+    const storage: SlashHistoryStorage = {
+      getItem: vi.fn(() => JSON.stringify([])),
+      setItem: vi.fn(() => {
+        throw new Error("storage full");
+      }),
+    };
+    h = setup([{ id: "bold", title: "Bold", run }], withHistory({
+      storage,
+      storageKey: "test-slash-history",
+    }));
+
+    open(h.editor, "");
+
+    expect(() => pressKey("Enter")).not.toThrow();
+    expect(storage.setItem).toHaveBeenCalledWith("test-slash-history", JSON.stringify(["bold"]));
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves ArrowUp and ArrowDown highlight through the reordered list", () => {
+    const storage = createMemoryStorage(JSON.stringify(["bold"]));
+    h = setup(
+      baseCommands,
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    open(h.editor, "");
+
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+    pressKey("ArrowDown");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("h1");
+    pressKey("ArrowUp");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("bold");
+  });
+
+  it("confirms the reordered active item with Enter", () => {
+    const h1Run = vi.fn();
+    const boldRun = vi.fn();
+    const storage = createMemoryStorage(JSON.stringify(["bold"]));
+    h = setup(
+      [
+        { id: "h1", title: "Heading 1", run: h1Run },
+        { id: "h2", title: "Heading 2" },
+        { id: "bold", title: "Bold", run: boldRun },
+      ],
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    open(h.editor, "");
+    pressKey("Enter");
+
+    expect(boldRun).toHaveBeenCalledTimes(1);
+    expect(h1Run).not.toHaveBeenCalled();
+  });
+
+  it("confirms the clicked reordered item", () => {
+    const h1Run = vi.fn();
+    const h2Run = vi.fn();
+    const boldRun = vi.fn();
+    const storage = createMemoryStorage(JSON.stringify(["bold"]));
+    h = setup(
+      [
+        { id: "h1", title: "Heading 1", run: h1Run },
+        { id: "h2", title: "Heading 2", run: h2Run },
+        { id: "bold", title: "Bold", run: boldRun },
+      ],
+      withHistory({ storage, storageKey: "test-slash-history" })
+    );
+
+    open(h.editor, "");
+    items(h.menu)[1].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(h1Run).toHaveBeenCalledTimes(1);
+    expect(h2Run).not.toHaveBeenCalled();
+    expect(boldRun).not.toHaveBeenCalled();
+  });
+
+  it("keeps keyboard and click behavior unchanged when history is disabled", () => {
+    const h1Run = vi.fn();
+    const h2Run = vi.fn();
+    const boldRun = vi.fn();
+    h = setup(
+      [
+        { id: "h1", title: "Heading 1", run: h1Run },
+        { id: "h2", title: "Heading 2", run: h2Run },
+        { id: "bold", title: "Bold", run: boldRun },
+      ],
+      withHistory(false)
+    );
+
+    open(h.editor, "");
+    pressKey("ArrowDown");
+    expect(activeItem(h.menu)?.dataset.slashCommandId).toBe("h2");
+    pressKey("Enter");
+    expect(h2Run).toHaveBeenCalledTimes(1);
+
+    open(h.editor, "");
+    items(h.menu)[2].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(boldRun).toHaveBeenCalledTimes(1);
+    expect(h1Run).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary / 摘要

Adds the `plugin-slash` follow-up for Roadmap item 16 by introducing opt-in recently-used slash command ordering.

This PR is independent from PR #71, which covers the `plugin-search` search query history slice. Together, the two PRs cover the search-history and command-history sides of Roadmap item 16 while keeping each change focused and reviewable.

## Motivation / 背景与动机

Slash commands are often reused during editing sessions. Bringing recently-used commands closer to the top can improve command discovery and repeated command execution, but it should not change the default command order for existing users.

This change adds a low-intrusion, opt-in recent command ordering layer to the slash menu UI. It does not implement slash query history and does not change core-level slash ranking.

## Changes / 变更内容

* `packages/plugin-slash`

  * Add `history?: boolean | SlashCommandHistoryOptions` to `createSlashMenuUI`.
  * Support `history: true` for session-only in-memory recent command ordering.
  * Support host-injected localStorage-like persistence through `history: { storage, storageKey, maxEntries }`.
  * Avoid implicit reads from or writes to global `localStorage`.
  * Record confirmed slash command ids.
  * De-duplicate repeated command ids by moving the newest confirmation to the front.
  * Respect configurable `maxEntries`.
  * Ignore stale or unknown command ids when reordering.
  * Safely recover from invalid stored JSON.
  * Safely handle storage `getItem` / `setItem` failures without breaking the slash menu.
  * Apply recently-used ordering only for empty-query slash menus.
  * Preserve existing non-empty query relevance ranking.
  * Keep render, highlight, Enter confirm, and click confirm aligned through a shared visible command list.

* `packages/core`

  * No changes.

* `packages/plugin-search`

  * No changes.

* `apps/electron-demo`

  * No changes.

* `openspec/`

  * Add `openspec/changes/add-slash-recent-command-history`.
  * Document this PR as the `plugin-slash` follow-up for Roadmap item 16.
  * Keep slash query history and core-level ranking refactors out of scope.

## Testing / 测试

* [x] Affected package Vitest suite:

  * `pnpm exec vitest run packages/plugin-slash/test/menu-ui.test.ts`
  * Passed: `39/39`

* [x] Type check:

  * `pnpm typecheck`
  * Passed

* [x] Build:

  * `pnpm build`
  * Passed

* [x] Diff check:

  * `git diff --check`
  * Passed, with only LF/CRLF warnings

* [ ] Full test suite:

  * `pnpm test`
  * Current result: fails only in existing `apps/electron-demo/test/sample-vault.test.ts` Windows path separator / fixture assertions.
  * This PR does not modify `apps/electron-demo/**`.
  * The `plugin-slash` test suite passes in the full run.

* [ ] OpenSpec CLI validation:

  * `pnpm exec openspec validate add-slash-recent-command-history --strict`
  * Could not run because the `openspec` command is not available in this workspace.

## Checklist / 自检清单

* [x] Title follows Conventional Commits.
* [x] Public API changes update exported types.
* [x] New capability is covered by OpenSpec proposal.
* [x] Added focused Vitest coverage for the affected plugin.
* [x] Default slash menu behavior remains backward-compatible when `history` is omitted or false.
* [x] No implicit global `localStorage` access.
* [x] No slash query history.
* [x] No `packages/core/**` changes.
* [x] No `packages/plugin-search/**` changes.
* [x] No `apps/electron-demo/**` changes.
* [x] No secrets or personal vault data committed.

## Screenshots / Recordings · 截图或录屏

N/A. This change updates slash menu ordering behavior covered by focused Vitest interaction tests.
