### PR TITLE
fix: restore workspace install and electron typecheck

### DIFF
--- a/apps/electron-demo/tsconfig.json
+++ b/apps/electron-demo/tsconfig.json
@@ -8,7 +8,8 @@
       "@floatboat/nexus-plugin-history": ["packages/plugin-history/src/index.ts"],
       "@floatboat/nexus-plugin-search": ["packages/plugin-search/src/index.ts"],
       "@floatboat/nexus-plugin-slash": ["packages/plugin-slash/src/index.ts"],
-      "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"]
+      "@floatboat/nexus-plugin-toolbar": ["packages/plugin-toolbar/src/index.ts"],
+      "@floatboat/nexus-plugin-wordcount": ["packages/plugin-wordcount/src/index.ts"]
     }
   },
   "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,10 @@ importers:
       '@floatboat/nexus-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@floatboat/nexus-plugin-history':
+        specifier: workspace:*
+        version: link:../plugin-history
 
   packages/plugin-vim:
     dependencies:


### PR DESCRIPTION
## Summary / 摘要

Restore CI install/typecheck wiring after the wordcount and toolbar workspace updates.

## Motivation / 背景与动机

- Issue: none
- Roadmap (docs/ROADMAP.md): #28 wordcount is marked done and used by the Electron demo
- OpenSpec change: none — bug/config fix only

`pnpm install --frozen-lockfile` currently fails because `packages/plugin-toolbar/package.json` declares `@floatboat/nexus-plugin-history` as a workspace dev dependency, but the lockfile importer was not updated.

The Electron demo also imports `@floatboat/nexus-plugin-wordcount` from `src/renderer/editor-shell.ts`, but its local `tsconfig.json` overrides the root path aliases and omits the wordcount alias. That makes the demo fail `tsc --noEmit` even though the package dependency exists.

## Changes / 变更内容

- `apps/electron-demo`:
  - add the missing `@floatboat/nexus-plugin-wordcount` path alias so demo typecheck resolves the workspace source consistently with Vite and the root tsconfig
- `packages/plugin-toolbar`:
  - sync `pnpm-lock.yaml` with the existing `@floatboat/nexus-plugin-history` devDependency declared in `packages/plugin-toolbar/package.json`
- `openspec/`:
  - not changed; this is not a new capability or public API change

## Testing / 测试

- [x] `CI=true corepack pnpm@9.15.4 install --frozen-lockfile`
- [x] `corepack pnpm@9.15.4 -r exec tsc --noEmit`
- [x] `corepack pnpm@9.15.4 test` — 514 tests passed
- [x] `corepack pnpm@9.15.4 -r --filter './packages/*' run build`
- [x] `corepack pnpm@9.15.4 --filter @floatboat/nexus-electron-demo build`
- [x] New / updated vitest cases: not needed; dependency wiring/config-only fix
- [ ] Manual UI check in electron-demo: not needed; no UI behavior changed

## Compliance / 合规自检

- [x] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI disclosure**: the functional code in this PR is **not** primarily generated by AI. AI assistance was used for repository triage, command selection, and PR description drafting; the final change is a minimal config/lockfile wiring fix reviewed against the failing commands above.
- [x] **New dependencies**: none
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`)
- [x] **No secrets** / `.env` / personal vault data committed

## Checklist / 自检清单

- [x] Title follows Conventional Commits
- [x] Public API changes update package README / types — no public API changes
- [x] Touched `live-preview-table.ts` — no
- [x] New capability / breaking change — no OpenSpec needed
- [x] Change aligns with project scope (GOVERNANCE.md §4)

## Screenshots / Recordings · 截图或录屏 (UI changes)

Not applicable.
