### PR TITLE
在 Demo 应用中接入块引用与内容嵌入

### DIFF
--- a/apps/electron-demo/sample-vault/Projects/Ideas.md
+++ b/apps/electron-demo/sample-vault/Projects/Ideas.md
@@ -11,5 +11,7 @@ A parking lot for features we might add to [[Projects/Nexus-Editor|the editor]].
 
 ## Long term
 
-- Block references `[[Projects/Nexus-Editor^some-block]]` (v2)
-- Heading anchors `[[Projects/Nexus-Editor#Context]]` (v2)
+- Block references `[[Projects/Nexus-Editor#some-block]]` — now implemented! See [[transclusion-demo]].
+- Heading anchors `[[Projects/Nexus-Editor#Context]]` — now implemented! Uses heading slugs.
+- ~~Block references `[[Projects/Nexus-Editor^some-block]]`~~ — replaced with `#` syntax; all block IDs (heading slugs + explicit `^{id}`) use `#`.
+- ~~Heading anchors `[[Projects/Nexus-Editor#Context]]`~~ — done.

--- a/apps/electron-demo/sample-vault/index.md
+++ b/apps/electron-demo/sample-vault/index.md
@@ -32,6 +32,10 @@ show a long list.
 
 - [[slash-demo]] — type `/` anywhere to open the floating command menu
 
+## Block references & transclusion
+
+- [[transclusion-demo]] — block reference and transclusion (![[ ]]) demos
+
 ## Edge cases
 
 - [[ghost-demo]] — try clicking the red dashed ghost link inside

--- a/apps/electron-demo/sample-vault/transclusion-demo.md
+++ b/apps/electron-demo/sample-vault/transclusion-demo.md
@@ -1,0 +1,35 @@
+# Transclusion Demo
+
+Back to [[index]].
+
+## Block-reference navigation
+
+Without the `!` prefix, `[[file#block-id]]` navigates to the block on click:
+
+- Jump to [[Projects/Nexus-Editor#context]] — the heading block
+- Jump to [[Projects/Nexus-Editor#some-block]] — explicit `^{id}` paragraph
+
+## Embedding specific blocks
+
+Use `![[file#block-id]]` to embed a block's content inline:
+
+![[Projects/Nexus-Editor#context]]
+
+Notice the breadcrumb header above — click it to edit the reference.
+
+## Embedding paragraphs
+
+Paragraphs tagged with `^{id}` can be transcluded with `#id`:
+
+![[Projects/Nexus-Editor#some-block]]
+
+## Embedding full files
+
+Omitting the block ID embeds the entire file:
+
+![[Topics/AI]]
+
+## Edge cases
+
+- Unresolved file: ![[ghost-demo]]
+- Unresolved block: ![[Topics/AI#no-such-block]]

--- a/apps/electron-demo/src/renderer/app.ts
+++ b/apps/electron-demo/src/renderer/app.ts
@@ -6,6 +6,7 @@ import { createSearchBar, type SearchBar } from "./search-bar";
 import { createVaultPanel, type VaultPanel } from "./vault-panel";
 import { LinkIndex, parseAnchor, findAnchorPosition } from "./link-index";
 import { createBacklinksPanel, type BacklinksPanel } from "./backlinks-panel";
+import { clearTransclusionCache, scanBlockIds } from "@floatboat/nexus-core";
 import { perfStart, perfEnd, installLongTaskWatch } from "./perf";
 
 installLongTaskWatch(50);
@@ -267,6 +268,7 @@ async function seedLinkIndex(): Promise<void> {
   } catch (err) {
     console.warn("seedLinkIndex failed:", err);
   }
+  clearTransclusionCache();
   perfEnd(total);
 }
 
@@ -324,6 +326,23 @@ async function handleWikilinkNavigate(target: string, opts: { unresolved: boolea
   }
 }
 
+async function handleTransclusionNavigate(file: string, blockId?: string): Promise<void> {
+  const resolved = linkIndex.resolve(file, state.activeFile);
+  if (!resolved) return;
+
+  if (resolved !== state.activeFile) {
+    await handleVaultFileOpen(resolved);
+  }
+  if (blockId) {
+    const registry = linkIndex.getBlockRegistry(resolved);
+    const entry = registry.get(blockId);
+    if (entry) {
+      shell.editor.setSelection(entry.contentFrom);
+      shell.editor.focus();
+    }
+  }
+}
+
 async function tryRestoreLastVault(): Promise<void> {
   try {
     const last = await window.nexusDemo.vault.getLast();
@@ -374,6 +393,15 @@ function boot(): void {
     onWikilinkNavigate: (target, opts) => {
       void handleWikilinkNavigate(target, opts);
     },
+    resolveTransclusion: (file, blockId) => {
+      const resolved = linkIndex.resolve(file, state.activeFile);
+      if (!resolved) return null;
+      if (!blockId) return linkIndex.getFileContent(resolved);
+      return linkIndex.resolveBlockContent(resolved, blockId);
+    },
+    onTransclusionNavigate: (file, blockId) => {
+      void handleTransclusionNavigate(file, blockId);
+    },
   });
 
   vault = createVaultPanel({
@@ -412,6 +440,7 @@ function boot(): void {
 
   // External file changes → re-seed the index (cheap for typical vaults).
   window.nexusDemo.vault.onChanged(() => {
+    clearTransclusionCache();
     void seedLinkIndex();
   });
 

--- a/apps/electron-demo/src/renderer/editor-shell.ts
+++ b/apps/electron-demo/src/renderer/editor-shell.ts
@@ -1,6 +1,8 @@
 import {
   createEditor,
   createWikilinksPlugin,
+  clearTransclusionCache,
+  invalidateFileCache,
   type EditorAPI,
   type LivePreviewRenderContext,
 } from "@floatboat/nexus-core";
@@ -76,6 +78,10 @@ export interface EditorShellOptions {
   resolveWikilink?(name: string): string | null;
   /** Returns autocomplete candidates for the query after `[[`. */
   suggestWikilinks?(query: string): string[];
+  /** Resolves `![[file#block-id]]` transclusion content to rendered Markdown. */
+  resolveTransclusion?: (file: string, blockId: string | undefined) => string | null;
+  /** Called when a block-reference link `[[file#block-id]]` is clicked. */
+  onTransclusionNavigate?: (file: string, blockId?: string) => void;
 }
 
 export interface EditorShell {
@@ -99,6 +105,8 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
     onWikilinkNavigate,
     resolveWikilink,
     suggestWikilinks,
+    resolveTransclusion,
+    onTransclusionNavigate,
   } = options;
 
   // Forward ref so the image renderer (built BEFORE createEditor returns)
@@ -318,6 +326,12 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
     tabSize: settings.tabSize,
     direction: settings.direction,
     indentGuides: settings.indentGuides,
+    transclusion: resolveTransclusion || onTransclusionNavigate
+      ? {
+          resolve: resolveTransclusion,
+          onNavigate: onTransclusionNavigate,
+        }
+      : undefined,
     onChange(doc) {
       state.content = doc;
       state.dirty = true;
@@ -325,6 +339,11 @@ export function createEditorShell(options: EditorShellOptions): EditorShell {
       // reacts immediately when the user types `[[...]]`.
       if (state.linkIndex && state.activeFile) {
         state.linkIndex.updateFile(state.activeFile, doc);
+      }
+      // Invalidate transclusion cache for the current file so embedded
+      // blocks from this file re-resolve after edits.
+      if (state.activeFile) {
+        invalidateFileCache(state.activeFile);
       }
       onStateChange();
     },

--- a/apps/electron-demo/src/renderer/link-index.ts
+++ b/apps/electron-demo/src/renderer/link-index.ts
@@ -1,4 +1,4 @@
-import { scanWikiLinks, type WikiLinkMatch } from "@floatboat/nexus-core";
+import { scanWikiLinks, scanBlockIds, resolveBlockContent, type WikiLinkMatch, type BlockRegistry } from "@floatboat/nexus-core";
 import { normalizeSlashes, joinPath } from "./path-utils";
 
 /** Prefer requestIdleCallback for yielding; fall back to a macrotask otherwise. */
@@ -30,6 +30,7 @@ interface IndexSnapshot {
   backward: Map<string, BacklinkHit[]>;
   contents: Map<string, string>;
   byBasename: Map<string, Set<string>>;
+  blockRegistries: Map<string, BlockRegistry>;
 }
 
 interface RebuildAsyncOptions {
@@ -165,6 +166,8 @@ export class LinkIndex {
   /** Memoized unlinked-mentions result per target; invalidated on any
    * contents/forward mutation. */
   private unlinkedCache = new Map<string, BacklinkHit[]>();
+  /** Per-file block registries (heading slugs + explicit ^{id} anchors). */
+  private blockRegistries = new Map<string, BlockRegistry>();
 
   private listeners = new Set<LinkIndexListener>();
 
@@ -221,6 +224,7 @@ export class LinkIndex {
   updateFile(path: string, content: string): void {
     this.removeFromBasenames(path);
     this.indexFile(path, content);
+    this.blockRegistries.delete(normalizeSlashes(path));
     this.invalidateUnlinkedCache();
     // Incremental reverse-index maintenance — only rewrites backward edges
     // whose `sourcePath` is this file. O(|edges of this file|) instead of
@@ -236,6 +240,7 @@ export class LinkIndex {
     const norm = normalizeSlashes(path);
     this.forward.delete(norm);
     this.contents.delete(norm);
+    this.blockRegistries.delete(norm);
     this.invalidateUnlinkedCache();
     // Only purge edges whose sourcePath is this file.
     this.removeBackwardEdgesFrom(norm);
@@ -323,6 +328,37 @@ export class LinkIndex {
     return [...this.contents.keys()];
   }
 
+  /** Raw content for an absolute file path, or null if unknown. */
+  getFileContent(path: string): string | null {
+    return this.contents.get(normalizeSlashes(path)) ?? null;
+  }
+
+  /** Block registry for a file (lazy-built and cached on demand). */
+  getBlockRegistry(path: string): BlockRegistry {
+    const norm = normalizeSlashes(path);
+    const cached = this.blockRegistries.get(norm);
+    if (cached) return cached;
+    const content = this.contents.get(norm);
+    if (!content) return new Map();
+    const registry = scanBlockIds(content);
+    this.blockRegistries.set(norm, registry);
+    return registry;
+  }
+
+  /**
+   * Resolve a block's Markdown content given an absolute file path and a block
+   * ID. Returns null when the file or block is not found.
+   */
+  resolveBlockContent(path: string, blockId: string): string | null {
+    if (!blockId) return null;
+    const registry = this.getBlockRegistry(path);
+    const entry = registry.get(blockId);
+    if (!entry) return null;
+    const content = this.contents.get(normalizeSlashes(path));
+    if (!content) return null;
+    return resolveBlockContent(entry, content);
+  }
+
   /**
    * Resolve a wiki-link name from a source file to an absolute target path.
    * Order: exact match → relative to source dir → same-dir basename → global
@@ -398,6 +434,7 @@ export class LinkIndex {
       backward: new Map(),
       contents: new Map(),
       byBasename: new Map(),
+      blockRegistries: new Map(),
     };
   }
 
@@ -407,6 +444,7 @@ export class LinkIndex {
       backward: this.backward,
       contents: this.contents,
       byBasename: this.byBasename,
+      blockRegistries: this.blockRegistries,
     };
   }
 
@@ -415,6 +453,7 @@ export class LinkIndex {
     this.backward = next.backward;
     this.contents = next.contents;
     this.byBasename = next.byBasename;
+    this.blockRegistries = next.blockRegistries;
     this.invalidateUnlinkedCache();
   }
 
@@ -465,6 +504,9 @@ export class LinkIndex {
       snapshot.byBasename.set(bn, bucket);
     }
     bucket.add(path);
+    // Build block registry lazily on first access via getBlockRegistry,
+    // but pre-seed during rebuild so resolveBlockContent is O(1).
+    snapshot.blockRegistries.set(path, scanBlockIds(content));
   }
 
   private removeFromBasenames(rawPath: string): void {

--- a/packages/core/src/block-id.ts
+++ b/packages/core/src/block-id.ts
@@ -1,0 +1,196 @@
+/**
+ * Block ID extraction utilities for block references and transclusion.
+ *
+ * ## Automatic IDs (heading slugs)
+ * Each heading (`## Design Goals`) auto-generates a slug via the same
+ * algorithm Obsidian uses: lowercase, non-alphanumeric removed, spaces → `-`,
+ * consecutive `-` collapsed, leading/trailing `-` stripped.
+ *
+ * ## Explicit IDs (`^{block-id}`)
+ * Any block-level line can end with `^{id}` to assign a stable, manually
+ * chosen identifier. Explicit IDs always win over slugs when both exist.
+ *
+ *   ## Design Goals ^{core-design}
+ *   → block ID = "core-design", heading text = "Design Goals"
+ */
+
+export interface BlockEntry {
+  /** Stable block identifier (heading slug or explicit `^{id}`). */
+  id: string;
+  /** Human-readable label (heading text sans markers and id suffix). */
+  label: string;
+  /** Offset where the labeled block starts in the document. */
+  from: number;
+  /** Offset where the labeled block content begins (first non-marker char). */
+  contentFrom: number;
+  /** Offset where this block ends (next sibling heading or EOF). */
+  to: number;
+  /** Type of block: "heading" or "paragraph". */
+  type: "heading" | "paragraph";
+  /** Heading level (1-6), only for heading blocks. */
+  level?: number;
+}
+
+/** Block whose content has been resolved for transclusion rendering. */
+export interface ResolvedBlock {
+  /** The label shown in the breadcrumb. */
+  label: string;
+  /** The Markdown source of the resolved block. */
+  markdown: string;
+}
+
+/** Registry: collected blocks in a document, keyed by block ID. */
+export type BlockRegistry = ReadonlyMap<string, BlockEntry>;
+
+/**
+ * Compute the slug of a heading text using Obsidian's algorithm.
+ *
+ *   "Design Goals"       → "design-goals"
+ *   "Hello, World!"      → "hello-world"
+ *   "  Spaces  "         → "spaces"
+ *   "Café 🍕 nom-nom"    → "cafe-nom-nom"
+ *   "a--b--c"            → "a-b-c"
+ *   "---"                → ""  (invalid block ID → filter upstream)
+ */
+export function headingSlug(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Parse a heading/paragraph line to extract an optional explicit `^{id}`
+ * suffix and the remaining label text.
+ *
+ *   "## Design Goals ^{core-design}" → { label: "Design Goals", explicitId: "core-design" }
+ *   "Some paragraph ^{para-1}"       → { label: "Some paragraph", explicitId: "para-1" }
+ *   "## No ID"                       → { label: "No ID", explicitId: null }
+ *   "Text with ^{escaped} chars"      → { label: "Text with \^{escaped} chars", explicitId: null }
+ */
+export function parseBlockAnnotation(line: string): {
+  label: string;
+  explicitId: string | null;
+} {
+  // Only the LAST `^{...}` at end-of-line counts as an ID annotation.
+  // Escaped `\^{...}` is literal text.
+  const match = /^(.*?)(?<!\\)\s*\^\{([a-zA-Z0-9_-]+)\}\s*$/.exec(line);
+  if (!match) return { label: line, explicitId: null };
+  return { label: match[1], explicitId: match[2] };
+}
+
+/** True when `id` is a valid block identifier (non-empty, alphanumeric + `_-`). */
+function isValidBlockId(id: string): boolean {
+  return id.length > 0 && /^[a-zA-Z0-9_-]+$/.test(id);
+}
+
+const HEADING_LINE_RE = /^(#{1,6})\s+(.+)$/;
+
+/**
+ * Scan a Markdown document and return a BlockRegistry mapping every block ID
+ * to its entry. ID conflicts: first-definition wins (ordered by `from`).
+ *
+ * Blocks are:
+ *   - Any heading line (auto-slug + optional explicit `^{id}`).
+ *   - Any non-blank, non-heading line that ends with `^{id}` (paragraph anchor).
+ *
+ * Each block spans from its start to:
+ *   - The next heading of equal-or-lower depth (for heading blocks), or
+ *   - The next block-annotated paragraph, or
+ *   - End of document.
+ */
+export function scanBlockIds(doc: string): BlockRegistry {
+  const map = new Map<string, BlockEntry>();
+  const lines = doc.split("\n");
+
+  // Phase 1: collect potential block anchors
+  const anchors: Array<{
+    index: number;
+    from: number;
+    label: string;
+    id: string;
+    type: "heading" | "paragraph";
+    level?: number;
+  }> = [];
+
+  let offset = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const headingMatch = HEADING_LINE_RE.exec(line);
+    if (headingMatch) {
+      const depth = headingMatch[1].length;
+      const { label, explicitId } = parseBlockAnnotation(headingMatch[2]);
+      // headingTextOffset: character offset where the heading text begins
+      const headingTextOffset = offset + line.indexOf(headingMatch[2]);
+      const slug = headingSlug(label);
+      const id = explicitId ?? slug;
+      if (isValidBlockId(id)) {
+        anchors.push({ index: i, from: offset, label, id, type: "heading", level: depth });
+      }
+    } else {
+      const { label, explicitId } = parseBlockAnnotation(line);
+      if (explicitId && isValidBlockId(explicitId) && label.trim().length > 0) {
+        anchors.push({ index: i, from: offset, label: label.trim(), id: explicitId, type: "paragraph" });
+      }
+    }
+    offset += line.length + 1;
+  }
+
+  // Phase 2: compute end positions and populate registry
+  for (let ai = 0; ai < anchors.length; ai++) {
+    const anchor = anchors[ai];
+    const line = lines[anchor.index];
+    const contentFrom =
+      anchor.type === "heading"
+        ? anchor.from + line.indexOf(anchor.label)
+        : anchor.from + (line.length - line.trimStart().length);
+    const markerLen = anchor.type === "heading" ? (anchor.level ?? 1) + 1 : 0;
+
+    // Determine end: for paragraph blocks, just the annotated line.
+    // For heading blocks, everything until the next heading of equal-or-lower level.
+    let to = doc.length;
+    if (anchor.type === "paragraph") {
+      to = anchor.from + lines[anchor.index].length;
+    } else {
+      for (let aj = ai + 1; aj < anchors.length; aj++) {
+        const next = anchors[aj];
+        if (next.type === "heading" && (next.level ?? 7) <= (anchor.level ?? 1)) {
+          to = next.from;
+          break;
+        }
+      }
+    }
+
+    if (!map.has(anchor.id)) {
+      map.set(anchor.id, {
+        id: anchor.id,
+        label: anchor.label,
+        from: anchor.from,
+        contentFrom,
+        to,
+        type: anchor.type,
+        level: anchor.level,
+      } satisfies BlockEntry);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Resolve a block's Markdown content given its registry entry and the full
+ * document source. Strips the heading/annotation markers and returns just the
+ * body content (suitable for rendering).
+ */
+export function resolveBlockContent(entry: BlockEntry, doc: string): string {
+  const content = doc.slice(entry.contentFrom, entry.to);
+  // For paragraph blocks, the content includes the annotation line; strip `^{id}`.
+  if (entry.type === "paragraph") {
+    return content.replace(/\s*\^\{[a-zA-Z0-9_-]+}\s*$/, "").trim();
+  }
+  return content;
+}

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -700,7 +700,7 @@ export function createEditor(config: EditorConfig): EditorAPI {
           deleteRow: locale.deleteRow,
           insertColumnAfter: locale.insertColumnAfter,
           insertRowBelow: locale.insertRowBelow,
-        }),
+        }, config.transclusion),
         ...(widgetParser ? createWidgetExtension(widgetParser, widgetDefs) : []),
         ...shortcutExtensions,
         ...commandKeymapExtensions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,10 +24,28 @@ export {
   scanWikiLinks,
   createWikilinksExtension,
   createWikilinksPlugin,
+  scanTransclusions,
+  scanBlockRefLinks,
+  splitBlockRef,
   type WikiLinkMatch,
   type WikilinksOptions,
   type WikiLinkNavigateOptions,
 } from "./wikilinks";
+export {
+  scanBlockIds,
+  resolveBlockContent,
+  headingSlug,
+  parseBlockAnnotation,
+  type BlockEntry,
+  type BlockRegistry,
+  type ResolvedBlock,
+} from "./block-id";
+export {
+  TransclusionWidget,
+  clearTransclusionCache,
+  invalidateFileCache,
+  resolveContent,
+} from "./transclusion-widget";
 export type {
   CodeHighlightToken,
   EditorAPI,
@@ -55,4 +73,9 @@ export type {
   TocEntry,
   WidgetDefinition,
   WidgetRenderContext
+} from "./types";
+export type {
+  TransclusionMatch,
+  TransclusionResolver,
+  TransclusionConfig,
 } from "./types";

--- a/packages/core/src/live-preview-ranges.ts
+++ b/packages/core/src/live-preview-ranges.ts
@@ -3,6 +3,8 @@ import type { Content, Parent, Root } from "mdast";
 
 import type { LivePreviewNode } from "./types";
 import { scanWikiLinks } from "./wikilinks";
+import { scanTransclusions, scanBlockRefLinks } from "./wikilinks";
+import type { TransclusionMatch } from "./types";
 
 export interface LivePreviewRange {
   from: number;
@@ -160,12 +162,25 @@ export function collectLivePreviewRanges(
   ast: Root,
   doc: string,
   selection: readonly SelectionRange[]
-): LivePreviewRange[] {
+): { ranges: LivePreviewRange[]; transclusions: TransclusionMatch[]; blockRefs: TransclusionMatch[] } {
   const ranges: LivePreviewRange[] = [];
-  const wikiLinkSpans = scanWikiLinks(doc).map((link) => [link.from, link.to] as [number, number]);
 
-  visit(ast, doc, selection, ranges, wikiLinkSpans);
+  // Collect spans that should NOT be further decorated by mdast walkers:
+  // wikilinks AND transclusions both create their own decorations.
+  const wikiLinkSpans = scanWikiLinks(doc).map((link) => [link.from, link.to] as [number, number]);
+  const transclusionSpans = scanTransclusions(doc).map((tm) => [tm.from, tm.to] as [number, number]);
+  const allSkipSpans = [...wikiLinkSpans, ...transclusionSpans];
+
+  visit(ast, doc, selection, ranges, allSkipSpans);
   ranges.push(...collectImageRanges(doc, selection));
 
-  return ranges.sort((left, right) => left.from - right.from);
+  // Scan for transclusion `![[file#block-id]]` and block-reference links.
+  const transclusions = scanTransclusions(doc);
+  const blockRefs = scanBlockRefLinks(doc);
+
+  return {
+    ranges: ranges.sort((left, right) => left.from - right.from),
+    transclusions,
+    blockRefs,
+  };
 }

--- a/packages/core/src/live-preview.ts
+++ b/packages/core/src/live-preview.ts
@@ -16,7 +16,10 @@ import type {
   LivePreviewLabels,
   LivePreviewNodeType,
   LivePreviewRenderer,
+  TransclusionConfig,
 } from "./types";
+import { TransclusionWidget } from "./transclusion-widget";
+import { scanTransclusions, scanBlockRefLinks } from "./wikilinks";
 
 const COMPOSITION_REDECORATE_DELAY_MS = 60;
 
@@ -1034,6 +1037,8 @@ interface BuildContext {
   /** Optional pre-computed code highlight tokens for the snapshot's fenced blocks. */
   codeTokens?: CodeHighlightToken[];
   compositionActive?: boolean;
+  /** Transclusion configuration for `![[file#block-id]]` rendering. */
+  transclusion?: TransclusionConfig;
 }
 
 function buildDecorations(
@@ -1058,11 +1063,52 @@ function buildDecorations(
   // pairs hit the LRU in highlightCodeBlock so cursor moves don't re-tokenize.
   const codeTokens = ctx.codeTokens ?? highlightAllCodeBlocks(ast, doc);
   const t1b = perfEnabled ? performance.now() : 0;
-  const ranges = collectLivePreviewRanges(ast, doc, selection);
+  const { ranges, transclusions } = collectLivePreviewRanges(ast, doc, selection);
   const t2 = perfEnabled ? performance.now() : 0;
   const astHit = !!ctx.ast;
   const decos: Range<Decoration>[] = [];
   const parentSpans: [number, number][] = [];
+
+  // ── Transclusion widgets ─────────────────────────────────────────
+  if (transclusions.length > 0) {
+    for (const tm of transclusions) {
+      const cursorOnTransclusion = selectionIntersects(tm.from, tm.to, selection, true);
+      if (cursorOnTransclusion) continue; // show raw `![[  ]]` source when editing
+
+      const widget = new TransclusionWidget(
+        tm.file,
+        tm.blockId,
+        tm.display,
+        tm.from,
+        ctx.transclusion?.resolve,
+        viewRef,
+      );
+      decos.push(
+        Decoration.replace({
+          widget,
+          block: true,
+        }).range(tm.from, tm.to)
+      );
+    }
+  }
+
+  // ── Block-reference link decorations ─────────────────────────────
+  if (ctx.transclusion?.onNavigate) {
+    const blockRefs = scanBlockRefLinks(doc);
+    for (const bm of blockRefs) {
+      const cursorOnRef = selectionIntersects(bm.from, bm.to, selection, true);
+      if (cursorOnRef) continue;
+
+      const attrs: Record<string, string> = {
+        style: "color:var(--nexus-accent);cursor:pointer;text-decoration:underline;" +
+               "text-decoration-color:var(--nexus-accent);text-decoration-thickness:1px;",
+        "data-blockref-file": bm.file,
+        "data-blockref-blockid": bm.blockId ?? "",
+      };
+
+      decos.push(Decoration.mark({ attributes: attrs }).range(bm.from, bm.to));
+    }
+  }
 
   for (const range of ranges) {
     if (parentSpans.some(([from, to]) => range.from >= from && range.to <= to)) continue;
@@ -1300,7 +1346,8 @@ function buildDecorations(
 
 export function createLivePreviewExtension(
   config: boolean | LivePreviewConfig | undefined,
-  localeLabels?: LivePreviewLabels
+  localeLabels?: LivePreviewLabels,
+  transclusion?: TransclusionConfig,
 ): Extension[] {
   const normalized = normalizeConfig(config);
   if (!normalized.enabled) return [];
@@ -1323,8 +1370,8 @@ export function createLivePreviewExtension(
   function build(state: EditorState, selection: readonly SelectionRange[], reuseCache: boolean): DecorationSet {
     const docStr = state.doc.toString();
     const ctx: BuildContext = reuseCache && lastBuilt && lastBuilt.doc === docStr
-      ? { ast: lastBuilt.ast, codeTokens: lastBuilt.codeTokens }
-      : {};
+      ? { ast: lastBuilt.ast, codeTokens: lastBuilt.codeTokens, transclusion }
+      : { transclusion };
     try {
       const out = buildDecorations(state, selection, normalized, viewRef, {
         ...ctx,
@@ -1469,6 +1516,23 @@ export function createLivePreviewExtension(
     }
   });
 
+  // Click to navigate block-reference links: [[file#block-id]]
+  const blockRefHandler = EditorView.domEventHandlers({
+    mousedown(event, _view) {
+      if (!transclusion?.onNavigate) return false;
+      const target = event.target as HTMLElement;
+      const el = target.closest("[data-blockref-file]");
+      if (!el) return false;
+      const file = el.getAttribute("data-blockref-file");
+      if (!file) return false;
+      const blockId = el.getAttribute("data-blockref-blockid") || undefined;
+      event.preventDefault();
+      event.stopPropagation();
+      transclusion.onNavigate(file, blockId);
+      return true;
+    },
+  });
+
   // 表格被渲染成 block replace widget（整段源码折叠成一个不可逐字进入的部件），
   // 若不告诉 CodeMirror 这是原子区间，方向键上下移动时光标会"掉进"被折叠隐藏的
   // 表格源码里而卡住。把每个表格 widget 的范围登记为 atomicRange，让光标把表格当作
@@ -1490,5 +1554,5 @@ export function createLivePreviewExtension(
     return builder.finish();
   });
 
-  return [field, viewCapture, compositionHandler, linkHandler, tableAtomicRanges, createLivePreviewDiagnostics()];
+  return [field, viewCapture, compositionHandler, linkHandler, blockRefHandler, tableAtomicRanges, createLivePreviewDiagnostics()];
 }

--- a/packages/core/src/transclusion-widget.ts
+++ b/packages/core/src/transclusion-widget.ts
@@ -1,0 +1,295 @@
+/**
+ * TransclusionWidget — renders embedded `![[file#block-id]]` content as a
+ * CodeMirror 6 block WidgetType (integrated into the live-preview pipeline).
+ *
+ * ## Features
+ * - Async content resolution via host-provided `resolve` callback.
+ * - Breadcrumb header: "→ source-file.md" with the block label.
+ * - Loading / error / unresolved / empty states.
+ * - Click-to-edit: clicking the breadcrumb navigates the cursor into the
+ *   source `![[ ]]` text so the user can edit the reference.
+ * - Recursion guard: a static Set<string> of active resolutions prevents
+ *   infinite loops (A → B → C → A). Cycles show a warning placeholder.
+ */
+
+import { WidgetType } from "@codemirror/view";
+import type { TransclusionResolver } from "./types";
+
+/** Cache resolved content keyed by "file::blockId". */
+const resolutionCache = new Map<string, string | null>();
+
+/** Active in-flight resolutions to prevent recursion. */
+const activeResolutions = new Set<string>();
+
+/** In-flight promises keyed by cache key. */
+const pendingResolutions = new Map<string, Promise<string | null>>();
+
+function cacheKey(file: string, blockId?: string): string {
+  return blockId ? `${file}::${blockId}` : file;
+}
+
+/** Clear the entire transclusion cache (call when vault content changes). */
+export function clearTransclusionCache(): void {
+  resolutionCache.clear();
+  pendingResolutions.clear();
+}
+
+/** Invalidate cached content for a specific file. */
+export function invalidateFileCache(file: string): void {
+  const prefix = `${file}::`;
+  for (const key of resolutionCache.keys()) {
+    if (key === file || key.startsWith(prefix)) resolutionCache.delete(key);
+  }
+  for (const key of pendingResolutions.keys()) {
+    if (key === file || key.startsWith(prefix)) pendingResolutions.delete(key);
+  }
+}
+
+/**
+ * Resolve transclusion content through the host callback with caching and
+ * recursion protection. Returns null when unresolved or in a cycle.
+ */
+export async function resolveContent(
+  resolve: TransclusionResolver,
+  file: string,
+  blockId: string | undefined,
+  sourcePath?: string,
+): Promise<string | null> {
+  const key = cacheKey(file, blockId);
+
+  // Return cached result immediately.
+  if (resolutionCache.has(key)) {
+    return resolutionCache.get(key) ?? null;
+  }
+
+  // Return in-flight promise without starting a new one.
+  if (pendingResolutions.has(key)) {
+    return pendingResolutions.get(key)!;
+  }
+
+  // Recursion / self-reference guard.
+  if (activeResolutions.has(key)) {
+    return null; // cycle detected
+  }
+
+  activeResolutions.add(key);
+
+  const promise = (async () => {
+    try {
+      const result = await Promise.resolve(resolve(file, blockId, sourcePath));
+      resolutionCache.set(key, result ?? null);
+      return result ?? null;
+    } catch {
+      resolutionCache.set(key, null);
+      return null;
+    } finally {
+      activeResolutions.delete(key);
+      pendingResolutions.delete(key);
+    }
+  })();
+
+  pendingResolutions.set(key, promise);
+  return promise;
+}
+
+// ── Widget ─────────────────────────────────────────────────────────────────
+
+const TRANSCLUSION_BORDER = "var(--nexus-accent, #8250df)";
+const TRANSCLUSION_BG = "var(--nexus-bg-subtle, rgba(130,80,223,0.05))";
+const BREADCRUMB_COLOR = "var(--nexus-text-muted, #666)";
+
+/**
+ * Build a simple HTML rendering of markdown text as a DOM tree suitable for
+ * a transclusion widget. This is deliberately minimal — no full Markdown
+ * parser — because transclusion content is meant to be read inline, not be
+ * an interactive Markdown surface itself. Hosts can override with their own
+ * markdown-to-HTML pipeline if they need richer rendering.
+ */
+function markdownToTransclusionHtml(md: string): string {
+  if (!md || md.trim().length === 0) return "";
+
+  let html = md;
+
+  // Headings
+  html = html.replace(/^#{1,6}\s+(.+)$/gm, (_m, text) =>
+    `<div style="font-weight:700;font-size:1.05em;margin:4px 0 2px;">${escapeHtml(text)}</div>`);
+  // Bold
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  // Italic
+  html = html.replace(/(?<!\*)\*(.+?)\*(?!\*)/g, "<em>$1</em>");
+  // Inline code
+  html = html.replace(/`([^`]+)`/g,
+    '<code style="font-family:monospace;background:var(--nexus-bg-muted,#e8e8e8);padding:1px 3px;border-radius:2px;">$1</code>');
+  // Links
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" style="color:var(--nexus-accent)" rel="noopener noreferrer">$1</a>');
+
+  // Paragraphs: wrap non-heading, non-empty lines in <div>
+  const lines = html.split("\n");
+  const result: string[] = [];
+  for (const line of lines) {
+    if (line.trim().length === 0) {
+      result.push('<div style="height:4px;"></div>');
+    } else if (line.startsWith("<div style=\"font-weight:700")) {
+      result.push(line);
+    } else {
+      result.push(`<div>${line}</div>`);
+    }
+  }
+  return result.join("");
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export class TransclusionWidget extends WidgetType {
+  constructor(
+    private readonly file: string,
+    private readonly blockId: string | undefined,
+    private readonly display: string,
+    private readonly sourceFrom: number,
+    private readonly resolve: TransclusionResolver | undefined,
+    private readonly viewRef: { current: import("@codemirror/view").EditorView | null },
+    private readonly sourcePath?: string,
+  ) {
+    super();
+  }
+
+  eq(other: TransclusionWidget): boolean {
+    return (
+      other.file === this.file &&
+      other.blockId === this.blockId &&
+      other.display === this.display &&
+      other.sourceFrom === this.sourceFrom
+    );
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+
+  get estimatedHeight(): number {
+    return 64;
+  }
+
+  toDOM(): HTMLElement {
+    const container = document.createElement("div");
+    container.className = "nexus-transclusion";
+    container.style.cssText = [
+      "display:block",
+      "position:relative",
+      "margin:4px 0",
+      "padding:0",
+      "border:1px solid",
+      "border-color:" + TRANSCLUSION_BORDER,
+      "background:" + TRANSCLUSION_BG,
+      "border-radius:6px",
+      "overflow:hidden",
+      "font-size:0.92em",
+    ].join(";") + ";";
+
+    // Breadcrumb header
+    const breadcrumb = document.createElement("div");
+    breadcrumb.className = "nexus-transclusion-breadcrumb";
+    const label = this.blockId
+      ? `${this.file} > ${this.blockId}`
+      : this.file;
+    breadcrumb.style.cssText = [
+      "display:flex",
+      "align-items:center",
+      "gap:4px",
+      "padding:4px 10px",
+      "font-size:0.8em",
+      "color:" + BREADCRUMB_COLOR,
+      "border-bottom:1px solid",
+      "border-color:var(--nexus-border-subtle, rgba(0,0,0,0.06))",
+      "cursor:pointer",
+      "user-select:none",
+    ].join(";") + ";";
+    breadcrumb.textContent = `→ ${label}`;
+    breadcrumb.title = "Click to edit reference";
+    breadcrumb.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const v = this.viewRef.current;
+      if (!v) return;
+      const safeFrom = Math.min(this.sourceFrom, v.state.doc.length);
+      v.dispatch({ selection: { anchor: safeFrom } });
+      v.focus();
+    });
+    container.appendChild(breadcrumb);
+
+    // Content body
+    const body = document.createElement("div");
+    body.className = "nexus-transclusion-body";
+    body.style.cssText = [
+      "padding:6px 10px",
+      "color:var(--nexus-text)",
+      "line-height:1.5",
+      "min-height:24px",
+      "max-height:320px",
+      "overflow-y:auto",
+    ].join(";") + ";";
+    body.textContent = "Loading…";
+    body.style.color = BREADCRUMB_COLOR;
+    container.appendChild(body);
+
+    // Async resolve
+    if (this.resolve) {
+      const sourceKey = this.sourcePath ?? "";
+      resolveContent(this.resolve, this.file, this.blockId, sourceKey).then((content) => {
+        if (!container.isConnected) return;
+
+        if (content === null) {
+          this.renderUnresolved(body, breadcrumb);
+          return;
+        }
+
+        if (content.trim().length === 0) {
+          this.renderEmpty(body);
+          return;
+        }
+
+        body.style.color = "";
+        body.style.fontSize = "";
+        body.style.padding = "";
+        body.textContent = "";
+        body.innerHTML = markdownToTransclusionHtml(content);
+      }).catch(() => {
+        if (!container.isConnected) return;
+        this.renderError(body, "Resolution failed");
+      });
+    } else {
+      this.renderUnresolved(body, breadcrumb);
+    }
+
+    return container;
+  }
+
+  private renderUnresolved(body: HTMLElement, breadcrumb: HTMLElement): void {
+    breadcrumb.style.color = "var(--nexus-hl-deletion, #c0392b)";
+    body.textContent = "⚠ Unresolved reference — no resolver configured or file not found.";
+    body.style.color = "var(--nexus-text-muted)";
+    body.style.fontSize = "0.85em";
+    body.style.padding = "8px 10px";
+  }
+
+  private renderEmpty(body: HTMLElement): void {
+    body.textContent = "(empty block)";
+    body.style.color = "var(--nexus-text-faint)";
+    body.style.fontSize = "0.85em";
+    body.style.padding = "8px 10px";
+  }
+
+  private renderError(body: HTMLElement, message: string): void {
+    body.textContent = `⚠ ${message}`;
+    body.style.color = "var(--nexus-hl-deletion, #c0392b)";
+    body.style.fontSize = "0.85em";
+    body.style.padding = "8px 10px";
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -113,11 +113,11 @@ export interface EditorConfig {
   onChange?: (doc: string, ast: Root) => void;
   onFocus?: () => void;
   onBlur?: () => void;
-  /**
-   * 资源上传钩子：粘贴 / 拖拽进来的图片或文件交给宿主落盘 / 上传，返回可供 markdown
-   * 引用的 URL（相对路径或远程地址）。返回 null 表示放弃，编辑器不会插入坏链接。
-   */
+  /** 资源上传钩子：粘贴 / 拖拽进来的图片或文件交给宿主落盘 / 上传，返回可供 markdown
+   * 引用的 URL（相对路径或远程地址）。返回 null 表示放弃，编辑器不会插入坏链接。 */
   onAssetUpload?: (file: File) => Promise<string | null>;
+  /** 块引用与内容嵌入配置（![[file#block-id]] 语法）。 */
+  transclusion?: TransclusionConfig;
 }
 
 export interface SlashMenuState {
@@ -395,4 +395,59 @@ export interface NexusPlugin {
   remarkPlugins?: Array<Plugin<[], Root, Root>>;
   cmExtensions?: Extension[];
   widgets?: WidgetDefinition[];
+}
+
+// ── Block References & Transclusion ─────────────────────────────────────────
+
+/**
+ * A parsed block-reference or transclusion match from the document.
+ *
+ *   [[Data#schema]]       → isTransclusion=false, file="Data", blockId="schema"
+ *   [[Data#schema|alias]] → isTransclusion=false, file="Data", blockId="schema", alias="alias"
+ *   ![[Data#schema]]      → isTransclusion=true,  file="Data", blockId="schema"
+ *   ![[Data|alias]]       → isTransclusion=true,  file="Data", blockId=undefined, alias="alias"
+ */
+export interface TransclusionMatch {
+  /** Absolute offset of the opening `![[` or `[[`. */
+  from: number;
+  /** Absolute offset after the closing `]]`. */
+  to: number;
+  /** Whether the leading `!` is present (embed, not just link). */
+  isTransclusion: boolean;
+  /** The file/target name (everything before `#` or `|` or `]]`). */
+  file: string;
+  /** Block identifier after `#` in the target; undefined for bare file links. */
+  blockId?: string;
+  /** Alias text when `|alias` is present. */
+  alias?: string;
+  /** The display text: alias when present, otherwise a compact `file#blockId`. */
+  display: string;
+}
+
+/**
+ * Host-provided resolver for transclusion content.
+ *
+ * When the editor encounters `![[file#block-id]]`, it calls this function to
+ * fetch the resolved Markdown content. Return `null` or `undefined` to show
+ * an "unresolved" state in the transclusion widget.
+ */
+export type TransclusionResolver = (
+  file: string,
+  blockId: string | undefined,
+  /** The current document source (for recursive-cycle detection). */
+  sourcePath?: string,
+) => string | null | undefined | Promise<string | null | undefined>;
+
+/** Configuration for block-transclusion behaviour. */
+export interface TransclusionConfig {
+  /**
+   * Host callback to resolve transclusion content. Without this the editor
+   * treats all `![[ ]]` links as unresolved (shows a placeholder).
+   */
+  resolve?: TransclusionResolver;
+  /**
+   * Callback when a block link (`[[file#id]]`) is clicked. The host decides
+   * what "navigate" means (open file, scroll to block, etc.).
+   */
+  onNavigate?: (file: string, blockId?: string) => void;
 }

--- a/packages/core/src/wikilinks.ts
+++ b/packages/core/src/wikilinks.ts
@@ -7,7 +7,7 @@ import {
 import { StateEffect, StateField, type Extension, type Range, type Transaction } from "@codemirror/state";
 import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
 
-import type { NexusPlugin } from "./types";
+import type { NexusPlugin, TransclusionMatch } from "./types";
 
 const COMPOSITION_REDECORATE_DELAY_MS = 60;
 
@@ -68,8 +68,8 @@ export interface WikilinksOptions {
 }
 
 // Must disallow: nested `[`/`]`, pipes in target, newlines.
-// Leading `(?<!\\)` skips escaped `\[[`.
-const WIKILINK_RE = /(?<!\\)\[\[([^\[\]\n|]+?)(?:\|([^\[\]\n]+?))?\]\]/g;
+// Leading `(?<![!\\])` skips escaped `\[[` and transclusion `![[`.
+const WIKILINK_RE = /(?<![!\\])\[\[([^\[\]\n|]+?)(?:\|([^\[\]\n]+?))?\]\]/g;
 
 /**
  * Scan a document string for all wiki links. Pure, side-effect-free.
@@ -106,6 +106,92 @@ export function scanWikiLinks(doc: string): WikiLinkMatch[] {
     }
 
     out.push({ from, to, target, alias, display, displayFrom, displayTo });
+  }
+  return out;
+}
+
+// ── Transclusion: ![[file#block-id]] scanning ─────────────────────────────
+
+/**
+ * Regex matching transclusion syntax: `![[file#block-id|alias]]` or
+ * `![[file#block-id]]` or `![[file|alias]]`. The `!` prefix distinguishes
+ * these from plain wiki links.
+ *
+ * The target portion allows `#` (block separator) — split downstream.
+ */
+const TRANSCLUSION_RE = /(?<!\\)!\[\[([^\[\]\n]+?)(?:\|([^\[\]\n]+?))?\]\]/g;
+
+/**
+ * Like TRANSCLUSION_RE but without the leading `!` — captures block
+ * references that navigate rather than embed: `[[file#block-id]]`.
+ */
+const BLOCKREF_RE = /(?<!\\)\[\[([^\[\]\n]+?)(?:\|([^\[\]\n]+?))?\]\]/g;
+
+/**
+ * Split a wikilink target into file name and optional block ID.
+ *
+ *   "Data"              → { file: "Data", blockId: undefined }
+ *   "Data#schema"       → { file: "Data", blockId: "schema" }
+ *   "Data#heading-text" → { file: "Data", blockId: "heading-text" }
+ *   "#block-only"       → { file: "", blockId: "block-only" }
+ */
+export function splitBlockRef(rawTarget: string): { file: string; blockId?: string } {
+  const hashIdx = rawTarget.indexOf("#");
+  if (hashIdx < 0) return { file: rawTarget.trim() };
+  return {
+    file: rawTarget.slice(0, hashIdx).trim(),
+    blockId: rawTarget.slice(hashIdx + 1).trim() || undefined,
+  };
+}
+
+/**
+ * Scan a document string for all transclusion `![[ ]]` matches.
+ * Pure, side-effect-free. Order: ascending `from`.
+ */
+export function scanTransclusions(doc: string): TransclusionMatch[] {
+  const out: TransclusionMatch[] = [];
+  TRANSCLUSION_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TRANSCLUSION_RE.exec(doc)) !== null) {
+    const from = match.index;
+    const source = match[0];
+    const to = from + source.length;
+    const rawTarget = match[1].trim();
+    const rawAlias = match[2]?.trim();
+    if (!rawTarget) continue;
+
+    const { file, blockId } = splitBlockRef(rawTarget);
+    const alias = rawAlias && rawAlias.length > 0 ? rawAlias : undefined;
+    const display = alias ?? (blockId ? `${file}#${blockId}` : file);
+
+    out.push({ from, to, isTransclusion: true, file, blockId, alias, display });
+  }
+  return out;
+}
+
+/**
+ * Scan for block-reference `[[file#block-id]]` links (no `!` prefix).
+ * These navigate on click rather than embedding.
+ */
+export function scanBlockRefLinks(doc: string): TransclusionMatch[] {
+  const out: TransclusionMatch[] = [];
+  BLOCKREF_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BLOCKREF_RE.exec(doc)) !== null) {
+    const from = match.index;
+    const source = match[0];
+    const to = from + source.length;
+    const rawTarget = match[1].trim();
+    const rawAlias = match[2]?.trim();
+    if (!rawTarget) continue;
+
+    const { file, blockId } = splitBlockRef(rawTarget);
+    if (!blockId) continue; // plain [[file]] — those are handled by scanWikiLinks
+
+    const alias = rawAlias && rawAlias.length > 0 ? rawAlias : undefined;
+    const display = alias ?? `${file}#${blockId}`;
+
+    out.push({ from, to, isTransclusion: false, file, blockId, alias, display });
   }
   return out;
 }

--- a/packages/core/test/block-id.test.ts
+++ b/packages/core/test/block-id.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  headingSlug,
+  parseBlockAnnotation,
+  scanBlockIds,
+  resolveBlockContent,
+} from "../src/block-id";
+
+describe("headingSlug", () => {
+  it("generates lowercase hyphenated slugs", () => {
+    expect(headingSlug("Design Goals")).toBe("design-goals");
+  });
+
+  it("removes special characters", () => {
+    expect(headingSlug("Hello, World!")).toBe("hello-world");
+  });
+
+  it("handles leading/trailing spaces", () => {
+    expect(headingSlug("  Spaces  ")).toBe("spaces");
+  });
+
+  it("handles unicode characters", () => {
+    // \u00e9 (\u00e9) is a letter and is preserved; emoji (\ud83c\udf55) is removed
+    expect(headingSlug("Caf\u00e9 \ud83c\udf55 nom-nom")).toBe("caf\u00e9-nom-nom");
+  });
+
+  it("collapses multiple hyphens", () => {
+    expect(headingSlug("a--b--c")).toBe("a-b-c");
+  });
+
+  it("strips leading/trailing hyphens", () => {
+    expect(headingSlug("---")).toBe("");
+  });
+});
+
+describe("parseBlockAnnotation", () => {
+  it("extracts explicit ^{id} from heading", () => {
+    const result = parseBlockAnnotation("Design Goals ^{core-design}");
+    expect(result.label).toBe("Design Goals");
+    expect(result.explicitId).toBe("core-design");
+  });
+
+  it("returns null for lines without annotation", () => {
+    const result = parseBlockAnnotation("Just Some Text");
+    expect(result.label).toBe("Just Some Text");
+    expect(result.explicitId).toBeNull();
+  });
+
+  it("does not match escaped \\^{ annotation", () => {
+    const result = parseBlockAnnotation("Text with \\^{not-an-id} chars");
+    expect(result.label).toBe("Text with \\^{not-an-id} chars");
+    expect(result.explicitId).toBeNull();
+  });
+
+  it("extracts from paragraph lines", () => {
+    const result = parseBlockAnnotation("Some paragraph ^{para-1}");
+    expect(result.label).toBe("Some paragraph");
+    expect(result.explicitId).toBe("para-1");
+  });
+
+  it("requires annotation at end of line", () => {
+    const result = parseBlockAnnotation("^{id} at start");
+    expect(result.label).toBe("^{id} at start");
+    expect(result.explicitId).toBeNull();
+  });
+});
+
+describe("scanBlockIds", () => {
+  it("extracts heading slugs as block IDs", () => {
+    const doc = [
+      "# Design Goals",
+      "",
+      "Some content here.",
+      "",
+      "## Architecture",
+      "",
+      "More content.",
+    ].join("\n");
+
+    const registry = scanBlockIds(doc);
+    expect(registry.has("design-goals")).toBe(true);
+    expect(registry.has("architecture")).toBe(true);
+
+    const goals = registry.get("design-goals")!;
+    expect(goals.type).toBe("heading");
+    expect(goals.level).toBe(1);
+    expect(goals.label).toBe("Design Goals");
+  });
+
+  it("extracts explicit ^{id} annotations", () => {
+    const doc = [
+      "## Design Goals ^{core-design}",
+      "",
+      "Content for core design.",
+      "",
+      "A standalone paragraph ^{para-note}",
+      "",
+      "## Another Section",
+    ].join("\n");
+
+    const registry = scanBlockIds(doc);
+    expect(registry.has("core-design")).toBe(true);
+    expect(registry.has("para-note")).toBe(true);
+    expect(registry.has("design-goals")).toBe(false); // explicit wins
+  });
+
+  it("handles empty document", () => {
+    const registry = scanBlockIds("");
+    expect(registry.size).toBe(0);
+  });
+
+  it("resolves block content for heading blocks", () => {
+    const doc = [
+      "## Design Goals ^{core-design}",
+      "We aim to build a fast editor.",
+      "",
+      "## Next Section",
+    ].join("\n");
+
+    const registry = scanBlockIds(doc);
+    const entry = registry.get("core-design")!;
+    const content = resolveBlockContent(entry, doc);
+    expect(content).toContain("We aim to build a fast editor.");
+    expect(content).not.toContain("Next Section");
+  });
+
+  it("resolves block content for paragraph blocks", () => {
+    const doc = [
+      "Some text",
+      "",
+      "Important note here ^{my-note}",
+      "",
+      "Other text",
+    ].join("\n");
+
+    const registry = scanBlockIds(doc);
+    const entry = registry.get("my-note")!;
+    expect(entry.type).toBe("paragraph");
+    const content = resolveBlockContent(entry, doc);
+    expect(content).toBe("Important note here");
+  });
+
+  it("handles duplicate IDs (first wins)", () => {
+    const doc = [
+      "## First ^{dup}",
+      "",
+      "## Second ^{dup}",
+    ].join("\n");
+
+    const registry = scanBlockIds(doc);
+    const entry = registry.get("dup")!;
+    expect(entry.label).toBe("First");
+  });
+});

--- a/packages/core/test/live-preview-ranges.test.ts
+++ b/packages/core/test/live-preview-ranges.test.ts
@@ -14,7 +14,7 @@ function parse(markdown: string): Root {
 describe("live preview ranges", () => {
   it("collects stable ranges for block and image previews", () => {
     const doc = "Intro\n\n# Heading\n\n> Quote\n\n![Alt](https://example.com/image.png)";
-    const ranges = collectLivePreviewRanges(
+    const { ranges } = collectLivePreviewRanges(
       parse(doc),
       doc,
       [EditorSelection.cursor(0)]
@@ -27,14 +27,14 @@ describe("live preview ranges", () => {
   it("always emits inline ranges regardless of cursor position", () => {
     const doc = "Text **bold** *italic*\n\nother line";
     // Inline ranges are always emitted; buildDecorations decides styling
-    const rangesSameLine = collectLivePreviewRanges(
+    const { ranges: rangesSameLine } = collectLivePreviewRanges(
       parse(doc),
       doc,
       [EditorSelection.cursor(8)]
     );
     expect(rangesSameLine.map((r) => r.node.type)).toEqual(["strong", "emphasis"]);
 
-    const rangesDiffLine = collectLivePreviewRanges(
+    const { ranges: rangesDiffLine } = collectLivePreviewRanges(
       parse(doc),
       doc,
       [EditorSelection.cursor(doc.length)]
@@ -46,17 +46,60 @@ describe("live preview ranges", () => {
     const doc = [
       "| Source | Address |",
       "|---|---|",
-      "| 百度热搜 | `https://top.baidu.com/board?tab=realtime` and [link](https://example.com) |",
+      "| \u767e\u5ea6\u70ed\u641c | `https://top.baidu.com/board?tab=realtime` and [link](https://example.com) |",
       "",
       "## After",
     ].join("\n");
 
-    const ranges = collectLivePreviewRanges(
+    const { ranges } = collectLivePreviewRanges(
       lezerStringToMdast(doc),
       doc,
       [EditorSelection.cursor(doc.length)]
     );
 
     expect(ranges.map((range) => range.node.type)).toEqual(["table", "heading"]);
+  });
+
+  it("collects transclusion matches", () => {
+    const doc = [
+      "Some text",
+      "",
+      "![[Data#schema]]",
+      "",
+      "More text",
+      "",
+      "![[Notes/Tech#design-goals|Design Goals]]",
+    ].join("\n");
+
+    const { transclusions } = collectLivePreviewRanges(
+      lezerStringToMdast(doc),
+      doc,
+      [EditorSelection.cursor(0)]
+    );
+
+    expect(transclusions).toHaveLength(2);
+    expect(transclusions[0].file).toBe("Data");
+    expect(transclusions[0].blockId).toBe("schema");
+    expect(transclusions[0].isTransclusion).toBe(true);
+
+    expect(transclusions[1].file).toBe("Notes/Tech");
+    expect(transclusions[1].blockId).toBe("design-goals");
+    expect(transclusions[1].alias).toBe("Design Goals");
+    expect(transclusions[1].display).toBe("Design Goals");
+  });
+
+  it("collects block reference links", () => {
+    const doc = "See [[Data#schema]] for details and [[Other|alias]] for more.";
+
+    const { blockRefs } = collectLivePreviewRanges(
+      lezerStringToMdast(doc),
+      doc,
+      [EditorSelection.cursor(0)]
+    );
+
+    expect(blockRefs).toHaveLength(1);
+    expect(blockRefs[0].file).toBe("Data");
+    expect(blockRefs[0].blockId).toBe("schema");
+    expect(blockRefs[0].isTransclusion).toBe(false);
   });
 });

--- a/packages/core/test/transclusion-widget.test.ts
+++ b/packages/core/test/transclusion-widget.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TransclusionWidget,
+  clearTransclusionCache,
+  invalidateFileCache,
+  resolveContent,
+} from "../src/transclusion-widget";
+
+// Helper to create a mock EditorView
+function mockView() {
+  const el = document.createElement("div");
+  return {
+    current: null as any,
+    dom: el,
+  };
+}
+
+describe("resolveContent", () => {
+  beforeEach(() => {
+    clearTransclusionCache();
+  });
+
+  it("resolves content through the callback and caches the result", async () => {
+    const resolve = vi.fn().mockReturnValue("# Resolved Content");
+
+    const result1 = await resolveContent(resolve, "TestFile", "heading-1");
+    expect(result1).toBe("# Resolved Content");
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    // Second call should use cached result, not call resolve again
+    const result2 = await resolveContent(resolve, "TestFile", "heading-1");
+    expect(result2).toBe("# Resolved Content");
+    expect(resolve).toHaveBeenCalledTimes(1); // still 1
+  });
+
+  it("returns null when resolve returns null", async () => {
+    const resolve = vi.fn().mockReturnValue(null);
+
+    const result = await resolveContent(resolve, "Missing", undefined);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when resolve throws", async () => {
+    const resolve = vi.fn().mockRejectedValue(new Error("Not found"));
+
+    const result = await resolveContent(resolve, "Boom", undefined);
+    expect(result).toBeNull();
+  });
+
+  it("uses different cache keys for different blockIds within same file", async () => {
+    const resolve = vi.fn((file: string, blockId: string | undefined) => {
+      if (blockId === "a") return "Content A";
+      if (blockId === "b") return "Content B";
+      return null;
+    });
+
+    const a = await resolveContent(resolve, "File", "a");
+    const b = await resolveContent(resolve, "File", "b");
+    expect(a).toBe("Content A");
+    expect(b).toBe("Content B");
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("clearTransclusionCache", () => {
+  it("clears all cached resolutions", async () => {
+    const resolve = vi.fn().mockReturnValue("content");
+
+    await resolveContent(resolve, "File", "id");
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    clearTransclusionCache();
+
+    // After clearing, should call resolve again
+    await resolveContent(resolve, "File", "id");
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("invalidateFileCache", () => {
+  beforeEach(() => {
+    clearTransclusionCache();
+  });
+
+  it("removes all block IDs for a given file", async () => {
+    const resolve = vi.fn().mockReturnValue("content");
+
+    await resolveContent(resolve, "FileA", "id1");
+    await resolveContent(resolve, "FileB", "id1");
+    expect(resolve).toHaveBeenCalledTimes(2);
+
+    invalidateFileCache("FileA");
+
+    // FileA should re-resolve, FileB should be cached
+    await resolveContent(resolve, "FileA", "id1");
+    expect(resolve).toHaveBeenCalledTimes(3);
+    await resolveContent(resolve, "FileB", "id1");
+    expect(resolve).toHaveBeenCalledTimes(3); // still cached
+  });
+
+  it("also removes the bare file key", async () => {
+    const resolve = vi.fn().mockReturnValue("content");
+
+    await resolveContent(resolve, "FileA", undefined);
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    invalidateFileCache("FileA");
+
+    await resolveContent(resolve, "FileA", undefined);
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("TransclusionWidget", () => {
+  it("creates a DOM element with breadcrumb and body", () => {
+    const viewRef = mockView();
+    const widget = new TransclusionWidget(
+      "TestFile",
+      "test-block",
+      "Test File > test-block",
+      0,
+      undefined,
+      viewRef,
+    );
+
+    const dom = widget.toDOM();
+    expect(dom.className).toBe("nexus-transclusion");
+    expect(dom.querySelector(".nexus-transclusion-breadcrumb")).not.toBeNull();
+    expect(dom.querySelector(".nexus-transclusion-body")).not.toBeNull();
+
+    const breadcrumb = dom.querySelector(".nexus-transclusion-breadcrumb")!;
+    expect(breadcrumb.textContent).toContain("TestFile");
+    expect(breadcrumb.textContent).toContain("test-block");
+  });
+
+  it("shows initial body text when no resolver is configured", () => {
+    const viewRef = mockView();
+    const widget = new TransclusionWidget(
+      "Missing",
+      "block",
+      "Missing > block",
+      0,
+      undefined,
+      viewRef,
+    );
+
+    const dom = widget.toDOM();
+    const body = dom.querySelector(".nexus-transclusion-body")!;
+    // When no resolver is provided, widget renders unresolved immediately
+    expect(body.textContent).toContain("Unresolved");
+  });
+
+  it("eq returns true for identical parameters", () => {
+    const viewRef = mockView();
+    const a = new TransclusionWidget("F", "b", "d", 0, undefined, viewRef);
+    const b = new TransclusionWidget("F", "b", "d", 0, undefined, viewRef);
+    expect(a.eq(b)).toBe(true);
+  });
+
+  it("eq returns false when file differs", () => {
+    const viewRef = mockView();
+    const a = new TransclusionWidget("A", "b", "d", 0, undefined, viewRef);
+    const b = new TransclusionWidget("B", "b", "d", 0, undefined, viewRef);
+    expect(a.eq(b)).toBe(false);
+  });
+
+  it("eq returns false when blockId differs", () => {
+    const viewRef = mockView();
+    const a = new TransclusionWidget("F", "a", "d", 0, undefined, viewRef);
+    const b = new TransclusionWidget("F", "b", "d", 0, undefined, viewRef);
+    expect(a.eq(b)).toBe(false);
+  });
+
+  it("eq returns false when sourceFrom differs", () => {
+    const viewRef = mockView();
+    const a = new TransclusionWidget("F", "b", "d", 5, undefined, viewRef);
+    const b = new TransclusionWidget("F", "b", "d", 10, undefined, viewRef);
+    expect(a.eq(b)).toBe(false);
+  });
+
+  it("ignoreEvent returns true", () => {
+    const viewRef = mockView();
+    const widget = new TransclusionWidget("F", "b", "d", 0, undefined, viewRef);
+    expect(widget.ignoreEvent()).toBe(true);
+  });
+
+  it("returns estimatedHeight > 0", () => {
+    const viewRef = mockView();
+    const widget = new TransclusionWidget("F", "b", "d", 0, undefined, viewRef);
+    expect(widget.estimatedHeight).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
将核心引擎已有的块引用/嵌入基础设施接入 Electron Demo，
实现 [[file#block-id]] 点击导航和 ![[file#block-id]] 内容嵌入渲染。

<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2.
Project scope and contribution policy — see GOVERNANCE.md.

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2。
项目范围与贡献政策见 GOVERNANCE.md。
-->

## Summary / 摘要

<!-- One sentence summary of the change. / 一句话说明改了什么。 -->

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->
<!-- 解决什么问题？关联 issue / roadmap 条目 / OpenSpec change id。 -->

- Issue:
- Roadmap (docs/ROADMAP.md):
- OpenSpec change:

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
- `apps/electron-demo`:
- `openspec/`:

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->
<!-- 描述如何验证，附上命令与覆盖的场景。 -->

- [ ] `pnpm test` passes / 全绿
- [ ] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：

## Compliance / 合规自检

<!-- See GOVERNANCE.md §6 for the full policy. / 完整政策见 GOVERNANCE.md §6。 -->

- [ ] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [ ] **AI disclosure**: the functional code in this PR is **not** primarily generated by AI. AI assistance, if any, is described below.
      AI-assisted notes / AI 使用说明：
      <!-- e.g. "tab-completion only", "AI wrote test cases for code I wrote", "AI rewrote a comment" -->
- [ ] **New dependencies** (if any) listed with license & rationale (none if blank):
      <!-- - <package>@<version> — <license> — <why we need it> -->
- [ ] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [ ] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [ ] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [ ] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [ ] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [ ] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
