### PR TITLE
fix(toolbar): make formatting commands atomic undo operations

### DIFF
--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -69,9 +69,7 @@ function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   const line = doc.slice(lineStart, lineEnd);
 
   const newLine = line.startsWith(prefix) ? line.slice(prefix.length) : prefix + line;
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.replaceRange(lineStart, lineEnd, newLine, { anchor: lineStart + newLine.length });
   return true;
 }
 
@@ -135,12 +133,9 @@ export function insertCodeBlock(editor: EditorAPI): boolean {
     "```\n" + (selected || "") + "\n```" +
     (needsTrailingNewline ? "\n" : "");
 
-  const newDoc = doc.slice(0, from) + block + doc.slice(to);
-  editor.setDocument(newDoc);
-
   // Place cursor on the language line (after ```)
   const langPos = from + (needsLeadingNewline ? 1 : 0) + 3;
-  editor.setSelection(langPos);
+  editor.replaceRange(from, to, block, { anchor: langPos });
   return true;
 }
 
@@ -153,12 +148,10 @@ export function insertImage(editor: EditorAPI): boolean {
 
   const alt = selected || "alt text";
   const md = `![${alt}](url)`;
-  const newDoc = doc.slice(0, from) + md + doc.slice(to);
-  editor.setDocument(newDoc);
 
   // Select the "url" part
   const urlStart = from + alt.length + 4;
-  editor.setSelection(urlStart, urlStart + 3);
+  editor.replaceRange(from, to, md, { anchor: urlStart, head: urlStart + 3 });
   return true;
 }
 
@@ -171,11 +164,10 @@ export function applyTextColor(editor: EditorAPI, color: string): boolean {
 
   if (from === to) return false;
 
-  const wrapped = `<span style="color:${color}">${selected}</span>`;
-  const newDoc = doc.slice(0, from) + wrapped + doc.slice(to);
-  editor.setDocument(newDoc);
-  const innerStart = from + `<span style="color:${color}">`.length;
-  editor.setSelection(innerStart, innerStart + selected.length);
+  const open = `<span style="color:${color}">`;
+  const wrapped = `${open}${selected}</span>`;
+  const innerStart = from + open.length;
+  editor.replaceRange(from, to, wrapped, { anchor: innerStart, head: innerStart + selected.length });
   return true;
 }
 
@@ -188,11 +180,10 @@ export function applyHighlight(editor: EditorAPI, color: string): boolean {
 
   if (from === to) return false;
 
-  const wrapped = `<mark style="background:${color}">${selected}</mark>`;
-  const newDoc = doc.slice(0, from) + wrapped + doc.slice(to);
-  editor.setDocument(newDoc);
-  const innerStart = from + `<mark style="background:${color}">`.length;
-  editor.setSelection(innerStart, innerStart + selected.length);
+  const open = `<mark style="background:${color}">`;
+  const wrapped = `${open}${selected}</mark>`;
+  const innerStart = from + open.length;
+  editor.replaceRange(from, to, wrapped, { anchor: innerStart, head: innerStart + selected.length });
   return true;
 }
 
@@ -203,8 +194,6 @@ export function insertHorizontalRule(editor: EditorAPI): boolean {
   const needsLeadingNewline = anchor > 0 && doc[anchor - 1] !== "\n";
   const hr = (needsLeadingNewline ? "\n" : "") + "---\n";
 
-  const newDoc = doc.slice(0, anchor) + hr + doc.slice(anchor);
-  editor.setDocument(newDoc);
-  editor.setSelection(anchor + hr.length);
+  editor.replaceRange(anchor, anchor, hr, { anchor: anchor + hr.length });
   return true;
 }

--- a/packages/plugin-toolbar/src/index.ts
+++ b/packages/plugin-toolbar/src/index.ts
@@ -26,20 +26,22 @@ export function toggleWrap(editor: EditorAPI, marker: string): boolean {
 
   if (before === marker && after === marker) {
     // Already wrapped — remove markers
-    const newDoc =
-      doc.slice(0, from - marker.length) +
-      selected +
-      doc.slice(to + marker.length);
-    editor.setDocument(newDoc);
-    editor.setSelection(from - marker.length, to - marker.length);
+    editor.replaceRange(
+      from - marker.length,
+      to + marker.length,
+      selected,
+      { anchor: from - marker.length, head: to - marker.length }
+    );
     return true;
   }
 
   // Wrap selection with markers
-  const newDoc =
-    doc.slice(0, from) + marker + selected + marker + doc.slice(to);
-  editor.setDocument(newDoc);
-  editor.setSelection(from + marker.length, to + marker.length);
+  editor.replaceRange(
+    from,
+    to,
+    marker + selected + marker,
+    { anchor: from + marker.length, head: to + marker.length }
+  );
   return true;
 }
 
@@ -68,12 +70,10 @@ export function insertLink(editor: EditorAPI): boolean {
 
   const linkText = selected || "link text";
   const md = `[${linkText}](url)`;
-  const newDoc = doc.slice(0, from) + md + doc.slice(to);
-  editor.setDocument(newDoc);
 
   // Select the "url" part for easy replacement
   const urlStart = from + linkText.length + 3;
-  editor.setSelection(urlStart, urlStart + 3);
+  editor.replaceRange(from, to, md, { anchor: urlStart, head: urlStart + 3 });
   return true;
 }
 
@@ -100,9 +100,7 @@ export function toggleHeading(editor: EditorAPI, level: number): boolean {
     newLine = prefix + line;
   }
 
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(end);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
+  editor.replaceRange(lineStart, end, newLine, { anchor: lineStart + newLine.length });
   return true;
 }
 

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { createEditor } from "@floatboat/nexus-core";
+import { createEditor, type EditorAPI } from "@floatboat/nexus-core";
 import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
 import {
+  applyHighlight,
+  applyTextColor,
   toggleBold,
+  toggleBlockquote,
+  toggleStrikethrough,
   toggleItalic,
   toggleInlineCode,
+  insertCodeBlock,
+  insertHorizontalRule,
+  insertImage,
   insertLink,
   toggleHeading,
   toggleOrderedList,
@@ -493,6 +500,132 @@ describe("createToolbarUI", () => {
 
     toolbar.destroy();
     editor.destroy();
+  });
+});
+
+describe("toolbar formatting commands — atomic undo", () => {
+  function expectSingleUndoStep(options: {
+    initialValue: string;
+    select?: [number, number?];
+    run: (editor: EditorAPI) => boolean;
+    expected: string;
+  }) {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: options.initialValue,
+      plugins: [createHistoryPlugin()],
+    });
+
+    const [anchor, head] = options.select ?? [0];
+    editor.setSelection(anchor, head);
+
+    expect(options.run(editor)).toBe(true);
+    expect(editor.getDocument()).toBe(options.expected);
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe(options.initialValue);
+    expect(editor.undo()).toBe(false);
+    editor.destroy();
+  }
+
+  it("wraps and unwraps inline formatting in one undo step", () => {
+    expectSingleUndoStep({
+      initialValue: "hello world",
+      select: [6, 11],
+      run: toggleBold,
+      expected: "hello **world**",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "hello **world**",
+      select: [8, 13],
+      run: toggleBold,
+      expected: "hello world",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "hello world",
+      select: [6, 11],
+      run: toggleItalic,
+      expected: "hello *world*",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "hello world",
+      select: [6, 11],
+      run: toggleStrikethrough,
+      expected: "hello ~~world~~",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "hello world",
+      select: [6, 11],
+      run: toggleInlineCode,
+      expected: "hello `world`",
+    });
+  });
+
+  it("inserts inline templates in one undo step", () => {
+    expectSingleUndoStep({
+      initialValue: "click here",
+      select: [6, 10],
+      run: insertLink,
+      expected: "click [here](url)",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "photo",
+      select: [0, 5],
+      run: insertImage,
+      expected: "![photo](url)",
+    });
+  });
+
+  it("updates line and block formatting in one undo step", () => {
+    expectSingleUndoStep({
+      initialValue: "Title",
+      select: [2],
+      run: (editor) => toggleHeading(editor, 2),
+      expected: "## Title",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "quote",
+      select: [2],
+      run: toggleBlockquote,
+      expected: "> quote",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "hello",
+      select: [0, 5],
+      run: insertCodeBlock,
+      expected: "```\nhello\n```",
+    });
+
+    expectSingleUndoStep({
+      initialValue: "",
+      select: [0],
+      run: insertHorizontalRule,
+      expected: "---\n",
+    });
+  });
+
+  it("applies HTML color wrappers in one undo step", () => {
+    expectSingleUndoStep({
+      initialValue: "hello",
+      select: [0, 5],
+      run: (editor) => applyTextColor(editor, "#f00"),
+      expected: '<span style="color:#f00">hello</span>',
+    });
+
+    expectSingleUndoStep({
+      initialValue: "hello",
+      select: [0, 5],
+      run: (editor) => applyHighlight(editor, "#ff0"),
+      expected: '<mark style="background:#ff0">hello</mark>',
+    });
   });
 });
 


### PR DESCRIPTION

## Summary / 摘要

Make toolbar formatting commands update document content and selection in a single editor transaction.

## Motivation / 背景与动机

Several toolbar commands updated the document with `setDocument()` and then moved the selection with `setSelection()`. With history enabled, that can create multiple undo steps for one user action.

This means a single Undo may only revert the selection move or leave the document in a partially reverted state. Toolbar commands should behave like one atomic editor operation: apply formatting and selection update together, then undo together.

- Issue: N/A
- Roadmap (docs/ROADMAP.md): N/A
- OpenSpec change: N/A, bug fix only

## Changes / 变更内容

- `packages/plugin-toolbar`:
  - Replaced `setDocument()` + `setSelection()` flows with `replaceRange()` for toolbar formatting commands.
  - Covered inline formatting commands: bold, italic, strikethrough, inline code.
  - Covered template/block commands: link, image, heading, blockquote, code block, horizontal rule.
  - Covered HTML wrapper commands: text color and highlight.
  - Added history regression tests proving each command creates one undo step.

- `packages/core`: N/A
- `apps/electron-demo`: N/A
- `openspec/`: N/A

## Testing / 测试

- [x] `pnpm test` passes / 全绿
- [x] Affected package typecheck passes / 受影响包类型检查通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - `packages/plugin-toolbar/test/plugin-toolbar.test.ts`
  - Covers toolbar formatting commands with `createHistoryPlugin()`
  - Verifies one Undo fully restores the original document and a second Undo returns false
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：not required for this non-visual behavior fix

Commands run:

```bash
pnpm test packages/plugin-toolbar/test/plugin-toolbar.test.ts
pnpm --filter @floatboat/nexus-plugin-toolbar exec tsc --noEmit
pnpm test
git diff --check
```

Note:

`pnpm typecheck` currently fails in an unrelated existing path because `apps/electron-demo` cannot resolve `@floatboat/nexus-plugin-wordcount` type declarations when package dist artifacts are not built locally. The affected toolbar package typecheck passes.

## Demo preview

Demo preview: https://nexus.demo.eyunzhu.com

This preview is deployed from my fork for review only.

## Compliance / 合规自检

- [x] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI disclosure**: AI assistance was used to inspect the codebase, propose the implementation approach, and draft/refine tests. I reviewed the changes and can explain the implementation.
- [x] **New dependencies**: none
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — N/A, no public API changes
- [x] Touched `live-preview-table.ts` → N/A
- [x] New capability / breaking change → N/A, bug fix only
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A. This PR fixes undo transaction behavior; the demo link above is provided for manual interaction.
