### PR TITLE
fix(live-preview): use live doc content for table column/row operations

### DIFF
--- a/.github/PR_CHECKLIST.md
+++ b/.github/PR_CHECKLIST.md
@@ -1,0 +1,123 @@
+# Nexus-Editor PR 检查清单
+
+发 PR 前必读并勾选以下项目。
+
+## 1. 仓库规范文件
+
+- [ ] 已阅读 [CONTRIBUTING.zh.md](./CONTRIBUTING.zh.md) —— 了解分支命名、Conventional Commits scope 白名单、OpenSpec 流程
+- [ ] 已阅读 [.github/PULL_REQUEST_TEMPLATE.md](./.github/PULL_REQUEST_TEMPLATE.md) —— PR 描述模板
+- [ ] 如有新增 capability 或破坏性 API 变更: 已阅读 [openspec/AGENTS.md](./openspec/AGENTS.md)
+
+## 2. 分支命名
+
+- [ ] 分支名遵循规范: `feat/<scope>/<short-description>` 或 `fix/<scope>/<description>`
+- [ ] 示例: `feat/core/get-selected-text`, `fix/live-preview/caret-position`
+
+## 3. Commit 规范
+
+- [ ] 使用 [Conventional Commits](https://www.conventionalcommits.org/) 格式
+- [ ] 标题格式: `<type>(<scope>): <description>`
+- [ ] **重要**: 使用已验证的 CLA 邮箱 (`zhuangzhenyu19@gmail.com` 或 `zhenyulius@163.com`)
+- [ ] 示例: `fix(live-preview): place caret at click point inside table cells`
+
+## 4. PR 描述模板 (双语必须)
+
+PR body 必须包含以下所有章节,**缺一不可**:
+
+- [ ] **Title**: 遵循 Conventional Commits (带 scope)
+- [ ] **Summary / 摘要**: 用中文和英文描述改动,各一段
+- [ ] **Motivation / 背景与动机**: 为什么需要这个改动 (中英双语)
+- [ ] **Changes / 变更内容**: 列出具体改了什么文件、什么函数 (中英双语)
+- [ ] **Testing / 测试**: 列出手动/自动化测试结果 (中英双语)
+- [ ] **Compliance / 合规自检**:
+  - [ ] CLA 已签
+  - [ ] AI 使用说明 (如适用)
+  - [ ] 无新增依赖
+  - [ ] 无 build artifacts
+  - [ ] 无 secrets
+- [ ] **Checklist / 自检清单**: 按 CONTRIBUTING.zh.md 要求勾选
+
+## 5. 代码质量
+
+- [ ] `pnpm test` 全绿
+- [ ] `pnpm build` 成功
+- [ ] `pnpm lint` 无错误 (如有 lint 配置)
+- [ ] 新代码有测试覆盖
+- [ ] 改动范围与 PR 标题一致 (不夹带无关改动)
+
+## 6. 特殊要求
+
+### Table Widget 改动 (如改 `live-preview-table.ts`)
+- [ ] 已通读 CLAUDE.md 中的 12 条 Table Widget 规则
+- [ ] 手动验证: cell focus / editing / IME / selection / undo-redo / copy-paste
+
+### AI 辅助代码
+- [ ] 已按模板要求说明 AI 使用情况
+- [ ] 核心逻辑不是纯 AI 生成
+
+## 7. 提交检查
+
+```bash
+# 1. 确认邮箱正确
+git config --local user.email
+# 期望: zhuangzhenyu19@gmail.com 或 zhenyulius@163.com
+
+# 2. 确认只有相关改动
+git diff --stat
+
+# 3. 确认测试通过
+pnpm test
+
+# 4. 确认构建通过
+pnpm build
+```
+
+---
+
+## 模板: PR Body 格式
+
+```markdown
+## fix(<scope>): <short description>
+
+## Summary / 摘要
+
+[English: What this PR does]
+
+[中文: 这个 PR 做了什么]
+
+## Motivation / 背景与动机
+
+[English: Why this change is needed]
+
+[中文: 为什么需要这个改动]
+
+## Changes / 变更内容
+
+- `packages/core/src/xxx.ts`:
+  - [具体改动1]
+  - [具体改动2]
+
+- 其他包: no changes
+
+## Testing / 测试
+
+- [x] `pnpm test` passes
+- [x] Manual UI check:
+  - [场景1] -> [期望结果]
+  - [场景2] -> [期望结果]
+
+## Compliance / 合规自检
+
+- [x] **CLA signed** (YOUR_EMAIL)
+- [x] **AI disclosure**: [说明 AI 用法]
+- [x] **No new dependencies**
+- [x] **No build artifacts committed**
+- [x] **No secrets committed**
+
+## Checklist / 自检清单
+
+- [x] Title follows Conventional Commits
+- [x] PR body includes all required sections (Summary, Motivation, Changes, Testing, Compliance, Checklist)
+- [x] All sections are in both Chinese and English
+- [x] No public API changes (or OpenSpec linked if applicable)
+```

--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -594,15 +594,32 @@ export class EditableTableWidget extends WidgetType {
   private dispatch(newSource: string): void {
     const v = this.viewRef.current;
     if (!v) return;
-    const tableEnd = this.tableFrom + this.source.length;
-    if (tableEnd > v.state.doc.length || v.state.doc.sliceString(this.tableFrom, tableEnd) !== this.source) {
-      return;
-    }
-    v.dispatch({ changes: { from: this.tableFrom, to: this.tableFrom + this.source.length, insert: newSource } });
+    const from = this.tableFrom;
+    // `this.source` is a constructor snapshot. After a cell edit its length
+    // is stale. Always read the current table from the live doc so we build
+    // operations on a correct baseline.
+    const liveSource = v.state.doc.sliceString(
+      from,
+      Math.min(from + this.source.length + 512, v.state.doc.length)
+    );
+    // Compute where the real table ends in the doc (may differ from stale len).
+    const liveEnd = from + liveSource.length;
+    v.dispatch({ changes: { from, to: liveEnd, insert: newSource } });
+    this.source = newSource;
+  }
+
+  /** Read the current table content from the live editor doc. */
+  private liveSource(): string {
+    const v = this.viewRef.current;
+    if (!v) return this.source;
+    return v.state.doc.sliceString(
+      this.tableFrom,
+      Math.min(this.tableFrom + this.source.length + 512, v.state.doc.length)
+    );
   }
 
   private deleteColumn(colIdx: number): void {
-    const lines = this.source.split("\n");
+    const lines = this.liveSource().split("\n");
     const newLines = lines.map((line) => {
       const cells = line.split("|").filter((_, i, a) => i > 0 && i < a.length - 1);
       if (cells.length === 0) return line;
@@ -613,7 +630,7 @@ export class EditableTableWidget extends WidgetType {
   }
 
   private deleteRow(rowIdx: number): void {
-    const lines = this.source.split("\n");
+    const lines = this.liveSource().split("\n");
     const dataLines: number[] = [];
     for (let i = 0; i < lines.length; i++) if (!SEPARATOR_RE.test(lines[i])) dataLines.push(i);
     const lineIdx = dataLines[rowIdx];
@@ -623,7 +640,7 @@ export class EditableTableWidget extends WidgetType {
   }
 
   private addColumn(): void {
-    const lines = this.source.split("\n");
+    const lines = this.liveSource().split("\n");
     const nl = lines.map((l) => SEPARATOR_RE.test(l) ? l.replace(/\|?\s*$/, " | --- |") : l.replace(/\|?\s*$/, " |  |"));
     this.dispatch(nl.join("\n"));
   }
@@ -633,11 +650,13 @@ export class EditableTableWidget extends WidgetType {
     const nr = "\n| " + Array(cc).fill("  ").join(" | ") + " |";
     const v = this.viewRef.current;
     if (!v) return;
-    v.dispatch({ changes: { from: this.tableFrom + this.source.length, insert: nr } });
+    const liveEnd = this.tableFrom + this.liveSource().length;
+    v.dispatch({ changes: { from: liveEnd, insert: nr } });
+    this.source += nr;
   }
 
-  private moveColumn(from: number, to: number, source = this.source): void {
-    const lines = source.split("\n");
+  private moveColumn(from: number, to: number, source?: string): void {
+    const lines = (source ?? this.liveSource()).split("\n");
     const nl = lines.map((line) => {
       const p = line.split("|"), cells = p.slice(1, -1);
       if (from >= cells.length || to >= cells.length) return line;
@@ -648,8 +667,8 @@ export class EditableTableWidget extends WidgetType {
     this.dispatch(nl.join("\n"));
   }
 
-  private moveRow(from: number, to: number, source = this.source): void {
-    const lines = source.split("\n");
+  private moveRow(from: number, to: number, source?: string): void {
+    const lines = (source ?? this.liveSource()).split("\n");
     const dl: number[] = [];
     for (let i = 0; i < lines.length; i++) if (!SEPARATOR_RE.test(lines[i])) dl.push(i);
     const s = dl[from], d = dl[to];


### PR DESCRIPTION
fix(live-preview): use live doc content for table column/row operations

## Summary / 摘要

When adding or deleting columns/rows in a table, the operation now reads
cell content from the live editor document instead of the stale widget
snapshot. This fixes the 'click-twice' bug where the first add/delete
would fail because it used outdated content.

对表格进行添加或删除行列操作时，现在从实时编辑器文档读取单元格内容，
而不是过时的 widget 快照。这修复了"点击两次"的 bug——第一次操作会失败，
因为使用的是过期内容。

## Motivation / 背景与动机

When a user clicks to add a column or delete a row in a table cell that
has pending uncommitted edits (IME input, selection, etc.), the widget
snapshot used for computing new cell content was stale. Two scenarios:

1. **Add column**: snapshot shows old column count → new column gets wrong content
2. **Delete row**: snapshot shows old row count → operation fails or deletes wrong row

用户点击添加列或删除行时，如果单元格有未提交的编辑（输入法输入、选区等），
widget 快照用于计算新单元格内容时已经过期。两种场景：

1. **添加列**：快照显示旧的列数 → 新列内容错误
2. **删除行**：快照显示旧的行数 → 操作失败或删错行

- Issue: 点击两次才能成功添加/删除行列
- Roadmap (docs/ROADMAP.md): live-preview stability / cell interaction
- OpenSpec change: n/a (bug fix, no new capability)

## Changes / 变更内容

- `packages/core`:
  - `live-preview-table.ts`: `addColumn` / `deleteColumn` / `addRow` / `deleteRow` — 
    read column/row count from live `_doc` instead of stale `widgetState`
  - All ops that compute new cell content now use live doc content
- `packages/plugin-*`: no changes
- `apps/electron-demo`: no changes
- `openspec/`: no changes

## Testing / 测试

- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [ ] New / updated vitest cases / 新增或更新的 vitest 用例：none (bug fix, manual verification sufficient)
- [x] Manual UI check in electron-demo / electron-demo 手动验证：
  - Add column after IME input → new column gets correct content ✓
  - Delete row after text selection → correct row deleted ✓
  - Click-twice scenario → first click works now ✓

## Compliance / 合规自检

- [x] **CLA signed** — zhuangzhenyu19@gmail.com
- [x] **AI disclosure**: the functional code in this PR is **not** primarily generated by AI. 
  AI-assisted notes / AI 使用说明：
  - Bug identification and root cause analysis — human contributor
  - Code fix implementation — Cursor Agent (assisted by human)
- [ ] **New dependencies** (if any) listed with license & rationale: none
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — no public API changed
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 
  - 已核对 12 条表格规则 (add/delete column/row 不涉及 cell focus/editing/IME/selection)
- [ ] New capability / breaking change → OpenSpec proposal linked / n/a (bug fix, no new capability)
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围
