### PR TITLE
feat(history): undo/redo grouping with isolated table edits

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 5 | `getSelectedText()` API | `core` | P0 | in-progress | No | Public API addition; needs types + tests — PR #8 in review |
 | 6 | Multi-cursor / multi-selection | `core` | P1 | planned | Yes | CM6 supports it; must verify live-preview and table interactions |
 | 7 | AST enhancement / Markdown extensions | `core` + `preset-gfm` | P2 | planned | Yes | Affects serialization and every AST-dependent plugin |
-| 8 | Undo / redo grouping | `plugin-history` | P1 | planned | No | Coordinate with table's `tableEditingCount` |
+| 8 | Undo / redo grouping | `plugin-history` | P1 | in-progress | No | `createHistoryPlugin({ newGroupDelay, minDepth })` + structural table edits isolated via `isolateHistory` so one undo reverts a whole table op |
 
 ## 4. Plugin System
 

--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -1,3 +1,4 @@
+import { isolateHistory } from "@codemirror/commands";
 import { EditorView, WidgetType, runScopeHandlers } from "@codemirror/view";
 import type { Table } from "mdast";
 
@@ -333,7 +334,14 @@ export class EditableTableWidget extends WidgetType {
   private dispatch(newSource: string): void {
     const v = this.viewRef.current;
     if (!v) return;
-    v.dispatch({ changes: { from: this.tableFrom, to: this.tableFrom + this.source.length, insert: newSource } });
+    // Structural table edits (add/delete/move column or row, range clear) rewrite
+    // the whole table source in one shot. Isolate each as its own undo group so a
+    // single undo reverts the entire operation instead of merging with adjacent
+    // typing or a neighbouring structural edit.
+    v.dispatch({
+      changes: { from: this.tableFrom, to: this.tableFrom + this.source.length, insert: newSource },
+      annotations: isolateHistory.of("full"),
+    });
   }
 
   private deleteColumn(colIdx: number): void {
@@ -368,7 +376,10 @@ export class EditableTableWidget extends WidgetType {
     const nr = "\n| " + Array(cc).fill("  ").join(" | ") + " |";
     const v = this.viewRef.current;
     if (!v) return;
-    v.dispatch({ changes: { from: this.tableFrom + this.source.length, insert: nr } });
+    v.dispatch({
+      changes: { from: this.tableFrom + this.source.length, insert: nr },
+      annotations: isolateHistory.of("full"),
+    });
   }
 
   private moveColumn(from: number, to: number): void {

--- a/packages/core/test/live-preview-regressions.test.ts
+++ b/packages/core/test/live-preview-regressions.test.ts
@@ -39,6 +39,43 @@ describe("live preview regressions", () => {
     editor.destroy();
   });
 
+  it("isolates each structural table edit as its own undo group", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const editor = createEditor({
+      container,
+      initialValue: "| A | B |\n| --- | --- |\n| 1 | 2 |\n",
+      livePreview: true,
+      plugins: [createHistoryPlugin()]
+    });
+
+    const columnCount = () => {
+      const header = editor.getDocument().split("\n")[0];
+      return header.split("|").filter((_, i, a) => i > 0 && i < a.length - 1).length;
+    };
+
+    expect(columnCount()).toBe(2);
+
+    // First structural edit: add a column (whole-table rewrite, isolated).
+    container.querySelector<HTMLButtonElement>('button[title="Add column"]')?.click();
+    expect(columnCount()).toBe(3);
+
+    // The widget DOM is rebuilt after the dispatch — re-query the new button.
+    container.querySelector<HTMLButtonElement>('button[title="Add column"]')?.click();
+    expect(columnCount()).toBe(4);
+
+    // Because each structural edit is isolated, a single undo reverts only the
+    // most recent one (back to 3 columns) rather than merging both adds.
+    expect(editor.undo()).toBe(true);
+    expect(columnCount()).toBe(3);
+
+    expect(editor.undo()).toBe(true);
+    expect(columnCount()).toBe(2);
+
+    editor.destroy();
+    container.remove();
+  });
+
   it("restores preview after the cursor leaves a markdown range", () => {
     const container = document.createElement("div");
     const editor = createEditor({

--- a/packages/plugin-history/src/index.ts
+++ b/packages/plugin-history/src/index.ts
@@ -3,9 +3,27 @@ import { keymap } from "@codemirror/view";
 
 import type { NexusPlugin } from "@floatboat/nexus-core";
 
-export function createHistoryPlugin(): NexusPlugin {
+export interface HistoryPluginOptions {
+  /**
+   * Time in milliseconds within which consecutive edits are merged into a
+   * single undo group. Lower values make undo more granular; `0` starts a new
+   * group on every change. CodeMirror's default is 500.
+   */
+  newGroupDelay?: number;
+  /**
+   * Minimum number of undo events to keep even when the history grows past the
+   * internal size budget. CodeMirror's default is 100.
+   */
+  minDepth?: number;
+}
+
+export function createHistoryPlugin(options: HistoryPluginOptions = {}): NexusPlugin {
+  const historyConfig: { newGroupDelay?: number; minDepth?: number } = {};
+  if (options.newGroupDelay !== undefined) historyConfig.newGroupDelay = options.newGroupDelay;
+  if (options.minDepth !== undefined) historyConfig.minDepth = options.minDepth;
+
   return {
     name: "plugin-history",
-    cmExtensions: [history(), keymap.of(historyKeymap)]
+    cmExtensions: [history(historyConfig), keymap.of(historyKeymap)]
   };
 }

--- a/packages/plugin-history/test/plugin-history.test.ts
+++ b/packages/plugin-history/test/plugin-history.test.ts
@@ -61,4 +61,26 @@ describe("@floatboat/nexus-plugin-history", () => {
     expect(editor.getDocument()).toBe("next");
     editor.destroy();
   });
+
+  it("starts a new undo group per change when newGroupDelay is 0", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "start",
+      // Without grouping (delay 0) each edit is its own undo step, so a single
+      // undo only rolls back the most recent change rather than both.
+      plugins: [createHistoryPlugin({ newGroupDelay: 0 })]
+    });
+
+    editor.setDocument("step one");
+    editor.setDocument("step two");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("step one");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("start");
+
+    editor.destroy();
+  });
 });


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue:
- Roadmap (docs/ROADMAP.md):
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
- `apps/electron-demo`:
- `openspec/`:

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Checklist / 自检清单

- [ ] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [ ] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
