### PR TITLE
fix(electron): normalize test path expectations for Windows compatibility

### DIFF
--- a/apps/electron-demo/test/sample-vault.test.ts
+++ b/apps/electron-demo/test/sample-vault.test.ts
@@ -5,7 +5,7 @@ import { scanWikiLinks } from "@floatboat/nexus-core";
 import { LinkIndex, findAnchorPosition, parseAnchor } from "../src/renderer/link-index";
 import { normalizeSlashes } from "../src/renderer/path-utils";
 
-const VAULT_ROOT = path.resolve(__dirname, "../sample-vault");
+const VAULT_ROOT = normalizeSlashes(path.resolve(__dirname, "../sample-vault"));
 const SUPPORTED = new Set([".md", ".markdown", ".txt"]);
 const SKIP_DIRS = new Set(["node_modules", ".git"]);
 
@@ -47,13 +47,13 @@ async function readFixtureFiles(): Promise<Array<{ path: string; content: string
  */
 describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   it("the vault directory exists and contains the hub", async () => {
-    const st = await stat(path.join(VAULT_ROOT, "index.md"));
+    const st = await stat(normalizeSlashes(path.join(VAULT_ROOT, "index.md")));
     expect(st.isFile()).toBe(true);
   });
 
   it("every note links back to index.md (hub topology)", async () => {
     const idx = await buildIndex();
-    const hub = path.join(VAULT_ROOT, "index.md");
+    const hub = normalizeSlashes(path.join(VAULT_ROOT, "index.md"));
     const hits = idx.getBacklinks(hub);
     const sources = new Set(hits.map((h) => normalizeSlashes(path.relative(VAULT_ROOT, h.sourcePath))));
     // README is documentation, not a note that must link in; every *other*
@@ -104,7 +104,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
     const idx = await buildIndex();
     // NotALink should not be resolvable via any rule — it must never appear
     // as a valid target because the scanner skipped it.
-    expect(idx.resolve("NotALink", path.join(VAULT_ROOT, "ghost-demo.md"))).toBeNull();
+    expect(idx.resolve("NotALink", normalizeSlashes(path.join(VAULT_ROOT, "ghost-demo.md")))).toBeNull();
     // And no file's forward edges include a "NotALink" target.
     for (const source of idx.getAllFiles()) {
       const hits = idx.getBacklinks(source);
@@ -144,7 +144,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("Testing.md shows linked backlinks from current sample-vault references", async () => {
     const idx = await buildIndex();
-    const testingPath = path.join(VAULT_ROOT, "Topics/Testing.md");
+    const testingPath = normalizeSlashes(path.join(VAULT_ROOT, "Topics/Testing.md"));
     const linked = idx.getBacklinks(testingPath).map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(linked.length).toBeGreaterThan(0);
     expect(linked).toContain(normalizeSlashes("Projects/Nexus-Editor.md"));
@@ -152,7 +152,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("Bob.md has an unlinked mention in Alice.md (plain text 'Bob' outside brackets)", async () => {
     const idx = await buildIndex();
-    const bob = path.join(VAULT_ROOT, "People/Bob.md");
+    const bob = normalizeSlashes(path.join(VAULT_ROOT, "People/Bob.md"));
     const mentions = idx.getUnlinkedMentions(bob);
     const sources = mentions.map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(sources).toContain(normalizeSlashes("People/Alice.md"));
@@ -160,7 +160,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("AI.md has an unlinked mention in Alice.md and Daily/2026-04-20.md has a linked one", async () => {
     const idx = await buildIndex();
-    const ai = path.join(VAULT_ROOT, "Topics/AI.md");
+    const ai = normalizeSlashes(path.join(VAULT_ROOT, "Topics/AI.md"));
     const unlinked = idx.getUnlinkedMentions(ai).map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
     const linked = idx.getBacklinks(ai).map((m) => normalizeSlashes(path.relative(VAULT_ROOT, m.sourcePath)));
     expect(unlinked).toContain(normalizeSlashes("People/Alice.md")); // plain text "AI" in Alice.md
@@ -169,7 +169,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
 
   it("v2-shaped anchors in Ideas.md resolve to the underlying file, not ghosts", async () => {
     const idx = await buildIndex();
-    const ideas = path.join(VAULT_ROOT, "Projects/Ideas.md");
+    const ideas = normalizeSlashes(path.join(VAULT_ROOT, "Projects/Ideas.md"));
     expect(idx.resolve("Projects/Nexus-Editor#Context", ideas)).toBe(
       normalizeSlashes(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"))
     );
@@ -179,7 +179,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   });
 
   it("#Context anchor in Ideas.md points into the real Context heading of Nexus-Editor.md", async () => {
-    const nexus = path.join(VAULT_ROOT, "Projects/Nexus-Editor.md");
+    const nexus = normalizeSlashes(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"));
     const content = await readFile(nexus, "utf-8");
     const { anchor } = parseAnchor("Projects/Nexus-Editor#Context");
     expect(anchor).not.toBeNull();
@@ -190,7 +190,7 @@ describe("sample-vault fixture — end-to-end wiki-link behavior", () => {
   });
 
   it("^some-block anchor in Ideas.md points into the tagged paragraph", async () => {
-    const nexus = path.join(VAULT_ROOT, "Projects/Nexus-Editor.md");
+    const nexus = normalizeSlashes(path.join(VAULT_ROOT, "Projects/Nexus-Editor.md"));
     const content = await readFile(nexus, "utf-8");
     const { anchor } = parseAnchor("Projects/Nexus-Editor^some-block");
     expect(anchor).not.toBeNull();


### PR DESCRIPTION
## Why
Fixes #77

On Windows, `path.join()` produces backslash-separated paths (`\`), but
`LinkIndex.normalizeSlashes` always returns forward-slash paths (`/`). This
caused 9 of 15 tests in `sample-vault.test.ts` to fail on Windows with
assertion errors like:

```
expected 'C:/.../Topics/AI.md' to be 'C:\\...\\Topics\\AI.md'
```

The production code's normalization is correct; this aligns all test
expectations with that behavior by wrapping every `path.join()` call site
with `normalizeSlashes()`, starting from `VAULT_ROOT` itself so derived
paths are consistently forward-slash formatted.

## What
- Normalize `VAULT_ROOT` at declaration time
- Wrap all `path.join()` inputs with `normalizeSlashes()`
- No changes to production code

## Checklist
- [x] Title follows Conventional Commits
- [x] All tests pass (514/514)
- [x] No changes to public API or production code
- [x] Single responsibility — only fixes test path format