### PR TITLE
feat(search): add fuzzy search helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 | `@floatboat/nexus-vue` | Vue 3 binding — `useEditor` composable |
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown preset (tables, strikethrough, task lists) |
 | `@floatboat/nexus-plugin-history` | Undo/redo with `Ctrl+Z` / `Ctrl+Shift+Z` |
-| `@floatboat/nexus-plugin-search` | Search and replace helpers |
+| `@floatboat/nexus-plugin-search` | Search, replace, regex, and fuzzy-match helpers |
 | `@floatboat/nexus-plugin-slash` | Slash command detection, ranking, and a vanilla-DOM floating menu UI |
 | `@floatboat/nexus-plugin-toolbar` | Toolbar primitives for formatting commands |
 | `@floatboat/nexus-plugin-math` | Inline / block math rendering (KaTeX) |

--- a/README.zh.md
+++ b/README.zh.md
@@ -174,7 +174,7 @@ pnpm dev:electron-demo
 | `@floatboat/nexus-vue` | Vue 3 绑定 —— `useEditor` 组合式函数 |
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown 预设（表格、删除线、任务列表） |
 | `@floatboat/nexus-plugin-history` | 撤销/重做，支持 `Ctrl+Z` / `Ctrl+Shift+Z` |
-| `@floatboat/nexus-plugin-search` | 搜索替换辅助函数 |
+| `@floatboat/nexus-plugin-search` | 搜索、替换、正则与模糊匹配辅助函数 |
 | `@floatboat/nexus-plugin-slash` | 斜杠命令检测、排序与 vanilla DOM 浮层菜单 UI |
 | `@floatboat/nexus-plugin-toolbar` | 工具栏基础组件与格式化命令 |
 | `@floatboat/nexus-plugin-math` | 行内 / 块级数学公式渲染（KaTeX） |

--- a/apps/electron-demo/src/renderer/search-bar.ts
+++ b/apps/electron-demo/src/renderer/search-bar.ts
@@ -51,6 +51,15 @@ const COUNT_STYLES = `
   min-width: 60px;
 `;
 
+const TOGGLE_STYLES = `
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--nexus-text-muted, #666);
+  font-size: 12px;
+  user-select: none;
+`;
+
 const CLOSE_BTN_STYLES = `
   background: none;
   border: none;
@@ -100,6 +109,14 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   replaceAllBtn.title = "Replace all";
   replaceAllBtn.style.cssText = BTN_STYLES;
 
+  const fuzzyToggle = document.createElement("input");
+  fuzzyToggle.type = "checkbox";
+  fuzzyToggle.title = "Use fuzzy subsequence matching";
+
+  const fuzzyLabel = document.createElement("label");
+  fuzzyLabel.style.cssText = TOGGLE_STYLES;
+  fuzzyLabel.append(fuzzyToggle, "Fuzzy");
+
   // Count label
   const countLabel = document.createElement("span");
   countLabel.style.cssText = COUNT_STYLES;
@@ -113,7 +130,18 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   const spacer = document.createElement("div");
   spacer.style.flex = "1";
 
-  bar.append(findInput, prevBtn, nextBtn, countLabel, replaceInput, replaceBtn, replaceAllBtn, spacer, closeBtn);
+  bar.append(
+    findInput,
+    fuzzyLabel,
+    prevBtn,
+    nextBtn,
+    countLabel,
+    replaceInput,
+    replaceBtn,
+    replaceAllBtn,
+    spacer,
+    closeBtn
+  );
 
   // State
   let matches: Array<{ from: number; to: number }> = [];
@@ -129,7 +157,7 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
       return;
     }
     const doc = editor.getDocument();
-    matches = findSearchMatches(doc, query);
+    matches = findSearchMatches(doc, query, { fuzzy: fuzzyToggle.checked });
     if (matches.length === 0) {
       currentIdx = -1;
       countLabel.textContent = "0 results";
@@ -178,13 +206,14 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
     const query = findInput.value;
     if (!query) return;
     const doc = editor.getDocument();
-    const newDoc = replaceAllMatches(doc, query, replaceInput.value);
+    const newDoc = replaceAllMatches(doc, query, replaceInput.value, { fuzzy: fuzzyToggle.checked });
     editor.setDocument(newDoc);
     updateMatches();
   }
 
   // Event handlers
   findInput.addEventListener("input", updateMatches);
+  fuzzyToggle.addEventListener("change", updateMatches);
   findInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") { e.shiftKey ? goPrev() : goNext(); e.preventDefault(); }
     if (e.key === "Escape") { close(); }

--- a/apps/electron-demo/src/renderer/search-bar.ts
+++ b/apps/electron-demo/src/renderer/search-bar.ts
@@ -80,38 +80,57 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
   const findInput = document.createElement("input");
   findInput.type = "text";
   findInput.placeholder = "Find...";
+  findInput.setAttribute("aria-label", "Find");
+  findInput.dataset.testId = "search-find-input";
   findInput.style.cssText = INPUT_STYLES;
 
   // Replace input
   const replaceInput = document.createElement("input");
   replaceInput.type = "text";
   replaceInput.placeholder = "Replace...";
+  replaceInput.setAttribute("aria-label", "Replace");
+  replaceInput.dataset.testId = "search-replace-input";
   replaceInput.style.cssText = INPUT_STYLES;
   replaceInput.style.width = "160px";
 
   // Buttons
   const prevBtn = document.createElement("button");
+  prevBtn.type = "button";
   prevBtn.textContent = "\u2191"; // ↑
   prevBtn.title = "Previous match";
+  prevBtn.setAttribute("aria-label", "Previous match");
+  prevBtn.dataset.testId = "search-previous-button";
   prevBtn.style.cssText = BTN_STYLES;
 
   const nextBtn = document.createElement("button");
+  nextBtn.type = "button";
   nextBtn.textContent = "\u2193"; // ↓
   nextBtn.title = "Next match";
+  nextBtn.setAttribute("aria-label", "Next match");
+  nextBtn.dataset.testId = "search-next-button";
   nextBtn.style.cssText = BTN_STYLES;
 
   const replaceBtn = document.createElement("button");
+  replaceBtn.type = "button";
   replaceBtn.textContent = "Replace";
+  replaceBtn.title = "Replace";
+  replaceBtn.setAttribute("aria-label", "Replace");
+  replaceBtn.dataset.testId = "search-replace-button";
   replaceBtn.style.cssText = BTN_STYLES;
 
   const replaceAllBtn = document.createElement("button");
+  replaceAllBtn.type = "button";
   replaceAllBtn.textContent = "All";
   replaceAllBtn.title = "Replace all";
+  replaceAllBtn.setAttribute("aria-label", "Replace all");
+  replaceAllBtn.dataset.testId = "search-replace-all-button";
   replaceAllBtn.style.cssText = BTN_STYLES;
 
   const fuzzyToggle = document.createElement("input");
   fuzzyToggle.type = "checkbox";
   fuzzyToggle.title = "Use fuzzy subsequence matching";
+  fuzzyToggle.setAttribute("aria-label", "Fuzzy search");
+  fuzzyToggle.dataset.testId = "search-fuzzy-toggle";
 
   const fuzzyLabel = document.createElement("label");
   fuzzyLabel.style.cssText = TOGGLE_STYLES;
@@ -123,8 +142,11 @@ export function createSearchBar(editor: EditorAPI): SearchBar {
 
   // Close
   const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
   closeBtn.innerHTML = "&times;";
   closeBtn.title = "Close (Esc)";
+  closeBtn.setAttribute("aria-label", "Close");
+  closeBtn.dataset.testId = "search-close-button";
   closeBtn.style.cssText = CLOSE_BTN_STYLES;
 
   const spacer = document.createElement("div");

--- a/apps/electron-demo/test/search-bar.test.ts
+++ b/apps/electron-demo/test/search-bar.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EditorAPI } from "@floatboat/nexus-core";
+import { createSearchBar } from "../src/renderer/search-bar";
+
+function createMockEditor(initialDoc: string): EditorAPI {
+  let doc = initialDoc;
+  let selection = { anchor: 0, head: 0 };
+
+  return {
+    getDocument: () => doc,
+    getAst: vi.fn(),
+    setDocument: vi.fn((nextDoc: string) => {
+      doc = nextDoc;
+    }),
+    getSelection: () => selection,
+    setSelection: vi.fn((anchor: number, head = anchor) => {
+      selection = { anchor, head };
+    }),
+    focus: vi.fn(),
+    blur: vi.fn(),
+    destroy: vi.fn(),
+    on: vi.fn(() => () => undefined)
+  } as unknown as EditorAPI;
+}
+
+describe("createSearchBar", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("keeps fuzzy search opt-in and updates matches when enabled", () => {
+    const editor = createMockEditor("Nexus Editor");
+    const searchBar = createSearchBar(editor);
+    document.body.append(searchBar.element);
+    searchBar.open();
+
+    const input = searchBar.element.querySelector<HTMLInputElement>("[data-test-id='search-find-input']");
+    const fuzzyToggle = searchBar.element.querySelector<HTMLInputElement>("[data-test-id='search-fuzzy-toggle']");
+    expect(input).not.toBeNull();
+    expect(fuzzyToggle).not.toBeNull();
+    expect(input?.getAttribute("aria-label")).toBe("Find");
+    expect(fuzzyToggle?.checked).toBe(false);
+    expect(fuzzyToggle?.getAttribute("aria-label")).toBe("Fuzzy search");
+
+    input!.value = "nr";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(editor.setSelection).not.toHaveBeenCalled();
+
+    fuzzyToggle!.checked = true;
+    fuzzyToggle!.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(editor.setSelection).toHaveBeenLastCalledWith(0, 12);
+
+    searchBar.destroy();
+    searchBar.element.remove();
+  });
+
+  it("uses fuzzy replacement when the fuzzy toggle is enabled", () => {
+    const editor = createMockEditor("Nexus Editor");
+    const searchBar = createSearchBar(editor);
+    document.body.append(searchBar.element);
+    searchBar.open();
+
+    const findInput = searchBar.element.querySelector<HTMLInputElement>("[data-test-id='search-find-input']");
+    const replaceInput = searchBar.element.querySelector<HTMLInputElement>("[data-test-id='search-replace-input']");
+    const fuzzyToggle = searchBar.element.querySelector<HTMLInputElement>("[data-test-id='search-fuzzy-toggle']");
+    const replaceButton = searchBar.element.querySelector<HTMLButtonElement>(
+      "[data-test-id='search-replace-button']"
+    );
+    const replaceAllButton = searchBar.element.querySelector<HTMLButtonElement>(
+      "[data-test-id='search-replace-all-button']"
+    );
+
+    expect(findInput).not.toBeNull();
+    expect(replaceInput).not.toBeNull();
+    expect(fuzzyToggle).not.toBeNull();
+    expect(replaceButton).not.toBeNull();
+    expect(replaceAllButton).not.toBeNull();
+    expect(replaceInput?.getAttribute("aria-label")).toBe("Replace");
+    expect(replaceButton?.type).toBe("button");
+    expect(replaceAllButton?.getAttribute("aria-label")).toBe("Replace all");
+    expect(replaceAllButton?.type).toBe("button");
+
+    findInput!.value = "ne";
+    replaceInput!.value = "NE";
+    fuzzyToggle!.checked = true;
+    replaceAllButton!.click();
+
+    expect(editor.setDocument).toHaveBeenLastCalledWith("NExus Editor");
+
+    searchBar.destroy();
+    searchBar.element.remove();
+  });
+});

--- a/apps/electron-demo/tsconfig.json
+++ b/apps/electron-demo/tsconfig.json
@@ -8,7 +8,8 @@
       "@floatboat/nexus-plugin-history": ["packages/plugin-history/src/index.ts"],
       "@floatboat/nexus-plugin-search": ["packages/plugin-search/src/index.ts"],
       "@floatboat/nexus-plugin-slash": ["packages/plugin-slash/src/index.ts"],
-      "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"]
+      "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"],
+      "@floatboat/nexus-plugin-wordcount": ["packages/plugin-wordcount/src/index.ts"]
     }
   },
   "include": [

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 2  | Whole-word matching | `plugin-search` | P1 | done | No | `wholeWord` option via `buildSearchPattern` with `\b` boundaries |
 | 15 | Regex search | `plugin-search` | P1 | done | No | `regexp` option landed alongside whole-word; invalid-regex guarded |
 | 16 | Command / search history | `plugin-search` + `plugin-slash` | P2 | done | Yes | Host-injected storage (no implicit localStorage) — `add-search-query-history` + `add-slash-recent-command-history` |
-| 17 | Fuzzy search | `plugin-search` | P2 | planned | No | Evaluate fzf-like algorithm vs. third-party lib; needs backtracking matcher |
+| 17 | Fuzzy search | `plugin-search` | P2 | in-progress | No | Adds dependency-free subsequence ranking, match ranges, and demo search-bar toggle — see `openspec/changes/add-fuzzy-search` |
 | 3  | Slash command sorting + limit | `plugin-slash` | P0 | done | Yes | Landed alongside the floating menu UI — see `openspec/changes/add-slash-menu-ui` |
 | 27 | Slash command floating menu UI | `plugin-slash` + `electron-demo` | P0 | done | Yes | `createSlashMenuUI(editor, options)` — see `openspec/changes/add-slash-menu-ui` |
 

--- a/openspec/changes/add-fuzzy-search/proposal.md
+++ b/openspec/changes/add-fuzzy-search/proposal.md
@@ -1,0 +1,33 @@
+# Change: Add Fuzzy Search Helpers
+
+## Why
+
+Roadmap #17 calls for fuzzy search in `@floatboat/nexus-plugin-search`. Exact, whole-word, and regex search work well when users know the precise text, but note-taking workflows often need quick subsequence lookup across headings, filenames, and prose where the user remembers only initials or partial characters.
+
+## What Changes
+
+- Add opt-in fuzzy matching to `findSearchMatches()` via `SearchOptions.fuzzy`.
+- Return fuzzy match metadata with ranking `score` and contiguous `ranges` for UI highlighting.
+- Support score-first or document-order sorting through `SearchOptions.sortBy`.
+- Support `maxMatches` capping after sorting.
+- Preserve existing exact, whole-word, regex, replace, and CodeMirror search panel behavior by default.
+- Add fuzzy span replacement to `replaceAllMatches()` for hosts that use the helper outside the CodeMirror panel.
+- Add a fuzzy toggle to the Electron demo search bar to demonstrate the helper in a visible integration surface.
+
+## Non-Goals
+
+- No third-party fuzzy-search dependency.
+- No CodeMirror search panel fuzzy mode in this PR; CodeMirror's native panel remains exact/regex-oriented.
+- No cross-file vault search UI.
+- No changes to `packages/core` search or selection APIs.
+
+## Impact
+
+- Affected specs: `plugins`
+- Affected roadmap: Roadmap #17 (`Fuzzy search`)
+- Affected code:
+  - `packages/plugin-search/src/index.ts`
+  - `packages/plugin-search/test/plugin-search.test.ts`
+  - `packages/plugin-search/README.md`
+  - `apps/electron-demo/src/renderer/search-bar.ts`
+  - `docs/ROADMAP.md`

--- a/openspec/changes/add-fuzzy-search/specs/plugins/spec.md
+++ b/openspec/changes/add-fuzzy-search/specs/plugins/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Fuzzy Search Option
+
+`@floatboat/nexus-plugin-search` SHALL provide opt-in fuzzy matching through `findSearchMatches()` without changing the default exact search behavior.
+
+#### Scenario: Default exact search is unchanged
+- **WHEN** a host calls `findSearchMatches(doc, query)` without `fuzzy: true`
+- **THEN** the helper SHALL return exact matches using the existing case-sensitive, regexp, and whole-word options
+
+#### Scenario: Fuzzy search matches subsequences
+- **WHEN** a host calls `findSearchMatches(doc, query, { fuzzy: true })`
+- **THEN** the helper SHALL treat the query as a literal subsequence
+- **AND** it SHALL return matching spans that contain the matched subsequence
+
+### Requirement: Fuzzy Match Metadata
+
+Fuzzy search results SHALL include score and range metadata so host UIs can rank and highlight fuzzy hits without reparsing the text.
+
+#### Scenario: Fuzzy match exposes score
+- **WHEN** fuzzy search returns a match
+- **THEN** the match SHALL include a numeric `score`
+
+#### Scenario: Fuzzy match exposes ranges
+- **WHEN** fuzzy search returns a non-contiguous match
+- **THEN** the match SHALL include `ranges` for the contiguous matched character groups
+
+### Requirement: Fuzzy Result Ordering and Limits
+
+Fuzzy search SHALL support document-order results by default, score-first ordering when requested, and result capping after ordering.
+
+#### Scenario: Document order remains default
+- **WHEN** a host enables fuzzy search without `sortBy`
+- **THEN** matches SHALL be returned by their document position
+
+#### Scenario: Score ordering ranks better matches first
+- **WHEN** a host enables fuzzy search with `sortBy: "score"`
+- **THEN** matches with higher fuzzy scores SHALL be returned before lower-scored matches
+
+#### Scenario: Max matches caps ordered results
+- **WHEN** a host provides `maxMatches`
+- **THEN** the helper SHALL return no more than that many matches after applying the requested ordering
+
+### Requirement: Fuzzy Replacement
+
+`replaceAllMatches()` SHALL support fuzzy replacement by replacing each fuzzy match span literally while preserving regex capture replacement behavior for non-fuzzy regex search.
+
+#### Scenario: Fuzzy replacement replaces spans
+- **WHEN** a host calls `replaceAllMatches(doc, query, replacement, { fuzzy: true })`
+- **THEN** each fuzzy match span SHALL be replaced with the replacement text
+
+#### Scenario: Regex captures stay scoped to regex search
+- **WHEN** a host calls `replaceAllMatches()` with `regexp: true` and without `fuzzy: true`
+- **THEN** existing regex capture-group replacement behavior SHALL remain unchanged
+
+### Requirement: Demo Fuzzy Toggle
+
+The Electron demo search bar SHALL expose fuzzy matching as an opt-in toggle that demonstrates the helper without changing default demo search behavior.
+
+#### Scenario: Demo search remains exact by default
+- **WHEN** the Electron demo search bar opens
+- **THEN** fuzzy matching SHALL be disabled by default
+
+#### Scenario: Demo search can enable fuzzy matching
+- **WHEN** the user enables the fuzzy toggle and enters a query
+- **THEN** the demo search bar SHALL call the search helpers with `fuzzy: true`

--- a/openspec/changes/add-fuzzy-search/tasks.md
+++ b/openspec/changes/add-fuzzy-search/tasks.md
@@ -1,0 +1,27 @@
+## 1. OpenSpec
+
+- [x] 1.1 Create OpenSpec change `add-fuzzy-search`.
+- [x] 1.2 Define plugin-search fuzzy helper scope and CodeMirror panel non-goals.
+
+## 2. Plugin Search Implementation
+
+- [x] 2.1 Add typed fuzzy search options and fuzzy match metadata.
+- [x] 2.2 Implement dependency-free subsequence matching with ranking.
+- [x] 2.3 Preserve default exact, regex, whole-word, and replacement behavior.
+- [x] 2.4 Add `maxMatches` and score/document ordering support.
+- [x] 2.5 Add fuzzy replacement for helper-based replacement flows.
+
+## 3. Demo and Docs
+
+- [x] 3.1 Add a fuzzy toggle to the Electron demo search bar.
+- [x] 3.2 Document plugin-search fuzzy options and metadata.
+- [x] 3.3 Update roadmap status for Roadmap #17.
+
+## 4. Verification
+
+- [x] 4.1 Add Vitest coverage for fuzzy matching, ranking, case sensitivity, limits, boundaries, and replacement.
+- [x] 4.2 Run targeted plugin-search Vitest suite.
+- [x] 4.3 Run plugin-search TypeScript check.
+- [x] 4.4 Run plugin-search build.
+- [ ] 4.5 Run `openspec validate add-fuzzy-search --strict` — CLI is not installed in this dev environment; spec format was hand-checked against `openspec/AGENTS.md`.
+- [ ] 4.6 Run full repo `pnpm test` after full dependency install is available; direct full Vitest run is blocked locally by missing workspace dependencies after `pnpm install` timed out on `app-builder-bin`.

--- a/packages/plugin-search/README.md
+++ b/packages/plugin-search/README.md
@@ -1,0 +1,52 @@
+# @floatboat/nexus-plugin-search
+
+Search helpers and a CodeMirror search panel for Nexus Editor.
+
+## Usage
+
+```ts
+import {
+  createSearchPlugin,
+  findSearchMatches,
+  replaceAllMatches
+} from "@floatboat/nexus-plugin-search";
+
+const plugin = createSearchPlugin();
+
+const exact = findSearchMatches("Hello hello", "hello");
+const fuzzy = findSearchMatches("Nexus Editor\nplain note", "ne", {
+  fuzzy: true,
+  sortBy: "score"
+});
+
+const nextDoc = replaceAllMatches("Nexus Editor", "ne", "NE", {
+  fuzzy: true
+});
+```
+
+## Match Options
+
+`findSearchMatches(doc, query, options)` supports:
+
+- `caseSensitive`: match exact character casing.
+- `wholeWord`: require word boundaries around the final match span.
+- `regexp`: treat `query` as a regular expression for exact search.
+- `fuzzy`: treat `query` as a literal subsequence and return one best match per line.
+- `maxMatches`: cap returned matches after sorting.
+- `sortBy`: `"position"` by default, or `"score"` for best fuzzy hits first.
+
+Fuzzy matches include a `score` and `ranges` metadata:
+
+```ts
+[
+  {
+    from: 0,
+    to: 2,
+    text: "Ne",
+    score: 1183,
+    ranges: [{ from: 0, to: 2, text: "Ne" }]
+  }
+]
+```
+
+The score favors adjacent characters, word or camel-case boundaries, exact-case matches, short spans, and earlier line positions. Regex replacement capture groups are supported only for non-fuzzy regex search; fuzzy replacement replaces the matched span literally.

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -282,7 +282,7 @@ function isFuzzyBoundary(value: string, index: number): boolean {
 }
 
 function normalizeChar(value: string, caseSensitive: boolean): string {
-  return caseSensitive ? value : value.toLocaleLowerCase();
+  return caseSensitive ? value : value.toLowerCase();
 }
 
 interface FuzzyCandidate {
@@ -290,53 +290,87 @@ interface FuzzyCandidate {
   score: number;
 }
 
+interface FuzzyCandidateState {
+  index: number;
+  prev: FuzzyCandidateState | null;
+  score: number;
+}
+
+interface FuzzyQuery {
+  chars: string[];
+  normalizedChars: string[];
+  caseSensitive: boolean;
+}
+
+function createFuzzyQuery(query: string, caseSensitive: boolean): FuzzyQuery | null {
+  if (!query) return null;
+
+  const chars = query.split("");
+  return {
+    chars,
+    normalizedChars: chars.map((char) => normalizeChar(char, caseSensitive)),
+    caseSensitive
+  };
+}
+
+function fuzzyCandidateIndexes(candidate: FuzzyCandidateState): number[] {
+  const indexes: number[] = [];
+  let current: FuzzyCandidateState | null = candidate;
+
+  while (current) {
+    indexes.push(current.index);
+    current = current.prev;
+  }
+
+  return indexes.reverse();
+}
+
 function findBestFuzzyCandidate(
   value: string,
-  query: string,
-  caseSensitive: boolean
+  query: FuzzyQuery
 ): FuzzyCandidate | null {
-  if (!value || !query) return null;
+  if (!value || query.chars.length > value.length) return null;
 
-  const queryChars = query.split("");
-  const states: Array<FuzzyCandidate | null> = Array(queryChars.length).fill(null);
+  const states: Array<FuzzyCandidateState | null> = Array(query.chars.length).fill(null);
 
   for (let index = 0; index < value.length; index += 1) {
     const char = value[index] ?? "";
+    const normalizedChar = normalizeChar(char, query.caseSensitive);
 
-    for (let queryIndex = queryChars.length - 1; queryIndex >= 0; queryIndex -= 1) {
-      if (normalizeChar(char, caseSensitive) !== normalizeChar(queryChars[queryIndex] ?? "", caseSensitive)) {
+    for (let queryIndex = query.chars.length - 1; queryIndex >= 0; queryIndex -= 1) {
+      if (normalizedChar !== query.normalizedChars[queryIndex]) {
         continue;
       }
 
       const previous = queryIndex === 0 ? null : states[queryIndex - 1];
       if (queryIndex > 0 && !previous) continue;
 
-      const previousIndex = previous?.indexes[previous.indexes.length - 1] ?? -1;
+      const previousIndex = previous?.index ?? -1;
       const gap = previousIndex >= 0 ? index - previousIndex - 1 : 0;
       const adjacentBonus = gap === 0 && previousIndex >= 0 ? 80 : 0;
       const boundaryBonus = isFuzzyBoundary(value, index) ? 35 : 0;
-      const exactCaseBonus = char === (queryChars[queryIndex] ?? "") ? 10 : 0;
+      const exactCaseBonus = char === (query.chars[queryIndex] ?? "") ? 10 : 0;
       const gapPenalty = previousIndex >= 0 ? Math.min(40, gap * 4) : 0;
       const score = (previous?.score ?? 0) + 20 + adjacentBonus + boundaryBonus + exactCaseBonus - gapPenalty;
-      const indexes = [...(previous?.indexes ?? []), index];
       const current = states[queryIndex];
 
       if (!current || score > current.score) {
-        states[queryIndex] = { indexes, score };
+        states[queryIndex] = { index, prev: previous, score };
       }
     }
   }
 
-  const candidate = states[queryChars.length - 1];
+  const candidate = states[query.chars.length - 1];
   if (!candidate) return null;
 
-  const first = candidate.indexes[0] ?? 0;
-  const last = candidate.indexes[candidate.indexes.length - 1] ?? first;
+  const indexes = fuzzyCandidateIndexes(candidate);
+  const first = indexes[0] ?? 0;
+  const last = indexes[indexes.length - 1] ?? first;
   const span = last - first + 1;
 
   return {
-    indexes: candidate.indexes,
-    score: candidate.score + 1000 + queryChars.length * 15 - span * 3 - first
+    indexes,
+    score: candidate.score + 1000 + query.chars.length * 15 - span * 3 - first
   };
 }
 
@@ -379,12 +413,28 @@ function compareSearchMatches(a: SearchMatch, b: SearchMatch, sortBy: SearchOpti
   return a.from - b.from || a.to - b.to;
 }
 
-function applyMaxMatches(matches: SearchMatch[], maxMatches: number | undefined): SearchMatch[] {
+function resolveMatchLimit(maxMatches: number | undefined): number | null {
   if (maxMatches === undefined || !Number.isFinite(maxMatches)) {
+    return null;
+  }
+
+  return Math.max(0, Math.floor(maxMatches));
+}
+
+function applyMaxMatches(matches: SearchMatch[], limit: number | null): SearchMatch[] {
+  return limit === null ? matches : matches.slice(0, limit);
+}
+
+function hasReachedMatchLimit(matches: SearchMatch[], limit: number | null): boolean {
+  return limit !== null && matches.length >= limit;
+}
+
+function orderSearchMatches(matches: SearchMatch[], sortBy: SearchOptions["sortBy"]): SearchMatch[] {
+  if (sortBy !== "score") {
     return matches;
   }
 
-  return matches.slice(0, Math.max(0, Math.floor(maxMatches)));
+  return matches.sort((a, b) => compareSearchMatches(a, b, sortBy));
 }
 
 function findFuzzySearchMatches(
@@ -392,6 +442,13 @@ function findFuzzySearchMatches(
   query: string,
   options: SearchOptions = {}
 ): SearchMatch[] {
+  const sortBy = options.sortBy ?? "position";
+  const limit = resolveMatchLimit(options.maxMatches);
+  if (limit === 0) return [];
+
+  const queryState = createFuzzyQuery(query, options.caseSensitive ?? false);
+  if (!queryState) return [];
+
   const matches: SearchMatch[] = [];
   let lineStart = 0;
 
@@ -399,7 +456,7 @@ function findFuzzySearchMatches(
     const newlineIndex = doc.indexOf("\n", lineStart);
     const lineEnd = newlineIndex === -1 ? doc.length : newlineIndex;
     const line = doc.slice(lineStart, lineEnd);
-    const candidate = findBestFuzzyCandidate(line, query, options.caseSensitive ?? false);
+    const candidate = findBestFuzzyCandidate(line, queryState);
 
     if (candidate) {
       const first = candidate.indexes[0] ?? 0;
@@ -415,6 +472,9 @@ function findFuzzySearchMatches(
           score: candidate.score,
           ranges: toFuzzyRanges(line, lineStart, candidate.indexes)
         });
+        if (sortBy === "position" && hasReachedMatchLimit(matches, limit)) {
+          break;
+        }
       }
     }
 
@@ -422,8 +482,7 @@ function findFuzzySearchMatches(
     lineStart = newlineIndex + 1;
   }
 
-  matches.sort((a, b) => compareSearchMatches(a, b, options.sortBy ?? "position"));
-  return applyMaxMatches(matches, options.maxMatches);
+  return applyMaxMatches(orderSearchMatches(matches, sortBy), limit);
 }
 
 export function findSearchMatches(
@@ -443,6 +502,10 @@ export function findSearchMatches(
   if (!pattern) {
     return [];
   }
+  const sortBy = options.sortBy ?? "position";
+  const limit = resolveMatchLimit(options.maxMatches);
+  if (limit === 0) return [];
+
   const matches: SearchMatch[] = [];
 
   for (const match of doc.matchAll(pattern)) {
@@ -454,10 +517,12 @@ export function findSearchMatches(
       to: from + text.length,
       text
     });
+    if (hasReachedMatchLimit(matches, limit)) {
+      break;
+    }
   }
 
-  matches.sort((a, b) => compareSearchMatches(a, b, options.sortBy ?? "position"));
-  return applyMaxMatches(matches, options.maxMatches);
+  return applyMaxMatches(matches, limit);
 }
 
 export function replaceAllMatches(

--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -21,12 +21,23 @@ export interface SearchMatch {
   from: number;
   to: number;
   text: string;
+  score?: number;
+  ranges?: SearchMatchRange[];
+}
+
+export interface SearchMatchRange {
+  from: number;
+  to: number;
+  text: string;
 }
 
 export interface SearchOptions {
   caseSensitive?: boolean;
   wholeWord?: boolean;
   regexp?: boolean;
+  fuzzy?: boolean;
+  maxMatches?: number;
+  sortBy?: "position" | "score";
 }
 
 export interface SearchHistoryStorage {
@@ -250,6 +261,171 @@ function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp 
   }
 }
 
+function isWordChar(value: string): boolean {
+  return /[\p{L}\p{N}_]/u.test(value);
+}
+
+function isWordBoundary(value: string, from: number, to: number): boolean {
+  const before = from <= 0 ? "" : value[from - 1] ?? "";
+  const after = to >= value.length ? "" : value[to] ?? "";
+  return (!before || !isWordChar(before)) && (!after || !isWordChar(after));
+}
+
+function isFuzzyBoundary(value: string, index: number): boolean {
+  if (index <= 0) return true;
+
+  const previous = value[index - 1] ?? "";
+  const current = value[index] ?? "";
+  if (!isWordChar(previous)) return true;
+
+  return /[a-z]/.test(previous) && /[A-Z]/.test(current);
+}
+
+function normalizeChar(value: string, caseSensitive: boolean): string {
+  return caseSensitive ? value : value.toLocaleLowerCase();
+}
+
+interface FuzzyCandidate {
+  indexes: number[];
+  score: number;
+}
+
+function findBestFuzzyCandidate(
+  value: string,
+  query: string,
+  caseSensitive: boolean
+): FuzzyCandidate | null {
+  if (!value || !query) return null;
+
+  const queryChars = query.split("");
+  const states: Array<FuzzyCandidate | null> = Array(queryChars.length).fill(null);
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+
+    for (let queryIndex = queryChars.length - 1; queryIndex >= 0; queryIndex -= 1) {
+      if (normalizeChar(char, caseSensitive) !== normalizeChar(queryChars[queryIndex] ?? "", caseSensitive)) {
+        continue;
+      }
+
+      const previous = queryIndex === 0 ? null : states[queryIndex - 1];
+      if (queryIndex > 0 && !previous) continue;
+
+      const previousIndex = previous?.indexes[previous.indexes.length - 1] ?? -1;
+      const gap = previousIndex >= 0 ? index - previousIndex - 1 : 0;
+      const adjacentBonus = gap === 0 && previousIndex >= 0 ? 80 : 0;
+      const boundaryBonus = isFuzzyBoundary(value, index) ? 35 : 0;
+      const exactCaseBonus = char === (queryChars[queryIndex] ?? "") ? 10 : 0;
+      const gapPenalty = previousIndex >= 0 ? Math.min(40, gap * 4) : 0;
+      const score = (previous?.score ?? 0) + 20 + adjacentBonus + boundaryBonus + exactCaseBonus - gapPenalty;
+      const indexes = [...(previous?.indexes ?? []), index];
+      const current = states[queryIndex];
+
+      if (!current || score > current.score) {
+        states[queryIndex] = { indexes, score };
+      }
+    }
+  }
+
+  const candidate = states[queryChars.length - 1];
+  if (!candidate) return null;
+
+  const first = candidate.indexes[0] ?? 0;
+  const last = candidate.indexes[candidate.indexes.length - 1] ?? first;
+  const span = last - first + 1;
+
+  return {
+    indexes: candidate.indexes,
+    score: candidate.score + 1000 + queryChars.length * 15 - span * 3 - first
+  };
+}
+
+function toFuzzyRanges(line: string, lineStart: number, indexes: number[]): SearchMatchRange[] {
+  const ranges: SearchMatchRange[] = [];
+  let rangeStart = indexes[0] ?? 0;
+  let previous = rangeStart;
+
+  for (let i = 1; i < indexes.length; i += 1) {
+    const index = indexes[i] ?? previous;
+    if (index === previous + 1) {
+      previous = index;
+      continue;
+    }
+
+    ranges.push({
+      from: lineStart + rangeStart,
+      to: lineStart + previous + 1,
+      text: line.slice(rangeStart, previous + 1)
+    });
+    rangeStart = index;
+    previous = index;
+  }
+
+  ranges.push({
+    from: lineStart + rangeStart,
+    to: lineStart + previous + 1,
+    text: line.slice(rangeStart, previous + 1)
+  });
+
+  return ranges;
+}
+
+function compareSearchMatches(a: SearchMatch, b: SearchMatch, sortBy: SearchOptions["sortBy"]): number {
+  if (sortBy === "score") {
+    const scoreDiff = (b.score ?? 0) - (a.score ?? 0);
+    if (scoreDiff !== 0) return scoreDiff;
+  }
+
+  return a.from - b.from || a.to - b.to;
+}
+
+function applyMaxMatches(matches: SearchMatch[], maxMatches: number | undefined): SearchMatch[] {
+  if (maxMatches === undefined || !Number.isFinite(maxMatches)) {
+    return matches;
+  }
+
+  return matches.slice(0, Math.max(0, Math.floor(maxMatches)));
+}
+
+function findFuzzySearchMatches(
+  doc: string,
+  query: string,
+  options: SearchOptions = {}
+): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+  let lineStart = 0;
+
+  while (lineStart <= doc.length) {
+    const newlineIndex = doc.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? doc.length : newlineIndex;
+    const line = doc.slice(lineStart, lineEnd);
+    const candidate = findBestFuzzyCandidate(line, query, options.caseSensitive ?? false);
+
+    if (candidate) {
+      const first = candidate.indexes[0] ?? 0;
+      const last = candidate.indexes[candidate.indexes.length - 1] ?? first;
+      const from = lineStart + first;
+      const to = lineStart + last + 1;
+
+      if (!options.wholeWord || isWordBoundary(doc, from, to)) {
+        matches.push({
+          from,
+          to,
+          text: doc.slice(from, to),
+          score: candidate.score,
+          ranges: toFuzzyRanges(line, lineStart, candidate.indexes)
+        });
+      }
+    }
+
+    if (newlineIndex === -1) break;
+    lineStart = newlineIndex + 1;
+  }
+
+  matches.sort((a, b) => compareSearchMatches(a, b, options.sortBy ?? "position"));
+  return applyMaxMatches(matches, options.maxMatches);
+}
+
 export function findSearchMatches(
   doc: string,
   query: string,
@@ -257,6 +433,10 @@ export function findSearchMatches(
 ): SearchMatch[] {
   if (!query) {
     return [];
+  }
+
+  if (options.fuzzy) {
+    return findFuzzySearchMatches(doc, query, options);
   }
 
   const pattern = buildSearchPattern(query, options);
@@ -276,7 +456,8 @@ export function findSearchMatches(
     });
   }
 
-  return matches;
+  matches.sort((a, b) => compareSearchMatches(a, b, options.sortBy ?? "position"));
+  return applyMaxMatches(matches, options.maxMatches);
 }
 
 export function replaceAllMatches(
@@ -287,6 +468,15 @@ export function replaceAllMatches(
 ): string {
   if (!query) {
     return doc;
+  }
+
+  if (options.fuzzy) {
+    const matches = findFuzzySearchMatches(doc, query, options);
+    let replaced = doc;
+    for (const match of matches.slice().sort((a, b) => b.from - a.from)) {
+      replaced = replaced.slice(0, match.from) + replacement + replaced.slice(match.to);
+    }
+    return replaced;
   }
 
   const pattern = buildSearchPattern(query, options);

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -241,6 +241,99 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("supports fuzzy subsequence matching by line", () => {
+    expect(findSearchMatches("Ne\nnext\nplain note", "ne", { fuzzy: true })).toEqual([
+      {
+        from: 0,
+        to: 2,
+        text: "Ne",
+        score: expect.any(Number),
+        ranges: [{ from: 0, to: 2, text: "Ne" }]
+      },
+      {
+        from: 3,
+        to: 5,
+        text: "ne",
+        score: expect.any(Number),
+        ranges: [{ from: 3, to: 5, text: "ne" }]
+      },
+      {
+        from: 14,
+        to: 18,
+        text: "note",
+        score: expect.any(Number),
+        ranges: [
+          { from: 14, to: 15, text: "n" },
+          { from: 17, to: 18, text: "e" }
+        ]
+      }
+    ]);
+  });
+
+  it("can rank fuzzy matches by score", () => {
+    const matches = findSearchMatches("Nexus Editor\nnote extractor", "ne", {
+      fuzzy: true,
+      sortBy: "score"
+    });
+
+    expect(matches.map((match) => match.text)).toEqual(["Ne", "note e"]);
+    expect(matches[0].score).toBeGreaterThan(matches[1].score ?? 0);
+  });
+
+  it("honors case-sensitive fuzzy matching", () => {
+    expect(findSearchMatches("Nexus\nnext\nNEON", "Ne", { fuzzy: true, caseSensitive: true })).toEqual([
+      {
+        from: 0,
+        to: 2,
+        text: "Ne",
+        score: expect.any(Number),
+        ranges: [{ from: 0, to: 2, text: "Ne" }]
+      }
+    ]);
+  });
+
+  it("limits fuzzy matches after sorting", () => {
+    const matches = findSearchMatches("Nexus\nNeedle\nnote", "ne", {
+      fuzzy: true,
+      sortBy: "score",
+      maxMatches: 1
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe("Ne");
+  });
+
+  it("applies whole-word boundaries to fuzzy match spans", () => {
+    expect(findSearchMatches("a b\nalphaBeta", "ab", { fuzzy: true, wholeWord: true })).toEqual([
+      {
+        from: 0,
+        to: 3,
+        text: "a b",
+        score: expect.any(Number),
+        ranges: [
+          { from: 0, to: 1, text: "a" },
+          { from: 2, to: 3, text: "b" }
+        ]
+      }
+    ]);
+  });
+
+  it("replaces fuzzy match spans without regex captures", () => {
+    expect(replaceAllMatches("Nexus Editor\nplain note", "ne", "NE", { fuzzy: true })).toBe(
+      "NExus Editor\nplain NE"
+    );
+  });
+
+  it("applies fuzzy replacement limits after requested ordering", () => {
+    expect(
+      replaceAllMatches("n------e\nNe", "ne", "NE", {
+        fuzzy: true,
+        sortBy: "score",
+        maxMatches: 1
+      })
+    ).toBe("n------e\nNE");
+  });
+
   it("creates a search plugin descriptor", () => {
     const plugin = createSearchPlugin();
 

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -193,6 +193,24 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("limits exact matches in document order", () => {
+    expect(findSearchMatches("alpha alpha alpha", "alpha", { maxMatches: 2 })).toEqual([
+      { from: 0, to: 5, text: "alpha" },
+      { from: 6, to: 11, text: "alpha" }
+    ]);
+  });
+
+  it("treats score sorting as document order for exact matches", () => {
+    expect(findSearchMatches("alpha alpha alpha", "alpha", { maxMatches: 2, sortBy: "score" })).toEqual([
+      { from: 0, to: 5, text: "alpha" },
+      { from: 6, to: 11, text: "alpha" }
+    ]);
+  });
+
+  it("returns no exact matches when maxMatches is zero", () => {
+    expect(findSearchMatches("alpha alpha", "alpha", { maxMatches: 0 })).toEqual([]);
+  });
+
   it("replaces all matches in a document", () => {
     expect(replaceAllMatches("cat scatter cat", "cat", "dog")).toBe("dog sdogter dog");
   });
@@ -301,6 +319,20 @@ describe("@floatboat/nexus-plugin-search", () => {
 
     expect(matches).toHaveLength(1);
     expect(matches[0].text).toBe("Ne");
+  });
+
+  it("limits fuzzy matches in document order by default", () => {
+    const matches = findSearchMatches("Nexus\nNeedle\nnote", "ne", {
+      fuzzy: true,
+      maxMatches: 2
+    });
+
+    expect(matches.map((match) => match.from)).toEqual([0, 6]);
+    expect(matches.map((match) => match.text)).toEqual(["Ne", "Ne"]);
+  });
+
+  it("returns no fuzzy matches when maxMatches is zero", () => {
+    expect(findSearchMatches("Nexus\nNeedle\nnote", "ne", { fuzzy: true, maxMatches: 0 })).toEqual([]);
   });
 
   it("applies whole-word boundaries to fuzzy match spans", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,10 @@ importers:
       '@floatboat/nexus-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@floatboat/nexus-plugin-history':
+        specifier: workspace:*
+        version: link:../plugin-history
 
   packages/plugin-vim:
     dependencies:


### PR DESCRIPTION
## Summary

Add opt-in fuzzy search helpers to `@floatboat/nexus-plugin-search`, with score/range metadata for host UIs and a visible Electron demo toggle.

## Changes

- Add `SearchOptions.fuzzy`, `sortBy`, and `maxMatches`.
- Return fuzzy `score` and contiguous `ranges` metadata for highlighting.
- Keep exact, regex, whole-word, and CodeMirror panel behavior unchanged by default.
- Support fuzzy replacement spans, including `sortBy: "score"` plus `maxMatches` limiting.
- Add a fuzzy toggle to the Electron demo search bar.
- Document the plugin-search fuzzy API and add OpenSpec change files.
- Update README/roadmap references for fuzzy search.

## Verification

- `./node_modules/.bin/vitest run packages/plugin-search/test/plugin-search.test.ts`
- `./node_modules/.bin/tsc -p packages/plugin-search/tsconfig.json --noEmit`
- `./node_modules/.bin/tsup packages/plugin-search/src/index.ts --format esm --dts --clean`
- `git diff --check`

## Notes

- `openspec validate add-fuzzy-search --strict` could not be run locally because the OpenSpec CLI is not installed in this environment; the spec format was checked against `openspec/AGENTS.md`.
- A direct full Vitest run was attempted, but the local dependency install is incomplete after `pnpm install` timed out downloading `app-builder-bin`; unrelated suites fail to resolve missing workspace dependencies such as `remark-gfm`, `@codemirror/commands`, and `electron`. The targeted plugin-search suite passes.
