### PR TITLE
fix: render strikethrough text inside markdown table cells

### DIFF
--- a/packages/core/src/lezer-mdast-adapter.ts
+++ b/packages/core/src/lezer-mdast-adapter.ts
@@ -237,6 +237,7 @@ const MARKER_NODE_NAMES = new Set([
   "EmphasisMark",
   "CodeMark",
   "LinkMark",
+  "StrikethroughMark",
   "ListMark",
   "QuoteMark",
   "HeaderMark",

--- a/packages/core/test/live-preview.test.ts
+++ b/packages/core/test/live-preview.test.ts
@@ -942,12 +942,12 @@ describe("live preview", () => {
     editor.destroy();
   });
 
-  it("renders inline bold/em/code inside table cells", () => {
+  it("renders inline bold/em/code/delete inside table cells", () => {
     const container = document.createElement("div");
     const editor = createEditor({
       container,
       initialValue:
-        "| Style | Sample |\n|---|---|\n| Bold | **strong** |\n| Italic | *em* |\n| Code | `code` |",
+        "| Style | Sample |\n|---|---|\n| Bold | **strong** |\n| Italic | *em* |\n| Code | `code` |\n| Delete | ~~removed~~ |",
       livePreview: true,
       plugins: [createGfmPreset()],
     });
@@ -955,6 +955,8 @@ describe("live preview", () => {
     expect(container.querySelector("table strong")?.textContent).toBe("strong");
     expect(container.querySelector("table em")?.textContent).toBe("em");
     expect(container.querySelector("table code")?.textContent).toBe("code");
+    expect(container.querySelector("table del")?.textContent).toBe("removed");
+    expect(container.querySelector("table")?.textContent).not.toContain("~~");
     editor.destroy();
   });
 


### PR DESCRIPTION
## Summary
- Treat Lezer `StrikethroughMark` nodes as inline markdown markers so GFM delete text inside table cells renders without raw `~~` delimiters.
- Extend the live-preview table inline formatting test to cover delete/strikethrough cells.

## Verification
- `pnpm exec vitest run packages/core/test/live-preview.test.ts` -> pass (63 tests)
- `pnpm --filter @floatboat/nexus-core build` -> pass
- `git diff --check` -> pass