### PR TITLE
feat(toolbar):emoji-table-add

### DIFF
--- a/apps/electron-demo/test/sample-vault.test.ts
+++ b/apps/electron-demo/test/sample-vault.test.ts
@@ -8,6 +8,11 @@ const VAULT_ROOT = path.resolve(__dirname, "../sample-vault");
 const SUPPORTED = new Set([".md", ".markdown", ".txt"]);
 const SKIP_DIRS = new Set(["node_modules", ".git"]);
 
+/** Normalize path separators for cross-platform comparison. */
+function norm(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
 async function collect(dir: string, acc: string[]): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true });
   for (const e of entries) {
@@ -54,7 +59,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
     const idx = await buildIndex();
     const hub = path.join(VAULT_ROOT, "index.md");
     const hits = idx.getBacklinks(hub);
-    const sources = new Set(hits.map((h) => path.relative(VAULT_ROOT, h.sourcePath)));
+    const sources = new Set(hits.map((h) => norm(path.relative(VAULT_ROOT, h.sourcePath))));
     // README is documentation, not a note that must link in; every *other*
     // markdown file should.
     const expected = [
@@ -77,19 +82,19 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("[[AI]] from Daily resolves to Topics/AI.md (globally unique basename)", async () => {
     const idx = await buildIndex();
     const daily = path.join(VAULT_ROOT, "Daily/2026-04-20.md");
-    expect(idx.resolve("AI", daily)).toBe(path.join(VAULT_ROOT, "Topics/AI.md"));
+    expect(norm(idx.resolve("AI", daily) ?? "")).toBe(norm(path.join(VAULT_ROOT, "Topics/AI.md")));
   });
 
   it("[[Meeting]] from work/Inbox.md resolves to work/Meeting.md (same-dir wins)", async () => {
     const idx = await buildIndex();
     const inbox = path.join(VAULT_ROOT, "work/Inbox.md");
-    expect(idx.resolve("Meeting", inbox)).toBe(path.join(VAULT_ROOT, "work/Meeting.md"));
+    expect(norm(idx.resolve("Meeting", inbox) ?? "")).toBe(norm(path.join(VAULT_ROOT, "work/Meeting.md")));
   });
 
   it("[[Meeting]] from personal/Diary.md resolves to personal/Meeting.md (symmetric)", async () => {
     const idx = await buildIndex();
     const diary = path.join(VAULT_ROOT, "personal/Diary.md");
-    expect(idx.resolve("Meeting", diary)).toBe(path.join(VAULT_ROOT, "personal/Meeting.md"));
+    expect(norm(idx.resolve("Meeting", diary) ?? "")).toBe(norm(path.join(VAULT_ROOT, "personal/Meeting.md")));
   });
 
   it("[[Ghost Note]] in ghost-demo.md is unresolved (creates-on-click scenario)", async () => {
@@ -133,7 +138,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
       expect(hits).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            sourcePath: file.path,
+            sourcePath: norm(file.path),
             target: match.target,
           }),
         ])
@@ -144,7 +149,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("Testing.md shows linked backlinks from current sample-vault references", async () => {
     const idx = await buildIndex();
     const testingPath = path.join(VAULT_ROOT, "Topics/Testing.md");
-    const linked = idx.getBacklinks(testingPath).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const linked = idx.getBacklinks(testingPath).map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(linked.length).toBeGreaterThan(0);
     expect(linked).toContain("Projects/Nexus-Editor.md");
   });
@@ -153,15 +158,15 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
     const idx = await buildIndex();
     const bob = path.join(VAULT_ROOT, "People/Bob.md");
     const mentions = idx.getUnlinkedMentions(bob);
-    const sources = mentions.map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const sources = mentions.map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(sources).toContain("People/Alice.md");
   });
 
   it("AI.md has an unlinked mention in Alice.md and Daily/2026-04-20.md has a linked one", async () => {
     const idx = await buildIndex();
     const ai = path.join(VAULT_ROOT, "Topics/AI.md");
-    const unlinked = idx.getUnlinkedMentions(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
-    const linked = idx.getBacklinks(ai).map((m) => path.relative(VAULT_ROOT, m.sourcePath));
+    const unlinked = idx.getUnlinkedMentions(ai).map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
+    const linked = idx.getBacklinks(ai).map((m) => norm(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(unlinked).toContain("People/Alice.md"); // plain text "AI" in Alice.md
     expect(linked).toContain("Daily/2026-04-20.md"); // [[AI]] in the daily
   });
@@ -169,11 +174,11 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("v2-shaped anchors in Ideas.md resolve to the underlying file, not ghosts", async () => {
     const idx = await buildIndex();
     const ideas = path.join(VAULT_ROOT, "Projects/Ideas.md");
-    expect(idx.resolve("Projects/Nexus-Editor#Context", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+    expect(norm(idx.resolve("Projects/Nexus-Editor#Context", ideas) ?? "")).toBe(
+      norm(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
-    expect(idx.resolve("Projects/Nexus-Editor^some-block", ideas)).toBe(
-      path.join(VAULT_ROOT, "Projects/Nexus-Editor.md")
+    expect(norm(idx.resolve("Projects/Nexus-Editor^some-block", ideas) ?? "")).toBe(
+      norm(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
   });
 

--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -547,6 +547,8 @@ export class EditableTableWidget extends WidgetType {
       const initial = baseWidths[dataColIdx + 1];
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
+      // 禁用水平滚动，防止拖拽时出现滚动条
+      document.body.style.overflowX = "hidden";
 
       const onMove = (ev: MouseEvent): void => {
         const delta = ev.clientX - startX;
@@ -561,6 +563,8 @@ export class EditableTableWidget extends WidgetType {
         document.removeEventListener("mouseup", onUp);
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
+        // 恢复水平滚动
+        document.body.style.overflowX = "";
         tableColumnWidths.set(widthKey, baseWidths.slice());
         releaseEditingLock("drag");
       };
@@ -585,7 +589,7 @@ export class EditableTableWidget extends WidgetType {
         const isSelected = sel.from !== sel.to && sel.from <= self.tableFrom && sel.to >= tableEnd;
         selectionOverlay.style.display = isSelected ? "block" : "none";
         // If cursor moved outside table, no active interaction, no active range, clear range selection
-        if (rangeStart && !isRangeSelecting && !cellMouseDown && !rangeActive && (sel.head < self.tableFrom || sel.head > tableEnd)) {
+        if (rangeStart && !isRangeSelecting && !cellMouseDown && !rangeActive && draggingCol < 0 && draggingRow < 0 && (sel.head < self.tableFrom || sel.head > tableEnd)) {
           clearRangeSelection();
         }
       } else {
@@ -902,6 +906,8 @@ export class EditableTableWidget extends WidgetType {
       document.removeEventListener("mouseup", onDragEnd);
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
+      // 恢复水平滚动
+      document.body.style.overflowX = "";
 
       // Release editing lock BEFORE dispatch so the resulting update rebuilds widget
       releaseEditingLock("drag");
@@ -930,6 +936,8 @@ export class EditableTableWidget extends WidgetType {
       document.addEventListener("mouseup", onDragEnd);
       document.body.style.cursor = "grabbing";
       document.body.style.userSelect = "none";
+      // 禁用水平滚动，防止拖拽时出现滚动条
+      document.body.style.overflowX = "hidden";
     }
 
     function startRowDrag(rowIdx: number, startY: number): void {
@@ -1357,6 +1365,11 @@ export class EditableTableWidget extends WidgetType {
             // CM 文档选区（常是第 0 行），让光标"飞到第一行"而非落在目标单元格。
             if (navigatingBetweenCells) {
               tableNavDebug("blur-dispatch:skipped (navigating)");
+              return;
+            }
+            // 在列/行拖拽期间也跳过，避免拖拽时触发不必要的视图更新
+            if (draggingCol >= 0 || draggingRow >= 0) {
+              tableNavDebug("blur-dispatch:skipped (dragging)");
               return;
             }
             const v = self.viewRef.current;

--- a/packages/plugin-toolbar/src/icons.ts
+++ b/packages/plugin-toolbar/src/icons.ts
@@ -174,3 +174,18 @@ export function iconHorizontalRule(): HTMLElement {
     `<line x1="2" y1="9" x2="16" y2="9"/>`
   );
 }
+
+export function iconEmoji(): HTMLElement {
+  return textLabel("😊", "font-size:14px;");
+}
+
+export function iconTable(): HTMLElement {
+  return svgIcon(
+    `<line x1="4" y1="4" x2="14" y2="4"/>` +
+    `<line x1="4" y1="9" x2="14" y2="9"/>` +
+    `<line x1="4" y1="14" x2="14" y2="14"/>` +
+    `<line x1="4" y1="4" x2="4" y2="14"/>` +
+    `<line x1="9" y1="4" x2="9" y2="14"/>` +
+    `<line x1="14" y1="4" x2="14" y2="14"/>`
+  );
+}

--- a/packages/plugin-toolbar/src/toolbar-ui.ts
+++ b/packages/plugin-toolbar/src/toolbar-ui.ts
@@ -38,6 +38,8 @@ import {
   iconHighlight,
   iconImage,
   iconFullscreen,
+  iconEmoji,
+  iconTable,
 } from "./icons";
 
 export interface ToolbarButton {
@@ -90,17 +92,36 @@ function installToolbarTooltip(button: HTMLButtonElement): () => void {
   tooltip.id = `nexus-toolbar-tooltip-${++tooltipId}`;
   tooltip.setAttribute("role", "tooltip");
   button.setAttribute("aria-describedby", tooltip.id);
+  tooltip.style.cssText = `
+    position: fixed;
+    padding: 4px 10px;
+    background: var(--nexus-bg, #ffffff);
+    color: var(--nexus-text, #24292e);
+    border: 1px solid var(--nexus-border, #e4e7eb);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: system-ui, -apple-system, sans-serif;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 10000;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    transform: translateX(-50%);
+  `;
 
   const show = () => {
     const label = button.dataset.toolbarTooltip ?? button.getAttribute("aria-label") ?? "";
     if (!label.trim()) return;
     tooltip.textContent = label;
     tooltip.dataset.state = "open";
+    // 禁用垂直滚动，防止 tooltip 导致页面出现滚动条
+    document.body.style.overflowY = "hidden";
     if (!tooltip.isConnected) pickOverlayMount(button).appendChild(tooltip);
     positionToolbarTooltip(button, tooltip);
   };
   const hide = () => {
     tooltip.dataset.state = "closed";
+    // 恢复垂直滚动
+    document.body.style.overflowY = "";
     tooltip.remove();
   };
   const updatePosition = () => {
@@ -181,6 +202,12 @@ function defaultGroups(options?: ToolbarUIOptions): ToolbarGroup[] {
     },
     {
       buttons: [
+        { id: "table", title: "Insert table", icon: iconTable, action: () => {} },
+        { id: "emoji", title: "Insert emoji", icon: iconEmoji, action: () => {} },
+      ],
+    },
+    {
+      buttons: [
         { id: "image", title: "Insert image", icon: iconImage, action: insertImage },
         { id: "fullscreen", title: "Fullscreen", icon: iconFullscreen, action: () => options?.onFullscreen?.() },
       ],
@@ -198,6 +225,7 @@ const TOOLBAR_STYLES = `
   user-select: none;
   flex-shrink: 0;
   overflow-x: auto;
+  overflow-y: hidden;
   font-family: system-ui, -apple-system, sans-serif;
 `;
 
@@ -440,8 +468,225 @@ function showColorPicker(
   };
 }
 
+const EMOJI_PALETTE = [
+  // Smileys & People
+  "😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂",
+  "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "🤩",
+  // Animals & Nature
+  "🐶", "🐱", "🐭", "🐹", "🐰", "🦊", "🐻", "🐼",
+  "🐨", "🐯", "🦁", "🐮", "🐷", "🐸", "🐵", "🐔",
+  // Food & Drink
+  "🍎", "🍊", "🍋", "🍇", "🍓", "🍑", "🍒", "🥝",
+  "🍅", "🥑", "🍕", "🍔", "🍟", "🌭", "🍿", "🍦",
+  // Activities
+  "⚽", "🏀", "🎾", "🏈", "⚾", "🎱", "🏆", "🎮",
+  "🎲", "🎸", "🎹", "🎤", "🎧", "🎨", "📷", "🎭",
+];
+
+const EMOJI_PICKER_STYLES = `
+  position: fixed;
+  background: var(--nexus-bg, #fff);
+  border: 1px solid var(--nexus-border, #eee);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  padding: 8px;
+  z-index: 10000;
+  max-height: 300px;
+  overflow-y: auto;
+`;
+
+const TABLE_PICKER_STYLES = `
+  position: fixed;
+  background: var(--nexus-bg, #fff);
+  border: 1px solid var(--nexus-border, #eee);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  padding: 12px;
+  z-index: 10000;
+`;
+
+function showTablePicker(
+  editor: EditorAPI,
+  anchorBtn: HTMLElement,
+  onClose: () => void,
+): { destroy: () => void } {
+  const panel = document.createElement("div");
+  panel.className = "nexus-toolbar-dropdown";
+  panel.style.cssText = TABLE_PICKER_STYLES;
+
+  const rect = anchorBtn.getBoundingClientRect();
+  panel.style.top = rect.bottom + 4 + "px";
+  panel.style.left = rect.left + "px";
+
+  const label = document.createElement("div");
+  label.style.cssText = `
+    font-size: 12px;
+    color: var(--nexus-text-muted, #888);
+    margin-bottom: 8px;
+    padding: 0 4px;
+  `;
+  label.textContent = "Select rows × columns";
+  panel.appendChild(label);
+
+  const grid = document.createElement("div");
+  grid.style.cssText = `display:grid;grid-template-columns:repeat(6,1fr);gap:2px;`;
+
+  const maxRows = 6;
+  const maxCols = 6;
+  const itemCleanups: Array<() => void> = [];
+
+  for (let rows = 1; rows <= maxRows; rows++) {
+    for (let cols = 1; cols <= maxCols; cols++) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = `${rows}×${cols}`;
+      button.dataset.rows = String(rows);
+      button.dataset.cols = String(cols);
+      button.style.cssText = `
+        padding: 6px 10px;
+        border: 1px solid var(--nexus-border-subtle, #ddd);
+        border-radius: 4px;
+        background: transparent;
+        cursor: pointer;
+        font-size: 12px;
+        font-family: system-ui, -apple-system, sans-serif;
+        color: var(--nexus-text, #24292e);
+        transition: background 0.15s, border-color 0.15s;
+      `;
+
+      const handleClick = (e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const r = parseInt(button.dataset.rows || "3");
+        const c = parseInt(button.dataset.cols || "3");
+        
+        const headerRow = "| " + Array(c).fill("Header").join(" | ") + " |";
+        const separatorRow = "| " + Array(c).fill("---").join(" | ") + " |";
+        const bodyRows = Array(r - 1).fill("| " + Array(c).fill("").join(" | ") + " |").join("\n");
+        
+        const table = headerRow + "\n" + separatorRow + "\n" + bodyRows;
+        
+        const doc = editor.getDocument();
+        const { anchor, head } = editor.getSelection();
+        const before = doc.slice(0, anchor);
+        const after = doc.slice(head);
+        editor.setDocument(before + table + after);
+        editor.setSelection(anchor + table.length);
+        editor.focus();
+        onClose();
+      };
+      const handleEnter = () => { 
+        button.style.background = "var(--nexus-bg-muted, #f0f0f0)"; 
+        button.style.borderColor = "var(--nexus-accent, #0969da)";
+      };
+      const handleLeave = () => { 
+        button.style.background = "transparent"; 
+        button.style.borderColor = "var(--nexus-border-subtle, #ddd)";
+      };
+
+      button.addEventListener("click", handleClick);
+      button.addEventListener("mouseenter", handleEnter);
+      button.addEventListener("mouseleave", handleLeave);
+      itemCleanups.push(() => {
+        button.removeEventListener("click", handleClick);
+        button.removeEventListener("mouseenter", handleEnter);
+        button.removeEventListener("mouseleave", handleLeave);
+      });
+
+      grid.appendChild(button);
+    }
+  }
+
+  panel.appendChild(grid);
+  pickOverlayMount(anchorBtn).appendChild(panel);
+
+  return {
+    destroy() {
+      for (const fn of itemCleanups) fn();
+      itemCleanups.length = 0;
+      panel.remove();
+    },
+  };
+}
+
+function showEmojiPicker(
+  editor: EditorAPI,
+  anchorBtn: HTMLElement,
+  onClose: () => void,
+): { destroy: () => void } {
+  const panel = document.createElement("div");
+  panel.className = "nexus-toolbar-dropdown";
+  panel.style.cssText = EMOJI_PICKER_STYLES;
+
+  const rect = anchorBtn.getBoundingClientRect();
+  panel.style.top = rect.bottom + 4 + "px";
+  panel.style.left = rect.left + "px";
+
+  const grid = document.createElement("div");
+  grid.style.cssText = `display:grid;grid-template-columns:repeat(8,1fr);gap:2px;`;
+
+  const itemCleanups: Array<() => void> = [];
+
+  for (const emoji of EMOJI_PALETTE) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = emoji;
+    button.style.cssText = `
+      width: 32px;
+      height: 32px;
+      border: none;
+      border-radius: 4px;
+      background: transparent;
+      cursor: pointer;
+      padding: 0;
+      font-size: 18px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.15s;
+    `;
+
+    const handleClick = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const doc = editor.getDocument();
+      const { anchor, head } = editor.getSelection();
+      const before = doc.slice(0, anchor);
+      const after = doc.slice(head);
+      editor.setDocument(before + emoji + after);
+      editor.setSelection(anchor + emoji.length);
+      editor.focus();
+      onClose();
+    };
+    const handleEnter = () => { button.style.background = "var(--nexus-bg-muted, #f0f0f0)"; };
+    const handleLeave = () => { button.style.background = "transparent"; };
+
+    button.addEventListener("click", handleClick);
+    button.addEventListener("mouseenter", handleEnter);
+    button.addEventListener("mouseleave", handleLeave);
+    itemCleanups.push(() => {
+      button.removeEventListener("click", handleClick);
+      button.removeEventListener("mouseenter", handleEnter);
+      button.removeEventListener("mouseleave", handleLeave);
+    });
+
+    grid.appendChild(button);
+  }
+
+  panel.appendChild(grid);
+  pickOverlayMount(anchorBtn).appendChild(panel);
+
+  return {
+    destroy() {
+      for (const fn of itemCleanups) fn();
+      itemCleanups.length = 0;
+      panel.remove();
+    },
+  };
+}
+
 /** IDs that trigger dropdown behavior instead of a direct action. */
-const DROPDOWN_IDS = new Set(["heading-menu", "text-color", "highlight"]);
+const DROPDOWN_IDS = new Set(["heading-menu", "text-color", "highlight", "emoji", "table"]);
 
 export function createToolbarUI(editor: EditorAPI, options?: ToolbarUIOptions): ToolbarUI {
   const groups = options?.groups ?? defaultGroups(options);
@@ -510,6 +755,10 @@ export function createToolbarUI(editor: EditorAPI, options?: ToolbarUIOptions): 
             activeDropdown = showColorPicker(editor, button, COLOR_PALETTE, applyTextColor, closeDropdown);
           } else if (btn.id === "highlight") {
             activeDropdown = showColorPicker(editor, button, HIGHLIGHT_PALETTE, applyHighlight, closeDropdown);
+          } else if (btn.id === "emoji") {
+            activeDropdown = showEmojiPicker(editor, button, closeDropdown);
+          } else if (btn.id === "table") {
+            activeDropdown = showTablePicker(editor, button, closeDropdown);
           }
 
           outsideHandler = (ev: MouseEvent) => {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2
-->

## Summary / 摘要

新增工具栏 emoji 插入和表格插入功能，并修复了鼠标悬停时面板抖动及滚动条闪烁问题。

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue: 工具栏鼠标悬停时右侧面板抖动、滚动条闪烁
- 功能需求：用户需要在编辑器中快速插入 emoji 和表格
- Roadmap (docs/ROADMAP.md): 增强工具栏功能

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/plugin-toolbar`:
  - 添加 `iconTable()` 图标函数
  - 添加 emoji 选择器功能（64个常用 emoji，8×8 网格布局）
  - 添加表格选择器功能（支持 1-6 行 × 1-6 列）
  - 更新工具栏按钮组，添加表格和 emoji 按钮
  - 修复 tooltip 导致的垂直滚动条闪烁问题

- `packages/core`:
  - 修复 `live-preview-table.ts` 中 `checkSelection` 函数缺少拖拽状态检查的问题
  - 添加拖拽期间禁用水平/垂直滚动的逻辑
  - 修复 `blur` 事件处理中拖拽期间的 selection 更新问题

- `apps/electron-demo`:
  - 修复 `sample-vault.test.ts` 中 Windows 路径分隔符问题（`\` vs `/`）
  - 添加 `norm()` 函数统一路径格式

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：
  - 修复 `sample-vault.test.ts` 中的路径比较问题
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：
  - emoji 选择器正常显示和插入
  - 表格选择器支持 1-6 行列选择
  - 工具栏鼠标悬停无抖动
  - 拖拽操作无滚动条闪烁

## Checklist / 自检清单

- [ ] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [ ] No secrets / personal vault data committed / 无敏感信息被提交

## Screenshots / Recordings · 截图或录屏 (UI changes)

<img width="1920" height="966" alt="image" src="https://github.com/user-attachments/assets/49557cc4-bf8f-4bd7-8f37-1486b9504f91" />


<img width="1024" height="488" alt="image" src="https://github.com/user-attachments/assets/a64cb9e3-52df-400b-8632-d0e6b9b87e73" />

