### PR TITLE
feat(plugin-search): add fuzzy subsequence matcher and ranker

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 2  | Whole-word matching | `plugin-search` | P1 | done | No | `wholeWord` option via `buildSearchPattern` with `\b` boundaries |
 | 15 | Regex search | `plugin-search` | P1 | done | No | `regexp` option landed alongside whole-word; invalid-regex guarded |
 | 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | done | Yes | Host-injected storage (no implicit localStorage) — `add-search-query-history` + `add-slash-recent-command-history` |
-| 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib; needs backtracking matcher |
+| 17 | Fuzzy search | `plugin-search` | P2 | done | No | `fuzzyMatch` / `fuzzyFilter` — O(m·n) DP subsequence matcher with positional scoring; pure helpers, no UI coupling |
 | 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0 | done | Yes | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui` |
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -25,7 +25,7 @@
 | 2  | whole-word 匹配 | `plugin-search` | P1 | done | 否 | 经 `buildSearchPattern` 的 `wholeWord` 选项，使用 `\b` 边界 |
 | 15 | 正则搜索 | `plugin-search` | P1 | done | 否 | `regexp` 选项与 whole-word 一并落地；非法正则有保护 |
 | 16 | 历史命令 / 搜索记忆 | `plugin-search` + `plugin-slash` | P2 | done | 是 | 宿主注入式存储（不隐式写 localStorage）—— `add-search-query-history` + `add-slash-recent-command-history` |
-| 17 | 模糊搜索 | `plugin-search` | P2 | planned | 否 | 评估 fzf-like 算法 vs. 第三方 lib；需带回溯的匹配器 |
+| 17 | 模糊搜索 | `plugin-search` | P2 | done | 否 | `fuzzyMatch` / `fuzzyFilter`——O(m·n) 动态规划子序列匹配器，带位置打分；纯函数，不耦合 UI |
 | 3  | Slash 命令排序与 limit | `plugin-slash` | P0 | done | 是 | 与浮层菜单 UI 一并落地 —— 见 `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash 命令浮层菜单 UI | `plugin-slash` + `electron-demo` | P0 | done | 是 | `createSlashMenuUI(editor, options)` —— 见 `openspec/changes/add-slash-menu-ui` |
 

--- a/packages/plugin-search/README.md
+++ b/packages/plugin-search/README.md
@@ -1,0 +1,73 @@
+# @floatboat/nexus-plugin-search
+
+Search, replace, and fuzzy matching for
+[Nexus-Editor](https://github.com/floatboatai/Nexus-Editor).
+
+- **Find & replace panel** — case-sensitive, whole-word, and regex modes,
+  with an opt-in, host-injected query history (no implicit `localStorage`).
+- **Pure matching helpers** — `findSearchMatches` / `replaceAllMatches`
+  operate on a plain string, so they work in Node, a build script, or a
+  Worker without an editor instance.
+- **Fuzzy matcher** — `fuzzyMatch` / `fuzzyFilter` rank candidates by
+  subsequence match for slash menus, command palettes, and file pickers.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-plugin-search @floatboat/nexus-core
+```
+
+## Search plugin
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+import { createSearchPlugin } from "@floatboat/nexus-plugin-search";
+
+const editor = createEditor({
+  container,
+  plugins: [createSearchPlugin({ history: true })]
+});
+```
+
+`findSearchMatches(doc, query, options)` and
+`replaceAllMatches(doc, query, replacement, options)` accept
+`{ caseSensitive, wholeWord, regexp }` and find **contiguous** matches.
+
+## Fuzzy matching
+
+Fuzzy matching is different from the find panel: instead of contiguous runs,
+it asks whether the query characters appear in the target **in order but not
+necessarily adjacent** (`"gcl"` matches `"gamma cluster"`), and returns a
+score so candidates can be ranked best-first.
+
+```ts
+import { fuzzyMatch, fuzzyFilter } from "@floatboat/nexus-plugin-search";
+
+fuzzyMatch("gamma cluster", "gcl");
+// → { score: 83, positions: [0, 6, 7] }   (indices into the target)
+
+fuzzyMatch("Gamma", "g", { caseSensitive: true });
+// → null
+
+// Rank a list, best match first; non-matches are dropped.
+fuzzyFilter(["Heading 1", "Heading 2", "Code Block"], "head");
+// → [{ item: "Heading 1", score, positions }, { item: "Heading 2", ... }]
+
+// Object items via a key extractor, capped to N results.
+fuzzyFilter(commands, "img", { key: (c) => c.title, limit: 8 });
+```
+
+### Scoring
+
+The score rewards, in order of weight: matches at the start of the target,
+consecutive matched characters, and matches right after a word boundary
+(space, `-`, `_`, `/`, `.`, `:`, or a camelCase hump). Leading and
+intervening gaps are penalized. The magnitude is an implementation detail —
+sort on it rather than threshold against a constant.
+
+An empty query is the "menu just opened" case: `fuzzyMatch` returns
+`{ score: 0, positions: [] }` and `fuzzyFilter` returns every item in its
+original order, so callers don't reorder before the user types.
+
+The matcher runs an `O(query.length × target.length)` dynamic-programming
+pass — no backtracking blow-up on pathological repeated-character input.

--- a/packages/plugin-search/src/fuzzy.ts
+++ b/packages/plugin-search/src/fuzzy.ts
@@ -1,0 +1,231 @@
+/**
+ * Fuzzy (subsequence) matcher with positional scoring.
+ *
+ * Unlike the exact / regex search in this package — which finds *contiguous*
+ * runs in a document — fuzzy matching asks whether the query characters appear
+ * in `target` in order but not necessarily adjacent ("gcl" matches "gamma
+ * cluster"). It returns a score so callers can rank candidates (slash menus,
+ * command palettes, file pickers) best-first.
+ *
+ * Scoring is a single forward dynamic-programming pass: `dp[i][j]` is the best
+ * total score for aligning the first `i + 1` query characters with the i-th
+ * landing on target position `j`. The per-position gap term is linear in `j`,
+ * so the running max over earlier landing positions collapses to O(1) — the
+ * whole pass is O(query.length * target.length) with no backtracking blow-up.
+ */
+
+export interface FuzzyMatch {
+  /**
+   * Total score. Higher is a better match. Always >= the base match score when
+   * matched. The exact magnitude is an implementation detail — only the
+   * relative ordering is meaningful, so callers should sort rather than
+   * threshold on a constant.
+   */
+  score: number;
+  /**
+   * Indices into `target` (not the query) of every matched character, in
+   * ascending order. Use these to highlight the matched glyphs.
+   */
+  positions: number[];
+}
+
+export interface FuzzyMatchOptions {
+  /**
+   * Match case-sensitively. Defaults to false — `query` and `target` are
+   * compared lower-cased.
+   */
+  caseSensitive?: boolean;
+}
+
+export interface FuzzyItemResult<T> {
+  item: T;
+  score: number;
+  positions: number[];
+}
+
+export interface FuzzyFilterOptions<T> extends FuzzyMatchOptions {
+  /**
+   * Extract the string to match against from each item. Defaults to using the
+   * item itself (so `T` must be `string`).
+   */
+  key?: (item: T) => string;
+  /**
+   * Cap the number of results returned, after sorting. Negative or zero means
+   * "no limit".
+   */
+  limit?: number;
+}
+
+// Scoring weights. Tuned so that, in order of importance:
+//   1. a match at the start of the target beats one in the middle,
+//   2. consecutive matched characters beat scattered ones,
+//   3. matches right after a word boundary (space, -, _, /, camelCase hump)
+//      beat matches mid-word.
+const SCORE_MATCH = 16;
+const BONUS_CONSECUTIVE = 18;
+const BONUS_START = 12;
+const BONUS_WORD_BOUNDARY = 10;
+const PENALTY_LEADING_GAP = 3; // per skipped char before the first match
+const PENALTY_GAP = 1; // per skipped char between matches
+
+const NEG_INF = -Infinity;
+
+function isWordBoundary(target: string, index: number): boolean {
+  if (index === 0) return true;
+  const prev = target.charCodeAt(index - 1);
+  // space, tab, newline, -, _ count as separators.
+  if (prev === 32 || prev === 9 || prev === 10 || prev === 45 || prev === 95) {
+    return true;
+  }
+  // /, ., : path/segment separators.
+  if (prev === 47 || prev === 46 || prev === 58) return true;
+  // camelCase / digit-to-upper hump. Use the original-cased characters here
+  // regardless of caseSensitive.
+  const prevCh = target[index - 1];
+  const curCh = target[index];
+  if (prevCh >= "a" && prevCh <= "z" && curCh >= "A" && curCh <= "Z") {
+    return true;
+  }
+  if (prevCh >= "0" && prevCh <= "9" && curCh >= "A" && curCh <= "Z") {
+    return true;
+  }
+  return false;
+}
+
+function charBase(original: string, j: number): number {
+  let score = SCORE_MATCH;
+  if (j === 0) score += BONUS_START;
+  else if (isWordBoundary(original, j)) score += BONUS_WORD_BOUNDARY;
+  return score;
+}
+
+/**
+ * Score a single (target, query) pair. Returns null when `query` is not a
+ * subsequence of `target`. An empty query matches everything with score 0 and
+ * no highlighted positions.
+ */
+export function fuzzyMatch(
+  target: string,
+  query: string,
+  options: FuzzyMatchOptions = {}
+): FuzzyMatch | null {
+  if (query === "") {
+    return { score: 0, positions: [] };
+  }
+  const n = target.length;
+  const m = query.length;
+  if (n === 0 || m > n) return null;
+
+  const haystack = options.caseSensitive ? target : target.toLowerCase();
+  const needle = options.caseSensitive ? query : query.toLowerCase();
+
+  // dp[j] holds the best score for the query char currently being processed,
+  // landing at target position j (NEG_INF if char[j] can't be that position).
+  // back[i][j] records the previous landing position chosen at (i, j), so the
+  // alignment can be reconstructed afterwards.
+  let prev = new Array<number>(n).fill(NEG_INF);
+  const back: Int32Array[] = [];
+  for (let i = 0; i < m; i++) back.push(new Int32Array(n).fill(-1));
+
+  // First query character: leading gap penalty grows with the start offset.
+  for (let j = 0; j < n; j++) {
+    if (haystack[j] !== needle[0]) continue;
+    prev[j] = charBase(target, j) - PENALTY_LEADING_GAP * j;
+    back[0][j] = -1;
+  }
+
+  for (let i = 1; i < m; i++) {
+    const cur = new Array<number>(n).fill(NEG_INF);
+    // Running max of g(k) = prev[k] + PENALTY_GAP * k over all earlier k < j.
+    // The gap term for landing at j is g(k) - PENALTY_GAP * (j - 1).
+    let bestG = NEG_INF;
+    let bestGk = -1;
+
+    for (let j = 0; j < n; j++) {
+      // Fold position k = j - 1 into the running max before using it (k < j).
+      if (j - 1 >= 0 && prev[j - 1] > NEG_INF) {
+        const g = prev[j - 1] + PENALTY_GAP * (j - 1);
+        if (g > bestG) {
+          bestG = g;
+          bestGk = j - 1;
+        }
+      }
+
+      if (haystack[j] !== needle[i]) continue;
+      if (bestGk < 0) continue; // no viable predecessor yet
+
+      // Gap option: best earlier landing minus the intervening-gap penalty.
+      let total = bestG - PENALTY_GAP * (j - 1);
+      let chosenK = bestGk;
+
+      // Consecutive option: predecessor at j - 1 with the run bonus, no gap.
+      if (j - 1 >= 0 && prev[j - 1] > NEG_INF) {
+        const consecutive = prev[j - 1] + BONUS_CONSECUTIVE;
+        if (consecutive > total) {
+          total = consecutive;
+          chosenK = j - 1;
+        }
+      }
+
+      cur[j] = charBase(target, j) + total;
+      back[i][j] = chosenK;
+    }
+
+    prev = cur;
+  }
+
+  // Best final landing for the last query character.
+  let bestJ = -1;
+  let bestScore = NEG_INF;
+  for (let j = 0; j < n; j++) {
+    if (prev[j] > bestScore) {
+      bestScore = prev[j];
+      bestJ = j;
+    }
+  }
+  if (bestJ < 0) return null;
+
+  const positions = new Array<number>(m);
+  let j = bestJ;
+  for (let i = m - 1; i >= 0; i--) {
+    positions[i] = j;
+    j = back[i][j];
+  }
+
+  return { score: bestScore, positions };
+}
+
+/**
+ * Rank `items` by fuzzy match against `query`, best first. Non-matching items
+ * are dropped. An empty query returns every item in original order with score
+ * 0 (the "menu just opened" case — callers shouldn't reorder on no input).
+ */
+export function fuzzyFilter<T>(
+  items: readonly T[],
+  query: string,
+  options: FuzzyFilterOptions<T> = {}
+): FuzzyItemResult<T>[] {
+  const key = options.key ?? ((item: T) => item as unknown as string);
+
+  if (query === "") {
+    return items.map((item) => ({ item, score: 0, positions: [] }));
+  }
+
+  const scored: Array<FuzzyItemResult<T> & { index: number }> = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const match = fuzzyMatch(key(item), query, options);
+    if (match === null) continue;
+    scored.push({ item, score: match.score, positions: match.positions, index: i });
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    // Stable tiebreak: original order so equal-score results stay deterministic.
+    return a.index - b.index;
+  });
+
+  const limit = options.limit;
+  const sliced = limit !== undefined && limit > 0 ? scored.slice(0, limit) : scored;
+  return sliced.map(({ item, score, positions }) => ({ item, score, positions }));
+}

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -17,6 +17,15 @@ import { keymap, runScopeHandlers, type EditorView, type Panel, type ViewUpdate 
 
 import type { NexusPlugin } from "@floatboat/nexus-core";
 
+export {
+  fuzzyMatch,
+  fuzzyFilter,
+  type FuzzyMatch,
+  type FuzzyMatchOptions,
+  type FuzzyItemResult,
+  type FuzzyFilterOptions
+} from "./fuzzy";
+
 export interface SearchMatch {
   from: number;
   to: number;

--- a/packages/plugin-search/test/fuzzy.test.ts
+++ b/packages/plugin-search/test/fuzzy.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyFilter, fuzzyMatch } from "../src/fuzzy";
+
+describe("fuzzyMatch", () => {
+  it("matches a contiguous prefix", () => {
+    const match = fuzzyMatch("gamma", "gam");
+    expect(match).not.toBeNull();
+    expect(match!.positions).toEqual([0, 1, 2]);
+    expect(match!.score).toBeGreaterThan(0);
+  });
+
+  it("matches non-contiguous subsequences", () => {
+    const match = fuzzyMatch("gamma cluster", "gcl");
+    expect(match).not.toBeNull();
+    // g(0) c(6) l(7)
+    expect(match!.positions).toEqual([0, 6, 7]);
+  });
+
+  it("returns null when the query is not a subsequence", () => {
+    expect(fuzzyMatch("gamma", "gax")).toBeNull();
+    expect(fuzzyMatch("gamma", "amg")).toBeNull();
+  });
+
+  it("treats an empty query as a zero-score match with no positions", () => {
+    expect(fuzzyMatch("gamma", "")).toEqual({ score: 0, positions: [] });
+  });
+
+  it("returns null for an empty target with a non-empty query", () => {
+    expect(fuzzyMatch("", "a")).toBeNull();
+  });
+
+  it("is case-insensitive by default", () => {
+    const match = fuzzyMatch("Gamma Cluster", "gc");
+    expect(match).not.toBeNull();
+    expect(match!.positions).toEqual([0, 6]);
+  });
+
+  it("respects caseSensitive option", () => {
+    expect(fuzzyMatch("Gamma", "g", { caseSensitive: true })).toBeNull();
+    expect(fuzzyMatch("Gamma", "G", { caseSensitive: true })).not.toBeNull();
+  });
+
+  it("scores a start-of-string match higher than a later match", () => {
+    const start = fuzzyMatch("abc", "a")!;
+    const later = fuzzyMatch("xxxa", "a")!;
+    expect(start.score).toBeGreaterThan(later.score);
+  });
+
+  it("scores consecutive matches higher than scattered ones", () => {
+    const consecutive = fuzzyMatch("abcdef", "abc")!;
+    const scattered = fuzzyMatch("axbxcx", "abc")!;
+    expect(consecutive.score).toBeGreaterThan(scattered.score);
+  });
+
+  it("rewards matches at word boundaries", () => {
+    // "fb" against "foo bar" should align f(0) b(4, after a space) and beat
+    // a same-length alignment that lands mid-word.
+    const match = fuzzyMatch("foo bar", "fb")!;
+    expect(match.positions).toEqual([0, 4]);
+  });
+
+  it("rewards camelCase humps as boundaries", () => {
+    const match = fuzzyMatch("fooBar", "fb")!;
+    expect(match.positions).toEqual([0, 3]);
+  });
+
+  it("handles a query equal to the target", () => {
+    const match = fuzzyMatch("abc", "abc")!;
+    expect(match.positions).toEqual([0, 1, 2]);
+  });
+
+  it("does not exceed target length in positions", () => {
+    const match = fuzzyMatch("aaa", "aa")!;
+    expect(match.positions.every((p) => p >= 0 && p < 3)).toBe(true);
+    expect(match.positions).toEqual([0, 1]);
+  });
+
+  it("stays bounded on pathological repeated-character input", () => {
+    const target = "a".repeat(2000);
+    const query = "a".repeat(8);
+    const match = fuzzyMatch(target, query);
+    expect(match).not.toBeNull();
+    expect(match!.positions).toHaveLength(8);
+  });
+});
+
+describe("fuzzyFilter", () => {
+  const commands = ["Heading 1", "Heading 2", "Bullet List", "Code Block", "Blockquote"];
+
+  it("ranks matches best-first and drops non-matches", () => {
+    const results = fuzzyFilter(commands, "head");
+    expect(results.map((r) => r.item)).toEqual(["Heading 1", "Heading 2"]);
+  });
+
+  it("returns every item in original order for an empty query", () => {
+    const results = fuzzyFilter(commands, "");
+    expect(results.map((r) => r.item)).toEqual(commands);
+    expect(results.every((r) => r.score === 0)).toBe(true);
+  });
+
+  it("matches subsequences across the candidate", () => {
+    const results = fuzzyFilter(commands, "bl");
+    // "Bullet List", "Code Block", "Blockquote" all contain b...l as a subsequence
+    expect(results.map((r) => r.item)).toContain("Blockquote");
+    expect(results.map((r) => r.item)).toContain("Bullet List");
+    expect(results.map((r) => r.item)).toContain("Code Block");
+  });
+
+  it("ranks a prefix match above a mid-string match", () => {
+    const results = fuzzyFilter(commands, "block");
+    expect(results[0].item).toBe("Blockquote");
+  });
+
+  it("supports a key extractor for object items", () => {
+    const items = [
+      { id: 1, label: "Insert Table" },
+      { id: 2, label: "Insert Image" }
+    ];
+    const results = fuzzyFilter(items, "img", { key: (i) => i.label });
+    expect(results).toHaveLength(1);
+    expect(results[0].item.id).toBe(2);
+  });
+
+  it("honors the limit option after sorting", () => {
+    const results = fuzzyFilter(commands, "e", { limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  it("treats a non-positive limit as no limit", () => {
+    const all = fuzzyFilter(commands, "e", { limit: 0 });
+    const unlimited = fuzzyFilter(commands, "e");
+    expect(all.map((r) => r.item)).toEqual(unlimited.map((r) => r.item));
+  });
+
+  it("returns matched positions for highlighting", () => {
+    const results = fuzzyFilter(["Heading 1"], "hd");
+    expect(results[0].positions).toEqual([0, 3]);
+  });
+
+  it("keeps equal-score results in original order", () => {
+    const tied = ["abx", "aby"];
+    const results = fuzzyFilter(tied, "ab");
+    expect(results.map((r) => r.item)).toEqual(["abx", "aby"]);
+  });
+});


### PR DESCRIPTION
Add fuzzyMatch(target, query) and fuzzyFilter(items, query) as pure helpers for ranking slash menus, command palettes, and file pickers by subsequence match. Distinct from the existing contiguous find/replace: characters match in order but not necessarily adjacent, and results carry a score plus matched positions for highlighting.

The scorer is an O(query.length x target.length) dynamic-programming pass (start, consecutive-run, and word-boundary bonuses; leading/intervening gap penalties), so pathological repeated-character input stays bounded.

Resolves ROADMAP #17.

<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2.
Project scope and contribution policy — see GOVERNANCE.md.

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2。
项目范围与贡献政策见 GOVERNANCE.md。
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue:
- Roadmap (docs/ROADMAP.md):
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
- `apps/electron-demo`:
- `openspec/`:

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
- [x] Manual UI check in electron-demo / electron-demo 手动验证：

## Compliance / 合规自检

<!-- See GOVERNANCE.md §6 for the full policy. / 完整政策见 GOVERNANCE.md §6。 -->

- [x] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI disclosure**: the functional code in this PR is **not** primarily generated by AI. AI assistance, if any, is described below.
      AI-assisted notes / AI 使用说明：
      <!-- e.g. "tab-completion only", "AI wrote test cases for code I wrote", "AI rewrote a comment" -->
- [x] **New dependencies** (if any) listed with license & rationale (none if blank):
      <!-- - <package>@<version> — <license> — <why we need it> -->
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x]  Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x]  Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [x]  Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [x]  New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [x]  Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
