### PR TITLE
feat(react): add onReady and containerProps to <Editor/> (react + vue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ export default function App() {
       initialValue="# Hello, Nexus 👋"
       plugins={[createGfmPreset()]}
       livePreview
+      onReady={(editor) => console.log("ready", editor.getDocument())}
       onChange={(doc, ast) => console.log(doc)}
     />
   );
@@ -110,6 +111,7 @@ import { createGfmPreset } from "@floatboat/nexus-preset-gfm";
     initial-value="# Hello"
     :plugins="[createGfmPreset()]"
     :live-preview="true"
+    @ready="(editor) => console.log('ready', editor.getDocument())"
     @change="(doc) => console.log(doc)"
   />
 </template>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ This document maps every planned feature to **package ownership / priority / sta
 
 | # | Feature | Package | Priority | Status | Needs OpenSpec | Notes |
 |---|---|---|---|---|---|---|
-| 4 | `<Editor />` container pass-through props + `onReady` callback | `react` (and `vue` in lockstep) | P0 | planned | No | Public API addition; semantics must match across bindings |
+| 4 | `<Editor />` container pass-through props + `onReady` callback | `react` (and `vue` in lockstep) | P0 | in-progress | No | Public API addition; semantics must match across bindings. `onReady(editor)` + `containerProps` landed in both bindings |
 
 ## 7. Collaboration
 

--- a/packages/react/src/editor.tsx
+++ b/packages/react/src/editor.tsx
@@ -1,9 +1,9 @@
 import { useEditor } from "./use-editor";
 
-import type { UseEditorConfig } from "./types";
+import type { EditorProps } from "./types";
 
-export function Editor(props: UseEditorConfig) {
-  const { containerRef } = useEditor(props);
+export function Editor({ containerProps, ...config }: EditorProps) {
+  const { containerRef } = useEditor(config);
 
-  return <div ref={containerRef} />;
+  return <div ref={containerRef} {...containerProps} />;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,11 +2,20 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { RefObject } from "react";
+import type { HTMLAttributes, RefObject } from "react";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export type UseEditorConfig = Omit<EditorConfig, "container"> & {
+  /** Fires once after the editor instance is created, handing back the EditorAPI handle. */
+  onReady?: (editor: EditorAPI) => void;
+};
 
 export interface UseEditorResult {
   containerRef: RefObject<HTMLDivElement | null>;
   editor: EditorAPI | null;
+}
+
+export interface EditorProps extends UseEditorConfig {
+  /** Forwarded verbatim onto the editor's root container <div> (className / style / id / data-* / aria-*). */
+  containerProps?: HTMLAttributes<HTMLDivElement> &
+    Record<`data-${string}`, string | number | boolean | undefined>;
 }

--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -18,13 +18,15 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
+    const { onReady, ...editorConfig } = configRef.current;
     const instance = createEditor({
       container,
-      ...configRef.current
+      ...editorConfig
     });
 
     editorRef.current = instance;
     setEditor(instance);
+    onReady?.(instance);
 
     return () => {
       instance.destroy();

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { EditorAPI } from "@floatboat/nexus-core";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-react", () => {
@@ -36,5 +37,35 @@ describe("@floatboat/nexus-react", () => {
     render(<Harness />);
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("fires onReady once with the live editor api", () => {
+    const onReady = vi.fn<(editor: EditorAPI) => void>();
+
+    const { rerender } = render(<Editor initialValue="# Hi" onReady={onReady} />);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady.mock.calls[0][0].getDocument()).toBe("# Hi");
+
+    // A parent re-render must not recreate the editor or refire the callback.
+    rerender(<Editor initialValue="# Hi" onReady={onReady} />);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards containerProps onto the root element", () => {
+    const { container } = render(
+      <Editor
+        initialValue="x"
+        containerProps={{ className: "host-shell", id: "nexus-root", "data-testid": "shell" }}
+      />
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+
+    expect(root.classList.contains("host-shell")).toBe(true);
+    expect(root.id).toBe("nexus-root");
+    expect(root.getAttribute("data-testid")).toBe("shell");
+    expect(root.querySelector(".cm-editor")).not.toBeNull();
   });
 });

--- a/packages/vue/src/editor.ts
+++ b/packages/vue/src/editor.ts
@@ -1,6 +1,10 @@
 import { defineComponent, h } from "vue";
+import type { PropType } from "vue";
+
+import type { EditorAPI } from "@floatboat/nexus-core";
 
 import { useEditor } from "./use-editor";
+import type { EditorContainerProps } from "./types";
 
 export const Editor = defineComponent({
   name: "NexusEditor",
@@ -8,11 +12,22 @@ export const Editor = defineComponent({
     initialValue: {
       type: String,
       required: false
+    },
+    onReady: {
+      type: Function as PropType<(editor: EditorAPI) => void>,
+      required: false
+    },
+    containerProps: {
+      type: Object as PropType<EditorContainerProps>,
+      required: false
     }
   },
   setup(props) {
-    const { containerRef } = useEditor(props);
+    const { containerRef } = useEditor({
+      initialValue: props.initialValue,
+      onReady: props.onReady
+    });
 
-    return () => h("div", { ref: containerRef });
+    return () => h("div", { ref: containerRef, ...props.containerProps });
   }
 });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,3 @@
 export { Editor } from "./editor";
-export type { UseEditorConfig, UseEditorResult } from "./types";
+export type { EditorContainerProps, UseEditorConfig, UseEditorResult } from "./types";
 export { useEditor } from "./use-editor";

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -2,11 +2,17 @@ import type {
   EditorAPI,
   EditorConfig
 } from "@floatboat/nexus-core";
-import type { Ref, ShallowRef } from "vue";
+import type { HTMLAttributes, Ref, ShallowRef } from "vue";
 
-export type UseEditorConfig = Omit<EditorConfig, "container">;
+export type UseEditorConfig = Omit<EditorConfig, "container"> & {
+  /** Fires once after the editor instance is created, handing back the EditorAPI handle. */
+  onReady?: (editor: EditorAPI) => void;
+};
 
 export interface UseEditorResult {
   containerRef: Ref<HTMLDivElement | null>;
   editor: ShallowRef<EditorAPI | null>;
 }
+
+/** DOM attributes forwarded verbatim onto the editor's root container <div>. */
+export type EditorContainerProps = HTMLAttributes;

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -12,10 +12,12 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
       return;
     }
 
+    const { onReady, ...editorConfig } = config;
     editor.value = createEditor({
       container: containerRef.value,
-      ...config
+      ...editorConfig
     });
+    onReady?.(editor.value);
   });
 
   onBeforeUnmount(() => {

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, onMounted } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { EditorAPI } from "@floatboat/nexus-core";
 import { Editor, useEditor } from "../src/index";
 
 describe("@floatboat/nexus-vue", () => {
@@ -44,5 +45,43 @@ describe("@floatboat/nexus-vue", () => {
     await nextTick();
 
     expect(snapshots).toContain("updated");
+  });
+
+  it("fires onReady once with the live editor api", async () => {
+    const onReady = vi.fn<(editor: EditorAPI) => void>();
+
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "# Hi",
+        onReady
+      }
+    });
+
+    await nextTick();
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady.mock.calls[0][0].getDocument()).toBe("# Hi");
+
+    wrapper.unmount();
+  });
+
+  it("forwards containerProps onto the root element", async () => {
+    const wrapper = mount(Editor, {
+      props: {
+        initialValue: "x",
+        containerProps: { class: "host-shell", id: "nexus-root", "data-testid": "shell" }
+      }
+    });
+
+    await nextTick();
+
+    const root = wrapper.element as HTMLElement;
+
+    expect(root.classList.contains("host-shell")).toBe(true);
+    expect(root.id).toBe("nexus-root");
+    expect(root.getAttribute("data-testid")).toBe("shell");
+    expect(root.querySelector(".cm-editor")).not.toBeNull();
+
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue:
- Roadmap (docs/ROADMAP.md):
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
- `apps/electron-demo`:
- `openspec/`:

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Checklist / 自检清单

- [ ] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [ ] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
