### PR TITLE
fix(react,vue): restore rejected controlled edits

### DIFF
--- a/packages/react/src/use-editor.ts
+++ b/packages/react/src/use-editor.ts
@@ -24,7 +24,7 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<ReturnType<typeof createEditor> | null>(null);
   const [editor, setEditor] = useState<ReturnType<typeof createEditor> | null>(null);
-  const [, setSyncRevision] = useState(0);
+  const [syncRevision, setSyncRevision] = useState(0);
   const configRef = useRef(config);
   const lastSyncedDocRef = useRef<string | null>(null);
 
@@ -78,7 +78,7 @@ export function useEditor(config: UseEditorConfig): UseEditorResult {
     instance.setDocument(value, { silent: true });
     lastSyncedDocRef.current = value;
     setSyncRevision((revision) => revision + 1);
-  }, [config.value, editor]);
+  }, [config.value, editor, syncRevision]);
 
   return {
     containerRef,

--- a/packages/react/test/editor-react.test.tsx
+++ b/packages/react/test/editor-react.test.tsx
@@ -149,6 +149,30 @@ describe("@floatboat/nexus-react", () => {
     });
   });
 
+  it("restores the controlled value when the parent rejects a document change", async () => {
+    const onChange = vi.fn();
+
+    function Harness() {
+      const { containerRef, editor } = useEditor({
+        value: "accepted",
+        onChange
+      });
+
+      useEffect(() => {
+        editor?.setDocument("rejected");
+      }, [editor]);
+
+      return <div ref={containerRef} />;
+    }
+
+    const { container } = render(<Harness />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("rejected", expect.anything());
+      expect(container.querySelector(".cm-line")?.textContent).toBe("accepted");
+    });
+  });
+
   it("skips silent setDocument when controlled value already matches the last change", async () => {
     const silentDocs: string[] = [];
 
@@ -178,10 +202,11 @@ describe("@floatboat/nexus-react", () => {
       return <div ref={containerRef} />;
     }
 
-    render(<Harness />);
+    const { container } = render(<Harness />);
 
     await waitFor(() => {
-      expect(silentDocs.filter((doc) => doc === "beta")).toHaveLength(0);
+      expect(container.querySelector(".cm-line")?.textContent).toBe("beta");
+      expect(silentDocs).toHaveLength(0);
     });
   });
 

--- a/packages/vue/src/use-editor.ts
+++ b/packages/vue/src/use-editor.ts
@@ -60,8 +60,8 @@ export function useEditor(config: MaybeRefOrGetter<UseEditorConfig>): UseEditorR
   });
 
   watch(
-    () => resolveConfig().modelValue,
-    (value) => {
+    () => [resolveConfig().modelValue, syncRevision.value] as const,
+    ([value]) => {
       const instance = editor.value;
 
       if (!instance || value === undefined) {

--- a/packages/vue/test/editor-vue.test.ts
+++ b/packages/vue/test/editor-vue.test.ts
@@ -181,6 +181,61 @@ describe("@floatboat/nexus-vue", () => {
     });
   });
 
+  it("restores modelValue when the parent rejects a document change", async () => {
+    const onChange = vi.fn();
+
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef, editor } = useEditor({
+          modelValue: "accepted",
+          onChange
+        });
+
+        onMounted(() => {
+          editor.value?.setDocument("rejected");
+        });
+
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    const wrapper = mount(Harness);
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("rejected", expect.anything());
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("accepted");
+    });
+  });
+
+  it("keeps a document change when the parent accepts it", async () => {
+    const doc = ref("alpha");
+    const Harness = defineComponent({
+      setup() {
+        const { containerRef, editor } = useEditor(() => ({
+          modelValue: doc.value,
+          onChange: (next) => {
+            doc.value = next;
+          }
+        }));
+
+        onMounted(() => {
+          editor.value?.setDocument("beta");
+        });
+
+        return () => h("div", { ref: containerRef });
+      }
+    });
+
+    const wrapper = mount(Harness);
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(doc.value).toBe("beta");
+      expect(wrapper.element.querySelector(".cm-line")?.textContent).toBe("beta");
+    });
+  });
+
   it("supports v-model on the Editor component", async () => {
     const doc = ref("alpha");
     const Parent = defineComponent({


### PR DESCRIPTION
## Summary

Restore the parent-owned document after React or Vue controlled bindings reject an editor-originated change.

## Motivation

The controlled bindings only reconciled when `value` / `modelValue` changed. After an editor change, both bindings recorded the edited document as the last synchronized value. If the parent deliberately kept its existing value—for example, validation rejected the edit—the prop remained unchanged, no synchronization ran, and the editor incorrectly continued displaying the rejected content.

## Changes

- React: retain the internal synchronization revision and include it in the controlled-document reconciliation effect.
- Vue: watch both `modelValue` and the internal synchronization revision.
- In both bindings, accepted edits remain untouched while rejected edits are restored silently from the parent-owned value.
- Add integration tests for rejected edits in React and Vue, strengthen React accepted-edit coverage, and add equivalent Vue accepted-edit coverage.

## Testing

- [x] Regression tests observed failing in both React and Vue before the implementation
- [x] `pnpm vitest run packages/react/test/editor-react.test.tsx packages/vue/test/editor-vue.test.ts` — 28 tests passed
- [x] `pnpm test` — 34 files, 540 tests passed
- [x] `pnpm exec tsc --noEmit -p packages/react/tsconfig.json`
- [x] `pnpm exec tsc --noEmit -p packages/vue/tsconfig.json`
- [x] `pnpm --filter @floatboat/nexus-react build`
- [x] `pnpm --filter @floatboat/nexus-vue build`
- [x] `git diff --check`

## OpenSpec

No OpenSpec change: this fixes the existing controlled-document contract rather than introducing a new capability or public API.

## AI assistance disclosure

AI assistance was used to diagnose the synchronization gap, implement the reconciliation change, and write the regression tests. The complete diff was validated with failing-before/passing-after tests, full-suite tests, scoped typechecks, and package builds. No dependencies were added.