### PR TITLE
fix(search): handle whole-word symbol edges

### DIFF
--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -95,6 +95,8 @@ const DEFAULT_LABELS: SearchPluginLabels = {
 
 const DEFAULT_SEARCH_HISTORY_KEY = "nexus.search.history";
 const DEFAULT_SEARCH_HISTORY_MAX_ENTRIES = 20;
+const WORD_CHAR_CLASS = "A-Za-z0-9_";
+const WORD_CHAR_RE = /^[A-Za-z0-9_]$/;
 
 type SearchHistoryDirection = "previous" | "next";
 
@@ -232,6 +234,29 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function escapeCharacterClass(value: string): string {
+  return value.replace(/[\\\]\-\^\n\r\t]/g, (char) => {
+    if (char === "\n") return "\\n";
+    if (char === "\r") return "\\r";
+    if (char === "\t") return "\\t";
+    return `\\${char}`;
+  });
+}
+
+function wholeWordEdgeClass(char: string): string {
+  return WORD_CHAR_RE.test(char)
+    ? WORD_CHAR_CLASS
+    : `${WORD_CHAR_CLASS}${escapeCharacterClass(char)}`;
+}
+
+function wrapLiteralWholeWordPattern(pattern: string, query: string): string {
+  const chars = Array.from(query);
+  const first = chars[0] ?? "";
+  const last = chars[chars.length - 1] ?? "";
+
+  return `(?<![${wholeWordEdgeClass(first)}])${pattern}(?![${wholeWordEdgeClass(last)}])`;
+}
+
 function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp | null {
   const flags = options.caseSensitive ? "g" : "gi";
 
@@ -240,7 +265,7 @@ function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp 
     pattern = options.wholeWord ? `\\b(?:${query})\\b` : query;
   } else {
     const escaped = escapeRegExp(query);
-    pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+    pattern = options.wholeWord ? wrapLiteralWholeWordPattern(escaped, query) : escaped;
   }
 
   try {

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -187,6 +187,18 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("supports whole-word literal queries with symbol edges", () => {
+    expect(findSearchMatches("C++ C+++ xC++ C++Builder", "C++", { wholeWord: true })).toEqual([
+      { from: 0, to: 3, text: "C++" }
+    ]);
+    expect(findSearchMatches("#tag x#tag ##tag #tagged", "#tag", { wholeWord: true })).toEqual([
+      { from: 0, to: 4, text: "#tag" }
+    ]);
+    expect(replaceAllMatches("C++ C+++ xC++", "C++", "TypeScript", { wholeWord: true })).toBe(
+      "TypeScript C+++ xC++"
+    );
+  });
+
   it("supports case-sensitive whole-word matching", () => {
     expect(findSearchMatches("cat Cat CAT", "Cat", { wholeWord: true, caseSensitive: true })).toEqual([
       { from: 4, to: 7, text: "Cat" }


### PR DESCRIPTION
## Why

Literal whole-word search used `\b...\b` boundaries for every query. That works for plain words like `cat`, but breaks for symbol-edged literals: standalone `C++` was skipped, while prefixes such as `C++Builder` could be matched.

## What

- Build literal whole-word patterns with edge-aware lookarounds instead of unconditional `\b` boundaries.
- Preserve existing regex whole-word behavior.
- Add regression coverage for `C++` and `#tag` find/replace behavior.

## Testing

- `vitest run` - 34 files / 516 tests passed.
- `tsup src/index.ts --format esm --dts --clean` in `packages/plugin-search` - build passed.
- Attempted `pnpm test`, but the local pnpm 11.7.0 wrapper ran an install first and stopped on `ERR_PNPM_IGNORED_BUILDS` before executing tests; the full Vitest suite above was run through the local project binary.

## OpenSpec

Not required: this is a bug fix restoring intended search behavior, not a new capability or public API change.

## AI Assistance

- [x] AI assistance was used for investigation, patch drafting, and PR description preparation; the resulting diff was reviewed and verified with the commands above.