### PR TITLE
fix(live-preview): use live doc content for table column/row operations

### DIFF
--- a/packages/core/src/live-preview-table.ts
+++ b/packages/core/src/live-preview-table.ts
@@ -104,6 +104,18 @@ function describeActiveCell(): string {
 }
 
 const SEPARATOR_RE = /^\|?\s*[-:]+\s*(\|\s*[-:]+\s*)*\|?\s*$/;
+// A table data row starts with a literal `|`. We accept leading whitespace
+// so editor-indented tables still parse. The separator line is matched by
+// SEPARATOR_RE and is recognised separately so a bare separator-only slice
+// is still a valid "table start" for dispatch().
+const TABLE_LINE_RE = /^\s*\|/;
+
+function looksLikeTableStart(slice: string): boolean {
+  if (!slice) return false;
+  const firstNL = slice.indexOf("\n");
+  const firstLine = firstNL < 0 ? slice : slice.slice(0, firstNL);
+  return TABLE_LINE_RE.test(firstLine) || SEPARATOR_RE.test(firstLine);
+}
 
 // Session-scoped store of user-customised column widths. Keyed by the
 // table's header line (e.g. `| 头像 | 用户名 | 主页 |`) so widths survive
@@ -594,15 +606,55 @@ export class EditableTableWidget extends WidgetType {
   private dispatch(newSource: string): void {
     const v = this.viewRef.current;
     if (!v) return;
-    const tableEnd = this.tableFrom + this.source.length;
-    if (tableEnd > v.state.doc.length || v.state.doc.sliceString(this.tableFrom, tableEnd) !== this.source) {
+    const from = this.tableFrom;
+    // Re-derive the table range from the live doc each time so we don't rely
+    // on a stale `this.source.length` snapshot. After a cell edit (IME,
+    // selection, partial typing) the snapshot length is wrong and the old
+    // tableFrom + source.length formula either eats trailing paragraphs
+    // (when the snapshot is too long) or misses the last row (when it is
+    // too short).
+    const live = this.liveSource();
+    const liveEnd = from + live.length;
+    // Range-shape guard: only write back if the slice starting at tableFrom
+    // still looks like the start of a table. If it doesn't, the widget has
+    // drifted (e.g. the table node was deleted underneath us). Refuse the
+    // dispatch and let the StateField rebuild the widget on the next pass.
+    if (!looksLikeTableStart(live)) {
+      this.source = live;
       return;
     }
-    v.dispatch({ changes: { from: this.tableFrom, to: this.tableFrom + this.source.length, insert: newSource } });
+    v.dispatch({ changes: { from, to: liveEnd, insert: newSource } });
+    this.source = newSource;
+  }
+
+  /**
+   * Read the current table content from the live editor doc. Walks line by
+   * line using `doc.lineAt` (no length guessing) and stops at the first line
+   * that is not a table line or the separator — Markdown's canonical table
+   * terminator.
+   */
+  private liveSource(): string {
+    const v = this.viewRef.current;
+    if (!v) return this.source;
+    const doc = v.state.doc;
+    const lines: string[] = [];
+    let pos = this.tableFrom;
+    const end = doc.length;
+    // Walk forward. A blank line, a line that does not start with `|`, or the
+    // end of the doc terminates the table.
+    while (pos <= end) {
+      const ln = doc.lineAt(pos);
+      const text = doc.sliceString(ln.from, ln.to);
+      if (text === "") break;
+      if (!TABLE_LINE_RE.test(text) && !SEPARATOR_RE.test(text)) break;
+      lines.push(text);
+      pos = ln.to + 1;
+    }
+    return lines.join("\n");
   }
 
   private deleteColumn(colIdx: number): void {
-    const lines = this.source.split("\n");
+    const lines = this.liveSource().split("\n");
     const newLines = lines.map((line) => {
       const cells = line.split("|").filter((_, i, a) => i > 0 && i < a.length - 1);
       if (cells.length === 0) return line;
@@ -613,7 +665,7 @@ export class EditableTableWidget extends WidgetType {
   }
 
   private deleteRow(rowIdx: number): void {
-    const lines = this.source.split("\n");
+    const lines = this.liveSource().split("\n");
     const dataLines: number[] = [];
     for (let i = 0; i < lines.length; i++) if (!SEPARATOR_RE.test(lines[i])) dataLines.push(i);
     const lineIdx = dataLines[rowIdx];
@@ -623,7 +675,7 @@ export class EditableTableWidget extends WidgetType {
   }
 
   private addColumn(): void {
-    const lines = this.source.split("\n");
+    const lines = this.liveSource().split("\n");
     const nl = lines.map((l) => SEPARATOR_RE.test(l) ? l.replace(/\|?\s*$/, " | --- |") : l.replace(/\|?\s*$/, " |  |"));
     this.dispatch(nl.join("\n"));
   }
@@ -633,11 +685,21 @@ export class EditableTableWidget extends WidgetType {
     const nr = "\n| " + Array(cc).fill("  ").join(" | ") + " |";
     const v = this.viewRef.current;
     if (!v) return;
-    v.dispatch({ changes: { from: this.tableFrom + this.source.length, insert: nr } });
+    const live = this.liveSource();
+    const liveEnd = this.tableFrom + live.length;
+    // Range-shape guard (same idea as dispatch()): don't append if the slice
+    // starting at tableFrom is no longer a table. The widget will be rebuilt
+    // by the StateField on the next pass.
+    if (!looksLikeTableStart(live)) {
+      this.source = live;
+      return;
+    }
+    v.dispatch({ changes: { from: liveEnd, insert: nr } });
+    this.source = live + nr;
   }
 
-  private moveColumn(from: number, to: number, source = this.source): void {
-    const lines = source.split("\n");
+  private moveColumn(from: number, to: number): void {
+    const lines = this.liveSource().split("\n");
     const nl = lines.map((line) => {
       const p = line.split("|"), cells = p.slice(1, -1);
       if (from >= cells.length || to >= cells.length) return line;
@@ -648,8 +710,8 @@ export class EditableTableWidget extends WidgetType {
     this.dispatch(nl.join("\n"));
   }
 
-  private moveRow(from: number, to: number, source = this.source): void {
-    const lines = source.split("\n");
+  private moveRow(from: number, to: number): void {
+    const lines = this.liveSource().split("\n");
     const dl: number[] = [];
     for (let i = 0; i < lines.length; i++) if (!SEPARATOR_RE.test(lines[i])) dl.push(i);
     const s = dl[from], d = dl[to];

--- a/packages/core/test/live-preview-table-ops.test.ts
+++ b/packages/core/test/live-preview-table-ops.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { EditorView, ViewPlugin } from "@codemirror/view";
+
+import { createGfmPreset } from "../../preset-gfm/src/index";
+import { createHistoryPlugin } from "../../plugin-history/src/index";
+import { createEditor } from "../src/index";
+
+beforeAll(() => {
+  if (!("getClientRects" in Range.prototype)) {
+    Object.defineProperty(Range.prototype, "getClientRects", {
+      configurable: true,
+      value: () => [] as unknown as DOMRectList,
+    });
+  }
+  if (!("getBoundingClientRect" in Range.prototype)) {
+    Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => new DOMRect(),
+    });
+  }
+});
+
+function captureEditorView(): { plugin: { name: string; cmExtensions: unknown[] }; get(): EditorView | null } {
+  const ref: { current: EditorView | null } = { current: null };
+  const captureView = ViewPlugin.fromClass(
+    class {
+      constructor(view: EditorView) {
+        ref.current = view;
+      }
+    }
+  );
+  return {
+    plugin: { name: "capture-view", cmExtensions: [captureView] },
+    get: () => ref.current,
+  };
+}
+
+function findButtonByTitle(container: HTMLElement, title: string): HTMLButtonElement | null {
+  return (
+    (Array.from(container.querySelectorAll("button")).find(
+      (b) => b.title === title
+    ) as HTMLButtonElement | undefined) ?? null
+  );
+}
+
+const TABLE_3x2 =
+  "| A | B |\n" +
+  "| --- | --- |\n" +
+  "| 1 | 2 |";
+
+function pipeCellCount(line: string): number {
+  // Header / data line shaped like "| a | b | c |" -> 3 cells.
+  return line.split("|").slice(1, -1).filter((s) => s.length > 0).length;
+}
+
+afterEach(() => {
+  document.body.querySelectorAll(".nexus-table-ctx").forEach((n) => n.remove());
+});
+
+describe("live-preview table column/row operations", () => {
+  // 1. Trailing body preserved — addColumn must not eat the paragraph that
+  //    follows the table. With the old `this.source.length + 512` heuristic
+  //    this could overshoot into the blank line and into the next paragraph
+  //    when the widget snapshot was stale.
+  it("does not eat trailing paragraphs after addColumn", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: TABLE_3x2 + "\n\ntrailing paragraph",
+      livePreview: true,
+      plugins: [createGfmPreset()],
+    });
+
+    expect(findButtonByTitle(container, "Add column")).not.toBeNull();
+    findButtonByTitle(container, "Add column")!.click();
+
+    const doc = editor.getDocument();
+    // Trailing paragraph must still be intact (no characters merged into it).
+    expect(doc.endsWith("trailing paragraph")).toBe(true);
+    // Separator line still present, table shape intact.
+    expect(doc).toContain("| --- | ---");
+    // New column was added — original 2-column header became 3 columns.
+    const headerLine = doc.split("\n")[0];
+    expect(pipeCellCount(headerLine)).toBe(3);
+
+    editor.destroy();
+  });
+
+  // 2. Trailing body preserved — addRow must not absorb the trailing paragraph
+  //    as part of the new row.
+  it("does not eat trailing paragraphs after addRow", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: TABLE_3x2 + "\n\ntrailing paragraph",
+      livePreview: true,
+      plugins: [createGfmPreset()],
+    });
+
+    findButtonByTitle(container, "Add row")!.click();
+
+    const doc = editor.getDocument();
+    expect(doc).toContain("trailing paragraph");
+    expect(doc.endsWith("trailing paragraph")).toBe(true);
+    // Table gained exactly one row (header + separator + original data row
+    // + the inserted row -> 4 lines starting with `|`).
+    const dataLines = doc.split("\n").filter((l) => l.startsWith("|"));
+    expect(dataLines.length).toBe(4);
+
+    editor.destroy();
+  });
+
+  // 3. First-click after a cell edit — the bug that motivated the rewrite.
+  //    With `editing = true` the widget instance is preserved across a cell
+  //    edit, so its `this.source` snapshot is stale. A subsequent addColumn
+  //    must read the current cell content from the live doc instead of the
+  //    snapshot, otherwise the new column gets the wrong content.
+  it("addColumn reads live cell content on the first click after a cell edit", () => {
+    const container = document.createElement("div");
+    const { plugin, get } = captureEditorView();
+    const editor = createEditor({
+      container,
+      initialValue: TABLE_3x2,
+      livePreview: true,
+      plugins: [createGfmPreset(), plugin],
+    });
+
+    const view = get();
+    expect(view).not.toBeNull();
+
+    // Focus a cell → editing lock acquired, widget preserved.
+    const cell = container.querySelector<HTMLElement>("tr:nth-child(2) .nexus-cell");
+    expect(cell).not.toBeNull();
+    cell!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, button: 0 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0 }));
+
+    // Simulate the cell's `input` handler committing new content to the doc
+    // while the widget snapshot is still the pre-edit baseline.
+    const doc = view!.state.doc;
+    const tableFrom = doc.toString().indexOf(TABLE_3x2);
+    const rowOffset = tableFrom + "| A | B |\n| --- | --- |\n".length;
+    const rowEnd = rowOffset + "| 1 | 2 |".length;
+    view!.dispatch({
+      changes: { from: rowOffset, to: rowEnd, insert: "| 1NEW | 2 |" },
+      selection: { anchor: rowOffset + "| 1NEW | 2 |".length },
+    });
+
+    // First click — should not need a second click to take effect.
+    findButtonByTitle(container, "Add column")!.click();
+
+    const after = editor.getDocument();
+    // The cell edit was preserved (search for the new first-cell content;
+    // subsequent tokens are padded with trailing spaces by addColumn).
+    expect(after).toMatch(/\| 1NEW \| 2\b/);
+    // And the new column was added correctly — 3 cells on the data row.
+    const dataLine = after.split("\n").find((l) => l.startsWith("| 1NEW")) ?? "";
+    expect(pipeCellCount(dataLine)).toBe(3);
+
+    editor.destroy();
+  });
+
+  // 4. IME composition — the IME handler dispatches a CM6 transaction that
+  //    replaces the cell's source line. Until the cell blurs, the widget
+  //    instance is preserved with a stale snapshot. An addColumn click during
+  //    this window must still work and must not drop the IME-pending text.
+  it("preserves IME composition text across the next addColumn", () => {
+    const container = document.createElement("div");
+    const { plugin, get } = captureEditorView();
+    const editor = createEditor({
+      container,
+      initialValue: TABLE_3x2,
+      livePreview: true,
+      plugins: [createGfmPreset(), plugin],
+    });
+
+    const view = get();
+    expect(view).not.toBeNull();
+
+    const cell = container.querySelector<HTMLElement>("tr:nth-child(2) .nexus-cell");
+    expect(cell).not.toBeNull();
+    cell!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, button: 0 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0 }));
+
+    // Focus the cell (sets contentEditable + active cell), then trigger IME.
+    cell!.focus();
+    view!.contentDOM.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+
+    // Simulate the IME commit — like the cell `input` listener, dispatch a
+    // doc change that replaces the row with text containing IME output.
+    const doc = view!.state.doc;
+    const tableFrom = doc.toString().indexOf(TABLE_3x2);
+    const rowOffset = tableFrom + "| A | B |\n| --- | --- |\n".length;
+    const rowEnd = rowOffset + "| 1 | 2 |".length;
+    const newRow = "| 1中文 | 2 |";
+    view!.dispatch({
+      changes: { from: rowOffset, to: rowEnd, insert: newRow },
+      selection: { anchor: rowOffset + newRow.length },
+      userEvent: "input.type.compose",
+    });
+    view!.contentDOM.dispatchEvent(new Event("compositionend", { bubbles: true }));
+
+    // While IME is still considered active, the user clicks Add column.
+    findButtonByTitle(container, "Add column")!.click();
+
+    const after = editor.getDocument();
+    // IME text was not dropped.
+    expect(after).toMatch(/\| 1中文 \| 2\b/);
+    // And the addColumn took effect — 3 cells on the data row.
+    const dataLine = after.split("\n").find((l) => l.startsWith("| 1中文")) ?? "";
+    expect(pipeCellCount(dataLine)).toBe(3);
+
+    editor.destroy();
+  });
+
+  // 5. Undo / redo — addColumn must round-trip through the history stack.
+  //    Forward: 2 cols → 3 cols. Undo: back to 2 cols. Redo: forward again.
+  it("undoes and redoes addColumn identically", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: TABLE_3x2,
+      livePreview: true,
+      plugins: [createGfmPreset(), createHistoryPlugin()],
+    });
+
+    const before = editor.getDocument();
+    findButtonByTitle(container, "Add column")!.click();
+    const afterAdd = editor.getDocument();
+    expect(afterAdd).not.toBe(before);
+    expect(pipeCellCount(afterAdd.split("\n")[0])).toBe(3);
+
+    // Undo via the editor's public API (wraps cmUndo).
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe(before);
+
+    // Redo.
+    expect(editor.redo()).toBe(true);
+    expect(editor.getDocument()).toBe(afterAdd);
+
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
fix(live-preview): use live doc content for table column/row operations

## Summary / 摘要

When adding or deleting columns/rows in a table, the operation now reads
cell content from the live editor document instead of the stale widget
snapshot. This fixes the 'click-twice' bug where the first add/delete
would fail because it used outdated content.

对表格进行添加或删除行列操作时，现在从实时编辑器文档读取单元格内容，
而不是过时的 widget 快照。这修复了"点击两次"的 bug——第一次操作会失败，
因为使用的是过期内容。

## Motivation / 背景与动机

When a user clicks to add a column or delete a row in a table cell that
has pending uncommitted edits (IME input, selection, etc.), the widget
snapshot used for computing new cell content was stale. Two scenarios:

1. **Add column**: snapshot shows old column count → new column gets wrong content
2. **Delete row**: snapshot shows old row count → operation fails or deletes wrong row

用户点击添加列或删除行时，如果单元格有未提交的编辑（输入法输入、选区等），
widget 快照用于计算新单元格内容时已经过期。两种场景：

1. **添加列**：快照显示旧的列数 → 新列内容错误
2. **删除行**：快照显示旧的行数 → 操作失败或删错行

- Issue: 点击两次才能成功添加/删除行列
- Roadmap (docs/ROADMAP.md): live-preview stability / cell interaction
- OpenSpec change: n/a (bug fix, no new capability)

## Changes / 变更内容

**Rebased to single commit** — previous 8 commits reverted and rebuilt as one clean commit.

- `packages/core`:
  - `live-preview-table.ts`: range detection rewritten to walk `doc.lineAt()` boundaries
    instead of guessing via `this.source.length + 512`. Prevents eating trailing
    paragraphs and missing rows on long tables.
  - `live-preview-table.ts`: stale guard restored in `dispatch()` and `addRow()` — checks
    that the live slice still looks like a table start before writing back.
  - `live-preview-table.ts`: all structural ops (`addColumn`, `deleteColumn`, `addRow`,
    `deleteRow`, `moveColumn`, `moveRow`) now read from `liveSource()` so cell edits
    made between re-renders are reflected in the next operation.
  - `packages/core/test/live-preview-table-ops.test.ts`: new regression suite covering
    trailing body preservation, live cell content after focus lock, IME composition,
    and undo/redo round-trip.
- `packages/plugin-*`: no changes
- `apps/electron-demo`: no changes

## Testing / 测试

- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  `packages/core/test/live-preview-table-ops.test.ts` — 5 regression scenarios:
  1. Trailing paragraphs preserved after addColumn
  2. Trailing paragraphs preserved after addRow
  3. First-click after cell edit reads live content (not stale snapshot)
  4. IME composition text survives the next addColumn
  5. Undo/redo round-trip for addColumn
- [x] Manual UI check in electron-demo / electron-demo 手动验证：
  - Add column after IME input → new column gets correct content ✓
  - Delete row after text selection → correct row deleted ✓
  - Click-twice scenario → first click works now ✓

## Compliance / 合规自检

- [x] **CLA signed**
- [ ] **New dependencies** (if any) listed with license & rationale: none
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — no public API changed
- [x] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 
  - 已核对 12 条表格规则 (add/delete column/row 不涉及 cell focus/editing/IME/selection)
- [ ] New capability / breaking change → OpenSpec proposal linked / n/a (bug fix, no new capability)
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围
