### PR TITLE
fix(search): make whole-word matching Unicode-aware

### DIFF
--- a/packages/plugin-search/src/index.ts
+++ b/packages/plugin-search/src/index.ts
@@ -232,16 +232,26 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp | null {
-  const flags = options.caseSensitive ? "g" : "gi";
+const unicodeWordCharacterClass = "\\p{L}\\p{M}\\p{N}_";
+const cjkScriptPattern = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 
-  let pattern: string;
-  if (options.regexp) {
-    pattern = options.wholeWord ? `\\b(?:${query})\\b` : query;
-  } else {
-    const escaped = escapeRegExp(query);
-    pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+function shouldUseUnicodeWordBoundary(query: string): boolean {
+  return !cjkScriptPattern.test(query);
+}
+
+function wrapWholeWordPattern(pattern: string, useUnicodeBoundary: boolean): string {
+  if (!useUnicodeBoundary) {
+    return pattern;
   }
+
+  return `(?<![${unicodeWordCharacterClass}])(?:${pattern})(?![${unicodeWordCharacterClass}])`;
+}
+
+function buildSearchPattern(query: string, options: SearchOptions = {}): RegExp | null {
+  const useUnicodeBoundary = Boolean(options.wholeWord && shouldUseUnicodeWordBoundary(query));
+  const flags = `${options.caseSensitive ? "g" : "gi"}${useUnicodeBoundary ? "u" : ""}`;
+  const source = options.regexp ? query : escapeRegExp(query);
+  const pattern = options.wholeWord ? wrapWholeWordPattern(source, useUnicodeBoundary) : source;
 
   try {
     return new RegExp(pattern, flags);

--- a/packages/plugin-search/test/plugin-search.test.ts
+++ b/packages/plugin-search/test/plugin-search.test.ts
@@ -187,6 +187,24 @@ describe("@floatboat/nexus-plugin-search", () => {
     ]);
   });
 
+  it("supports Unicode whole-word matching", () => {
+    expect(findSearchMatches("café cafe decafé café", "café", { wholeWord: true })).toEqual([
+      { from: 0, to: 4, text: "café" },
+      { from: 17, to: 21, text: "café" }
+    ]);
+    expect(findSearchMatches("привет мир запривет привет", "привет", { wholeWord: true })).toEqual([
+      { from: 0, to: 6, text: "привет" },
+      { from: 20, to: 26, text: "привет" }
+    ]);
+  });
+
+  it("keeps whole-word search usable for CJK terms", () => {
+    expect(findSearchMatches("今天开会议，会议结束", "会议", { wholeWord: true })).toEqual([
+      { from: 3, to: 5, text: "会议" },
+      { from: 6, to: 8, text: "会议" }
+    ]);
+  });
+
   it("supports case-sensitive whole-word matching", () => {
     expect(findSearchMatches("cat Cat CAT", "Cat", { wholeWord: true, caseSensitive: true })).toEqual([
       { from: 4, to: 7, text: "Cat" }
@@ -200,6 +218,15 @@ describe("@floatboat/nexus-plugin-search", () => {
   it("replaces only whole-word matches", () => {
     expect(replaceAllMatches("cat catalog cat concatenate", "cat", "dog", { wholeWord: true })).toBe(
       "dog catalog dog concatenate"
+    );
+  });
+
+  it("replaces Unicode whole-word and CJK term matches", () => {
+    expect(replaceAllMatches("café cafe decafé café", "café", "coffee", { wholeWord: true })).toBe(
+      "coffee cafe decafé coffee"
+    );
+    expect(replaceAllMatches("今天开会议，会议结束", "会议", "讨论", { wholeWord: true })).toBe(
+      "今天开讨论，讨论结束"
     );
   });
 


### PR DESCRIPTION
## Summary / 摘要

Make search whole-word matching Unicode-aware so non-ASCII text is matched with correct word boundaries.

## Motivation / 背景与动机

The previous whole-word search behavior relied on ASCII-oriented word boundary logic, which may produce incorrect matches for Unicode text such as Chinese, accented characters, and mixed-language Markdown content.

This change improves search correctness for multilingual documents while keeping existing ASCII whole-word behavior unchanged.

- Issue: N/A
- Roadmap (docs/ROADMAP.md): N/A
- OpenSpec change: N/A

## Changes / 变更内容

- `packages/core`: N/A
- `packages/plugin-search`:
  - Updated whole-word matching logic to use Unicode-aware word boundaries when needed.
  - Improved whole-word search behavior for non-ASCII / multilingual content.
  - Kept existing whole-word behavior for ASCII text.
  - Added / updated regression tests for Unicode and existing ASCII whole-word matching.
- `apps/electron-demo`: N/A
- `openspec/`: N/A

## Testing / 测试

- [ ] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
  - `pnpm --filter @floatboat/nexus-plugin-search build`
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - Unicode whole-word search
  - ASCII whole-word search
  - Mixed-language boundary behavior
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：N/A, no visible UI changes

## Compliance / 合规自检

- [x] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI disclosure**: the functional code in this PR is **not** primarily generated by AI. AI assistance, if any, is described below.
      AI-assisted notes / AI 使用说明：
      AI was used to discuss the implementation approach, review edge cases, and help draft the PR description. The final code was reviewed and tested locally before submission.
- [x] **New dependencies** (if any) listed with license & rationale (none if blank):
      None
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — N/A, no public API changes
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / N/A
- [x] New capability / breaking change → OpenSpec proposal linked / N/A, no new capability or breaking change
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A, no visible UI changes.