### PR TITLE
fix(toolbar): support multi-line blockquote toggle

### DIFF
--- a/packages/plugin-toolbar/src/formatting.ts
+++ b/packages/plugin-toolbar/src/formatting.ts
@@ -62,17 +62,21 @@ function applyLines(editor: EditorAPI, lines: LineRange[], newLines: string[]): 
 /** Toggle a line prefix (e.g., "> " for blockquote). */
 function toggleLinePrefix(editor: EditorAPI, prefix: string): boolean {
   const doc = editor.getDocument();
-  const { anchor } = editor.getSelection();
-  const lineStart = doc.lastIndexOf("\n", anchor - 1) + 1;
-  const lineEndIdx = doc.indexOf("\n", anchor);
-  const lineEnd = lineEndIdx === -1 ? doc.length : lineEndIdx;
-  const line = doc.slice(lineStart, lineEnd);
+  const { anchor, head } = editor.getSelection();
+  const from = Math.min(anchor, head);
+  const to = Math.max(anchor, head);
+  const lines = getLinesInRange(doc, from, to);
 
-  const newLine = line.startsWith(prefix) ? line.slice(prefix.length) : prefix + line;
-  const newDoc = doc.slice(0, lineStart) + newLine + doc.slice(lineEnd);
-  editor.setDocument(newDoc);
-  editor.setSelection(lineStart + newLine.length);
-  return true;
+  const shouldRemove = lines.every(({ line }) => line.startsWith(prefix));
+  const newLines = lines.map(({ line }) => {
+    if (shouldRemove) {
+      return line.slice(prefix.length);
+    }
+  
+    return line.startsWith(prefix) ? line : `${prefix}${line}`;
+  });
+
+  return applyLines(editor, lines, newLines);
 }
 
 export function toggleBlockquote(editor: EditorAPI): boolean {

--- a/packages/plugin-toolbar/test/plugin-toolbar.test.ts
+++ b/packages/plugin-toolbar/test/plugin-toolbar.test.ts
@@ -8,6 +8,7 @@ import {
   toggleInlineCode,
   insertLink,
   toggleHeading,
+  toggleBlockquote,
   toggleOrderedList,
   toggleUnorderedList,
   createToolbarPlugin,
@@ -119,6 +120,67 @@ describe("toggleHeading", () => {
     toggleHeading(editor, 1);
 
     expect(editor.getDocument()).toBe("# Title");
+    editor.destroy();
+  });
+});
+
+describe("toggleBlockquote - multi-line selection", () => {
+  it("adds blockquote markers to every selected line", () => {
+    const container = document.createElement("div");
+    const input = "foo\nbar\nbaz";
+    const editor = createEditor({ container, initialValue: input });
+
+    editor.setSelection(0, input.length);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> foo\n> bar\n> baz");
+    editor.destroy();
+  });
+
+  it("removes blockquote markers when all selected lines already have one", () => {
+    const container = document.createElement("div");
+    const input = "> foo\n> bar\n> baz";
+    const editor = createEditor({ container, initialValue: input });
+
+    editor.setSelection(0, input.length);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("foo\nbar\nbaz");
+    editor.destroy();
+  });
+
+  it("adds missing blockquote markers for mixed selections", () => {
+    const container = document.createElement("div");
+    const input = "> foo\nbar";
+    const editor = createEditor({ container, initialValue: input });
+
+    editor.setSelection(0, input.length);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> foo\n> bar");
+    editor.destroy();
+  });
+
+  it("normalizes reversed selection", () => {
+    const container = document.createElement("div");
+    const input = "foo\nbar";
+    const editor = createEditor({ container, initialValue: input });
+
+    editor.setSelection(input.length, 0);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> foo\n> bar");
+    editor.destroy();
+  });
+
+  it("does not include the next line when selection ends at its start", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({ container, initialValue: "foo\nbar" });
+
+    editor.setSelection(0, "foo\n".length);
+    toggleBlockquote(editor);
+
+    expect(editor.getDocument()).toBe("> foo\nbar");
     editor.destroy();
   });
 });


### PR DESCRIPTION
## Summary / 摘要

Support blockquote toggling across multi-line selections in the toolbar plugin.

## Motivation / 背景与动机

The blockquote toolbar action previously only toggled the current line. For multi-line selections, this felt inconsistent with other line-based formatting actions such as unordered and ordered lists.

- Issue: N/A
- Roadmap (docs/ROADMAP.md): N/A
- OpenSpec change: N/A

## Changes / 变更内容

- `packages/core`: N/A
- `packages/plugin-*`:
  - Updated `plugin-toolbar` blockquote toggling to operate on every selected line.
  - Keeps already quoted lines unchanged when applying blockquote formatting to mixed selections.
  - Added vitest coverage for multi-line, mixed, reversed, and selection-boundary cases.
- `apps/electron-demo`: N/A
- `openspec/`: N/A

## Testing / 测试

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - `pnpm exec vitest run packages/plugin-toolbar/test/plugin-toolbar.test.ts`
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Compliance / 合规自检

- [ ] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI disclosure**: the functional code in this PR is **not** primarily generated by AI. AI assistance, if any, is described below.
      AI-assisted notes / AI 使用说明：
      Used AI assistance for implementation guidance and test-case review; code was reviewed and verified locally.
- [x] **New dependencies** (if any) listed with license & rationale (none if blank):
      None
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — N/A, no public API changes
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / N/A, not touched
- [x] New capability / breaking change → OpenSpec proposal linked / N/A, no new capability or breaking change
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A