### PR TITLE
feat(autosave): add debounced autosave plugin with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 | `@floatboat/nexus-plugin-math` | Inline / block math rendering (KaTeX) |
 | `@floatboat/nexus-plugin-vim` | Vim keybindings powered by `@replit/codemirror-vim` |
 | `@floatboat/nexus-plugin-wordcount` | Markdown-aware word / character / CJK / reading-time stats + ARIA-live status bar |
+| `@floatboat/nexus-plugin-autosave` | Debounced auto-save — persists Markdown to a host sink after edits settle |
 
 </details>
 

--- a/openspec/changes/add-autosave-plugin/proposal.md
+++ b/openspec/changes/add-autosave-plugin/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add debounced auto-save plugin
+
+## Why
+Hosts wiring Nexus-Editor into a notes / CMS backend must persist edits.
+The core README already warns that `onChange` needs manual debouncing,
+so every integrator re-implements the same timer dance. A first-party
+`plugin-autosave` removes that boilerplate and gives one tested,
+documented primitive.
+
+## What Changes
+- Add `@floatboat/nexus-plugin-autosave` exporting `createAutoSavePlugin`.
+- Debounces document changes by a configurable `delay` (default 1000ms).
+- Calls `onSave(markdown)` with the latest source; `flush()` forces an
+  immediate save; `destroy()` cancels pending work.
+- No new runtime dependencies (only `@floatboat/nexus-core` via workspace).
+
+## Impact
+- Affected specs: autosave
+- Affected code: `packages/plugin-autosave`

--- a/openspec/changes/add-autosave-plugin/specs/autosave/spec.md
+++ b/openspec/changes/add-autosave-plugin/specs/autosave/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Debounced Auto-Save
+The system SHALL provide a `createAutoSavePlugin` that persists the editor's
+Markdown source to a host-provided sink after edits settle.
+
+#### Scenario: Edits settle then save
+- **WHEN** the document changes and then stays unchanged for `delay` ms
+- **THEN** `onSave` is called once with the latest Markdown source
+
+#### Scenario: Burst edits collapse
+- **WHEN** multiple edits occur within one `delay` window
+- **THEN** only a single `onSave` fires after the window
+
+#### Scenario: Manual flush
+- **WHEN** `flush()` is called while a save is pending
+- **THEN** `onSave` runs immediately and the pending timer is cancelled
+
+#### Scenario: Teardown
+- **WHEN** `destroy()` is called
+- **THEN** no further `onSave` fires, even on later edits

--- a/openspec/changes/add-autosave-plugin/tasks.md
+++ b/openspec/changes/add-autosave-plugin/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+- [ ] 1.1 Scaffold `packages/plugin-autosave` (package.json, src, test, README)
+- [ ] 1.2 Implement `createAutoSavePlugin` (debounce + flush + destroy)
+- [ ] 1.3 Write vitest cases (debounce, burst, no-op before delay, flush, destroy)
+- [ ] 1.4 Document usage in package README
+
+## 2. Verification
+- [ ] 2.1 `pnpm test` passes for the new package
+- [ ] 2.2 `pnpm build` succeeds for the new package
+- [ ] 2.3 Manual note: behavior matches docs/ROADMAP pain point (onChange debounce)

--- a/packages/plugin-autosave/README.md
+++ b/packages/plugin-autosave/README.md
@@ -1,0 +1,58 @@
+# @floatboat/nexus-plugin-autosave
+
+Debounced auto-save for Nexus-Editor. Persist the editor's Markdown
+source to your own store (localStorage, a backend, IndexedDB, …)
+once edits settle, instead of re-implementing the `onChange` debounce
+the core README warns about.
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-plugin-autosave
+```
+
+## Usage
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+import {
+  createAutoSavePlugin,
+  attachAutoSavePlugin
+} from "@floatboat/nexus-plugin-autosave";
+
+const autosave = createAutoSavePlugin({
+  // `delay` defaults to 1000ms; set to 0 to save on every change.
+  delay: 800,
+  onSave: (markdown) => {
+    localStorage.setItem("draft", markdown);
+  }
+});
+
+const editor = createEditor({
+  container,
+  initialValue: "# Hello",
+  plugins: [autosave]
+});
+attachAutoSavePlugin(autosave, editor);
+
+// Persist immediately (e.g. on `beforeunload`):
+window.addEventListener("beforeunload", () => autosave.flush());
+// Stop saving (e.g. on unmount):
+autosave.destroy();
+```
+
+## API
+
+`createAutoSavePlugin(options)` returns a value that is **both** a
+Nexus plugin (pass it to `createEditor({ plugins })`) **and** a handle:
+
+| Member | Description |
+|---|---|
+| `onSave(markdown)` | Required. Called with the latest source after the debounce window. A rejected promise is swallowed. |
+| `delay?` | Quiet period in ms before `onSave` runs. Default `1000`. `0` saves on every change. |
+| `flush()` | Force an immediate save of the current document and cancel the pending timer. |
+| `destroy()` | Stop listening and cancel any pending save. |
+
+## License
+
+MIT

--- a/packages/plugin-autosave/package.json
+++ b/packages/plugin-autosave/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@floatboat/nexus-plugin-autosave",
+  "version": "0.0.1",
+  "description": "Debounced auto-save for Nexus-Editor: persist Markdown to your store after edits settle.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean"
+  },
+  "dependencies": {
+    "@floatboat/nexus-core": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/plugin-autosave/src/index.ts
+++ b/packages/plugin-autosave/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  createAutoSavePlugin,
+  attachAutoSavePlugin,
+  type AutoSaveOptions,
+  type AutoSaveAPI,
+  type AutoSavePlugin
+} from "./plugin";

--- a/packages/plugin-autosave/src/plugin.ts
+++ b/packages/plugin-autosave/src/plugin.ts
@@ -1,0 +1,117 @@
+import type { EditorAPI, NexusPlugin } from "@floatboat/nexus-core";
+
+export interface AutoSaveOptions {
+  /**
+   * Called with the current Markdown source whenever a debounced save
+   * fires. A rejected promise is swallowed so a failing sink can't
+   * break the editor's change loop.
+   */
+  onSave: (markdown: string) => void | Promise<void>;
+  /**
+   * Quiet period in milliseconds after the last edit before `onSave`
+   * runs. Default: 1000. Set to 0 to save on every change.
+   */
+  delay?: number;
+}
+
+export interface AutoSaveAPI {
+  /** Force an immediate save of the current document. */
+  flush(): void;
+  /** Stop listening and cancel any pending save. */
+  destroy(): void;
+}
+
+export type AutoSavePlugin = NexusPlugin &
+  AutoSaveAPI & {
+    /**
+     * Bind the plugin to an editor instance. Call once after
+     * `createEditor` returns. Most hosts will prefer the
+     * {@link attachAutoSavePlugin} free function for readability.
+     */
+    attachEditor(editor: EditorAPI): void;
+  };
+
+export function createAutoSavePlugin(options: AutoSaveOptions): AutoSavePlugin {
+  const delay = Math.max(0, options.delay ?? 1000);
+  const onSave = options.onSave;
+
+  let editor: EditorAPI | null = null;
+  let destroyed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const saveNow = (): void => {
+    if (destroyed || !editor) return;
+    const markdown = editor.getDocument();
+    Promise.resolve(onSave(markdown)).catch(() => {});
+  };
+
+  const schedule = (): void => {
+    if (destroyed) return;
+    if (timer) clearTimeout(timer);
+    if (delay === 0) {
+      saveNow();
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      saveNow();
+    }, delay);
+  };
+
+  const onChange = (): void => schedule();
+
+  const api: AutoSaveAPI = {
+    flush() {
+      if (destroyed || !editor) return;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      saveNow();
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (editor) {
+        try {
+          editor.off("change", onChange);
+        } catch {
+          /* editor may already be torn down */
+        }
+        editor = null;
+      }
+    }
+  };
+
+  const plugin: AutoSavePlugin = {
+    name: "plugin-autosave",
+    cmExtensions: [],
+    ...api,
+    attachEditor(target: EditorAPI) {
+      if (editor || destroyed) return;
+      editor = target;
+      target.on("change", onChange);
+    }
+  };
+
+  return plugin;
+}
+
+/**
+ * Bind an auto-save plugin to an editor instance. Equivalent to
+ * `plugin.attachEditor(editor)` but reads more naturally at the call
+ * site:
+ *
+ * ```ts
+ * const autosave = createAutoSavePlugin({ onSave: persist });
+ * const editor = createEditor({ container, plugins: [autosave] });
+ * attachAutoSavePlugin(autosave, editor);
+ * ```
+ */
+export function attachAutoSavePlugin(plugin: AutoSavePlugin, editor: EditorAPI): void {
+  plugin.attachEditor(editor);
+}

--- a/packages/plugin-autosave/test/plugin.test.ts
+++ b/packages/plugin-autosave/test/plugin.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createEditor, type EditorAPI } from "@floatboat/nexus-core";
+
+import {
+  attachAutoSavePlugin,
+  createAutoSavePlugin
+} from "../src/plugin";
+
+const flushMicrotasks = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+
+describe("createAutoSavePlugin", () => {
+  let container: HTMLDivElement;
+  let editor: EditorAPI;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+    container.remove();
+  });
+
+  it("saves the latest markdown after the debounce delay", async () => {
+    vi.useFakeTimers();
+    try {
+      const onSave = vi.fn();
+      const autosave = createAutoSavePlugin({ onSave, delay: 100 });
+      editor = createEditor({ container, initialValue: "a", plugins: [autosave] });
+      attachAutoSavePlugin(autosave, editor);
+      await vi.runAllTimersAsync();
+
+      onSave.mockClear();
+      editor.setDocument("a b c");
+      expect(onSave).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(120);
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave).toHaveBeenCalledWith("a b c");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("collapses bursts of edits into a single save", async () => {
+    vi.useFakeTimers();
+    try {
+      const onSave = vi.fn();
+      const autosave = createAutoSavePlugin({ onSave, delay: 200 });
+      editor = createEditor({ container, initialValue: "a", plugins: [autosave] });
+      attachAutoSavePlugin(autosave, editor);
+      await vi.runAllTimersAsync();
+
+      onSave.mockClear();
+      editor.setDocument("a b");
+      editor.setDocument("a b c");
+      editor.setDocument("a b c d");
+      expect(onSave).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave).toHaveBeenCalledWith("a b c d");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not save before the delay elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const onSave = vi.fn();
+      const autosave = createAutoSavePlugin({ onSave, delay: 500 });
+      editor = createEditor({ container, initialValue: "x", plugins: [autosave] });
+      attachAutoSavePlugin(autosave, editor);
+      await vi.runAllTimersAsync();
+
+      onSave.mockClear();
+      editor.setDocument("x y");
+      await vi.advanceTimersByTimeAsync(200);
+      expect(onSave).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not save on attach without an edit", async () => {
+    const onSave = vi.fn();
+    const autosave = createAutoSavePlugin({ onSave });
+    editor = createEditor({ container, initialValue: "hello", plugins: [autosave] });
+    attachAutoSavePlugin(autosave, editor);
+    await flushMicrotasks();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("flush() forces an immediate save and clears the timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const onSave = vi.fn();
+      const autosave = createAutoSavePlugin({ onSave, delay: 1000 });
+      editor = createEditor({ container, initialValue: "a", plugins: [autosave] });
+      attachAutoSavePlugin(autosave, editor);
+      await vi.runAllTimersAsync();
+
+      onSave.mockClear();
+      editor.setDocument("a b");
+      expect(onSave).not.toHaveBeenCalled();
+      await autosave.flush();
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave).toHaveBeenCalledWith("a b");
+      // pending timer must be cleared so no second save fires later
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(onSave).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("destroy() silences further saves", async () => {
+    const onSave = vi.fn();
+    const autosave = createAutoSavePlugin({ onSave, delay: 0 });
+    editor = createEditor({ container, initialValue: "hello", plugins: [autosave] });
+    attachAutoSavePlugin(autosave, editor);
+    await flushMicrotasks();
+
+    onSave.mockClear();
+    autosave.destroy();
+    editor.setDocument("hello world");
+    await flushMicrotasks();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-autosave/tsconfig.json
+++ b/packages/plugin-autosave/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:  <type>(<scope>): <subject>
  e.g.  feat(toolbar): list toggle for multi-line selection
Allowed scopes — see CONTRIBUTING.md §2.
Project scope and contribution policy — see GOVERNANCE.md.

PR 标题请遵循 Conventional Commits 规范，合法 scope 见 CONTRIBUTING.md §2。
项目范围与贡献政策见 GOVERNANCE.md。
-->

## Summary / 摘要

Add `@floatboat/nexus-plugin-autosave`: a debounced auto-save plugin that
persists the editor's Markdown to a host sink after edits settle.

## Motivation / 背景与动机

<!-- Why is this change needed? Link issue / roadmap entry / OpenSpec change. -->

- Issue:
- Roadmap (docs/ROADMAP.md): addresses the documented `onChange` debounce pain point
- OpenSpec change: `add-autosave-plugin`

## Changes / 变更内容

<!-- List key changes per package. / 按包分节，列出关键改动点。 -->

- `packages/core`:
- `packages/plugin-*`:
  - `packages/plugin-autosave` (new): `createAutoSavePlugin({ onSave, delay? })`
    exports a Nexus plugin that debounces document changes and calls
    `onSave(markdown)`. `flush()` forces an immediate save; `destroy()`
    cancels pending work. `delay` defaults to 1000ms (0 = save per change).
- `apps/electron-demo`:
- `openspec/`:
  - `openspec/changes/add-autosave-plugin/` (proposal + tasks + spec delta)

## Testing / 测试

<!-- How was this verified? Commands and scenarios covered. -->

- [x] `pnpm test` passes / 全绿
- [x] Affected packages build (`pnpm build`) / 受影响包构建通过
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - saves latest markdown after the debounce delay
  - collapses bursts of edits into a single save
  - does not save before the delay elapses
  - does not save on attach without an edit
  - `flush()` forces an immediate save and clears the timer
  - `destroy()` silences further saves
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：N/A (headless plugin, no UI)

## Compliance / 合规自检

<!-- See GOVERNANCE.md §6 for the full policy. / 完整政策见 GOVERNANCE.md §6。 -->

- [ ] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI Disclosure / AI 披露**：This PR was developed with AI assistance (WorkBuddy) for code drafting. The contributor selected the feature (debounced auto-save, addressing the documented `onChange` debounce pain point), reviewed the implementation line-by-line against the repo's `NexusPlugin` conventions, and verified it via the included Vitest suite (6/6 passing) plus `tsc --noEmit` and `tsup` build before submission. Design decisions (debounce strategy, flush/destroy lifecycle, zero new runtime deps) are understood and can be defended. / 本 PR 在代码起草阶段使用了 AI 辅助（WorkBuddy）。贡献者选定功能、逐行复核实现、并通过自带 6/6 Vitest + 类型检查 + 构建验证后提交；设计决策可解释。
- [x] **New dependencies** (if any) listed with license & rationale (none if blank):
      - (none — only `@floatboat/nexus-core` via `workspace:*`)
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [ ] Touched `live-preview-table.ts` → walked through the 12 Table Widget rules in CLAUDE.md / 已核对 12 条表格规则
- [x] New capability / breaking change → OpenSpec proposal linked / 新 capability 或破坏性变更已附 OpenSpec
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

<!-- Attach screenshots or gifs for visible UI changes. / 改动可见 UI 时请附上截图或 gif。 -->
