### PR TITLE
feat(history): add undo grouping controls and exclude silent loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We ship in priority tiers — **P0 is what we're working on right now**.
 | Tier | Theme | Highlights |
 |---|---|---|
 | **P0 — Now** | Core API completeness | `getSelectedText()`, slash command sorting, `<Editor />` `onReady`, TS strict coverage |
-| **P1 — Next** | Power-user features | Multi-cursor, regex search, undo/redo grouping, widget API standardization, Electron packaging |
+| **P1 — Next** | Power-user features | Multi-cursor, regex search, widget API standardization, Electron packaging |
 | **P2 — Mid-term** | UX & ecosystem | Advanced toolbar (emoji / table / color), fuzzy search, sync-scroll preview, web-component wrapper |
 | **P3 — Long-term** | Collaboration | Realtime CRDT collab, shared comments / @mention, plugin hot-reload |
 
@@ -173,7 +173,7 @@ A real Electron app with file IO, live preview, and every plugin enabled — the
 | `@floatboat/nexus-react` | React binding — `useEditor` hook and `<Editor />` component |
 | `@floatboat/nexus-vue` | Vue 3 binding — `useEditor` composable |
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown preset (tables, strikethrough, task lists) |
-| `@floatboat/nexus-plugin-history` | Undo/redo with `Ctrl+Z` / `Ctrl+Shift+Z` |
+| `@floatboat/nexus-plugin-history` | Undo/redo with configurable grouping, silent-load exclusion, `Ctrl+Z` / `Ctrl+Shift+Z` |
 | `@floatboat/nexus-plugin-search` | Search and replace helpers |
 | `@floatboat/nexus-plugin-slash` | Slash command detection, ranking, and a vanilla-DOM floating menu UI |
 | `@floatboat/nexus-plugin-toolbar` | Toolbar primitives for formatting commands |

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 | 优先级 | 主题 | 关键项 |
 |---|---|---|
 | **P0 — 当前** | 核心 API 完善 | `getSelectedText()`、斜杠命令排序、`<Editor />` `onReady`、TS 严格类型覆盖 |
-| **P1 — 下一阶段** | 进阶功能 | 多光标、正则搜索、撤销/重做分组、Widget API 标准化、Electron 打包优化 |
+| **P1 — 下一阶段** | 进阶功能 | 多光标、正则搜索、Widget API 标准化、Electron 打包优化 |
 | **P2 — 中期** | 体验与生态 | 高级工具栏（emoji / 表格 / 颜色）、模糊搜索、滚动同步预览、Web Component 包装 |
 | **P3 — 长期** | 协作能力 | 实时 CRDT 协作、共享评论 / @提醒、插件热重载 |
 
@@ -173,7 +173,7 @@ pnpm dev:electron-demo
 | `@floatboat/nexus-react` | React 绑定 —— `useEditor` Hook 与 `<Editor />` 组件 |
 | `@floatboat/nexus-vue` | Vue 3 绑定 —— `useEditor` 组合式函数 |
 | `@floatboat/nexus-preset-gfm` | GitHub Flavored Markdown 预设（表格、删除线、任务列表） |
-| `@floatboat/nexus-plugin-history` | 撤销/重做，支持 `Ctrl+Z` / `Ctrl+Shift+Z` |
+| `@floatboat/nexus-plugin-history` | 撤销/重做（可配置分组、silent 加载不进撤销栈），支持 `Ctrl+Z` / `Ctrl+Shift+Z` |
 | `@floatboat/nexus-plugin-search` | 搜索替换辅助函数 |
 | `@floatboat/nexus-plugin-slash` | 斜杠命令检测、排序与 vanilla DOM 浮层菜单 UI |
 | `@floatboat/nexus-plugin-toolbar` | 工具栏基础组件与格式化命令 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ This document maps every planned feature to **package ownership / priority / sta
 | 5 | `getSelectedText()` API | `core` | P0 | done | No | Plus atomic `replaceRange()` (single undo entry) — see `openspec/changes/add-selection-api` |
 | 6 | Multi-cursor / multi-selection | `core` | P1 | done | Yes | `openspec/changes/add-core-multi-cursor` — opt-in `multiCursor` config; live-preview reveal + table checks verified by regression tests |
 | 7 | AST enhancement / Markdown extensions | `core` + `preset-gfm` | P2 | planned | Yes | Affects serialization and every AST-dependent plugin |
-| 8 | Undo / redo grouping | `plugin-history` | P1 | planned | No | Coordinate with table's `tableEditingCount`; consolidate competing impls before merge |
+| 8 | Undo / redo grouping | `plugin-history` | P1 | done | No | Configurable `history()` options + `forceHistoryBoundary` / `notInHistory` / `withHistoryControl`; silent `setDocument`/`replaceRange` excluded from undo stack. In-cell contentEditable undo unification deferred. |
 
 ## 4. Plugin System
 

--- a/docs/ROADMAP.zh.md
+++ b/docs/ROADMAP.zh.md
@@ -36,7 +36,7 @@
 | 5 | `getSelectedText()` API | `core` | P0 | done | 否 | 另含原子 `replaceRange()`（单条 undo）—— 见 `openspec/changes/add-selection-api` |
 | 6 | 多光标 / 多选支持 | `core` | P1 | done | 是 | `openspec/changes/add-core-multi-cursor` — opt-in `multiCursor` 配置；live-preview 揭示与表格检查已有回归测试覆盖 |
 | 7 | AST 增强 / Markdown 扩展 | `core` + `preset-gfm` | P2 | planned | 是 | 影响序列化与所有依赖 AST 的插件 |
-| 8 | undo / redo 分组 | `plugin-history` | P1 | planned | 否 | 注意与表格交互的 `tableEditingCount` 协同；合并前需收敛多个竞品实现 |
+| 8 | undo / redo 分组 | `plugin-history` | P1 | done | 否 | 可配置 `history()` 选项 + `forceHistoryBoundary` / `notInHistory` / `withHistoryControl`；silent `setDocument`/`replaceRange` 不进撤销栈。单元格 contentEditable 与文档撤销栈打通留作后续。 |
 
 ## 4. 插件系统
 

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -1,4 +1,4 @@
-import { Annotation, EditorSelection, EditorState } from "@codemirror/state";
+import { Annotation, EditorSelection, EditorState, Transaction } from "@codemirror/state";
 
 // Annotation attached to dispatches that load content programmatically (e.g.
 // setDocument from file open) so updateListener can skip the user-edit path —
@@ -430,7 +430,11 @@ export function createEditor(config: EditorConfig): EditorAPI {
         to: view.state.doc.length,
         insert: next
       },
-      annotations: silent ? silentDocChange.of(true) : undefined,
+      // Silent loads skip onChange *and* the undo stack — opening / syncing a
+      // file must not become a Ctrl+Z step that restores the previous buffer.
+      annotations: silent
+        ? [silentDocChange.of(true), Transaction.addToHistory.of(false)]
+        : undefined,
       ...(selection ? { selection } : {}),
     };
 
@@ -833,7 +837,9 @@ export function createEditor(config: EditorConfig): EditorAPI {
           ? { anchor: selection.anchor, head: selection.head ?? selection.anchor }
           : undefined,
         scrollIntoView: true,
-        annotations: silent ? silentDocChange.of(true) : undefined,
+        annotations: silent
+          ? [silentDocChange.of(true), Transaction.addToHistory.of(false)]
+          : undefined,
       });
       if (silent) {
         const next = view.state.doc.toString();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -207,9 +207,10 @@ export interface EditorAPI {
   /**
    * Replace the document content.
    *
-   * @param opts.silent  When true, skip the onChange pipeline. Use when
-   *   loading a file from disk — avoids treating a file-open as a user
-   *   edit (no redundant mdast parse / link-index rebuild).
+   * @param opts.silent  When true, skip the onChange pipeline **and** exclude
+   *   the transaction from the undo stack. Use when loading a file from disk —
+   *   avoids treating a file-open as a user edit (no redundant mdast parse /
+   *   link-index rebuild, and Ctrl+Z will not restore the previous buffer).
    *
    * 组合输入（IME）进行中时，整文档替换会打断输入法、丢失正在合成的文字
    * 并把视口重置到顶部。此时本次替换会延迟到 compositionend 再应用，只保留
@@ -230,10 +231,11 @@ export interface EditorAPI {
    * - `selection` is optional. When omitted CM6 maps the existing selection
    *   through the change using its default position mapping — callers that
    *   don't care where the cursor lands after the edit can skip this.
-   * - `silent` mirrors `setDocument`: skips `onChange` / the `change` event.
-   *   The AST is still resynced inline so `getAst()` stays consistent for
-   *   immediate callers. Intended for non-user edits only (file-open, seeding).
-   *   Plugin code should leave `silent` unset.
+   * - `silent` mirrors `setDocument`: skips `onChange` / the `change` event
+   *   **and** excludes the transaction from the undo stack. The AST is still
+   *   resynced inline so `getAst()` stays consistent for immediate callers.
+   *   Intended for non-user edits only (file-open, seeding). Plugin code
+   *   should leave `silent` unset.
    * - Positions (`from`, `to`, and `selection` offsets) are in pre-edit doc
    *   coordinates — the same coordinate space as `getSelection()` returns.
    * - Bounds: callers are responsible for valid offsets. CM6 throws

--- a/packages/core/test/editor.test.ts
+++ b/packages/core/test/editor.test.ts
@@ -173,6 +173,50 @@ describe("createEditor", () => {
     editor.destroy();
   });
 
+  it("silent setDocument does not create an undo entry", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "draft",
+      plugins: [createHistoryPlugin()]
+    });
+
+    editor.setDocument("opened from disk", { silent: true });
+    expect(editor.getDocument()).toBe("opened from disk");
+    // File-open must not become a Ctrl+Z step that restores the empty/previous buffer.
+    expect(editor.undo()).toBe(false);
+    expect(editor.getDocument()).toBe("opened from disk");
+    editor.destroy();
+  });
+
+  it("silent replaceRange does not erase prior undoable user edits from the stack", () => {
+    const container = document.createElement("div");
+    let capturedView: EditorView | null = null;
+    const editor = createEditor({
+      container,
+      initialValue: "hello",
+      plugins: [
+        createHistoryPlugin(),
+        {
+          name: "capture-view",
+          cmExtensions: [captureViewPlugin((view) => (capturedView = view))]
+        }
+      ]
+    });
+
+    const cm = requireEditorView(capturedView);
+    cm.dispatch({ changes: { from: 5, to: 5, insert: "!" } });
+    expect(editor.getDocument()).toBe("hello!");
+
+    // Silent host tweak must not be undoable itself; the earlier user
+    // insertion must still undo cleanly around it.
+    editor.replaceRange(0, 1, "H", undefined, { silent: true });
+    expect(editor.getDocument()).toBe("Hello!");
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("Hello");
+    editor.destroy();
+  });
+
   it("keeps the editor usable when the parser throws", () => {
     const container = document.createElement("div");
     const docs: string[] = [];
@@ -605,6 +649,21 @@ describe("createEditor", () => {
     expect(editor.undo()).toBe(true);
     expect(editor.getDocument()).toBe("hello world");
     expect(editor.undo()).toBe(false);
+    editor.destroy();
+  });
+
+  it("replaceRange: silent does not create an undo entry", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "hello world",
+      plugins: [createHistoryPlugin()]
+    });
+
+    editor.replaceRange(0, 5, "HELLO", undefined, { silent: true });
+    expect(editor.getDocument()).toBe("HELLO world");
+    expect(editor.undo()).toBe(false);
+    expect(editor.getDocument()).toBe("HELLO world");
     editor.destroy();
   });
 

--- a/packages/plugin-history/README.md
+++ b/packages/plugin-history/README.md
@@ -1,0 +1,105 @@
+# @floatboat/nexus-plugin-history
+
+Undo / redo for [Nexus-Editor](https://github.com/floatboatai/Nexus-Editor),
+backed by CodeMirror 6 `history()`.
+
+- **Keyboard** — `Ctrl/Cmd+Z`, `Ctrl/Cmd+Shift+Z` / `Ctrl+Y`
+- **Configurable grouping** — tune `newGroupDelay`, `minDepth`, or supply a
+  custom `joinToEvent` predicate
+- **Explicit boundaries** — `forceHistoryBoundary` / `withHistoryControl` so
+  toolbar commands and multi-step edits don't silently merge with typing
+- **Silent loads stay out of the stack** — core attaches
+  `Transaction.addToHistory.of(false)` on `{ silent: true }`
+  `setDocument` / `replaceRange` (file-open must never become Ctrl+Z)
+
+## Install
+
+```bash
+pnpm add @floatboat/nexus-plugin-history @floatboat/nexus-core
+```
+
+## Quick start
+
+```ts
+import { createEditor } from "@floatboat/nexus-core";
+import { createHistoryPlugin } from "@floatboat/nexus-plugin-history";
+
+const editor = createEditor({
+  container: document.getElementById("editor")!,
+  initialValue: "# Hello",
+  plugins: [
+    createHistoryPlugin({
+      // Start a new undo group after 300ms of idle typing (CM6 default: 500).
+      newGroupDelay: 300,
+      minDepth: 100
+    })
+  ]
+});
+
+editor.undo(); // also available via the keymap
+editor.redo();
+```
+
+## Grouping helpers
+
+Use these when a plugin dispatches its own CM6 transactions and needs
+deterministic undo behavior:
+
+```ts
+import {
+  forceHistoryBoundary,
+  notInHistory,
+  withHistoryControl
+} from "@floatboat/nexus-plugin-history";
+
+// Never record this transaction (host seeding, external sync).
+view.dispatch(
+  withHistoryControl(
+    { changes: { from: 0, to: 0, insert: "<!-- seeded -->\n" } },
+    { addToHistory: false }
+  )
+);
+
+// Force a hard undo-group boundary before a command runs.
+view.dispatch({
+  changes: { from, to, insert },
+  annotations: forceHistoryBoundary("before")
+});
+
+// Equivalent annotation constant:
+view.dispatch({
+  changes: { from, to, insert },
+  annotations: notInHistory
+});
+```
+
+### When to isolate vs. rely on `newGroupDelay`
+
+| Situation | Approach |
+|---|---|
+| Normal typing | Default time-based joining (`newGroupDelay`) |
+| Toolbar / slash command that must be one Ctrl+Z | Single transaction (e.g. `editor.replaceRange`) — preferred |
+| Multi-transaction command that must not merge with typing | `forceHistoryBoundary("before" \| "full")` |
+| File open / external sync | `setDocument(md, { silent: true })` or `notInHistory` |
+
+> **Tables:** cell typing is buffered in the live-preview widget and flushed
+> as one document transaction on blur — that flush is already one undo entry.
+> In-cell `Ctrl+Z` still uses the browser's contentEditable stack until blur;
+> unifying those stacks is intentionally out of scope for this plugin.
+
+## API
+
+| Export | Description |
+|---|---|
+| `createHistoryPlugin(options?)` | Returns a `NexusPlugin` installing CM6 history + keymap |
+| `HistoryPluginOptions` | `{ minDepth?, newGroupDelay?, joinToEvent? }` |
+| `notInHistory` | `Transaction.addToHistory.of(false)` annotation |
+| `forceHistoryBoundary(side?)` | `isolateHistory` annotation (`full` / `before` / `after`) |
+| `withHistoryControl(spec, control)` | Merge the above into a `TransactionSpec` |
+| `isolateHistory` / `historyKeymap` | Re-exports from `@codemirror/commands` |
+
+## Roadmap
+
+This package covers roadmap item **#8 — Undo / redo grouping**
+(`docs/ROADMAP.md`). Coordinating deeper table-cell ↔ document undo
+unification remains a follow-up.

--- a/packages/plugin-history/package.json
+++ b/packages/plugin-history/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.8.1",
+    "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.36.1",
     "@floatboat/nexus-core": "workspace:*"
   },

--- a/packages/plugin-history/src/index.ts
+++ b/packages/plugin-history/src/index.ts
@@ -1,11 +1,107 @@
-import { history, historyKeymap } from "@codemirror/commands";
+import { history, historyKeymap, isolateHistory } from "@codemirror/commands";
+import {
+  Transaction,
+  type Annotation,
+  type TransactionSpec
+} from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 
 import type { NexusPlugin } from "@floatboat/nexus-core";
 
-export function createHistoryPlugin(): NexusPlugin {
+/**
+ * Options forwarded to CodeMirror 6's `history()` extension.
+ *
+ * Use these to tune undo grouping without reaching into CM6 directly:
+ * - `newGroupDelay` — max gap (ms) between adjacent events that may still
+ *   join into one undo group. CM6 default is 500.
+ * - `minDepth` — minimum number of undo events retained.
+ * - `joinToEvent` — custom predicate for whether a transaction should join
+ *   the previous history event (advanced; most hosts can ignore this).
+ */
+export interface HistoryPluginOptions {
+  minDepth?: number;
+  newGroupDelay?: number;
+  joinToEvent?: (tr: Transaction, isAdjacent: boolean) => boolean;
+}
+
+/** Side of the current transaction at which to force a history boundary. */
+export type HistoryIsolate = "full" | "before" | "after";
+
+/**
+ * Annotation that excludes a transaction from the undo stack.
+ *
+ * Prefer this (or `withHistoryControl`) over inventing a second history
+ * mechanism. Core already attaches the equivalent annotation to silent
+ * `setDocument` / `replaceRange` loads.
+ */
+export const notInHistory: Annotation<boolean> = Transaction.addToHistory.of(false);
+
+/**
+ * Force an undo-group boundary around (or beside) a transaction.
+ *
+ * Typical use: a toolbar command that must never merge with adjacent typing,
+ * even when it lands inside `newGroupDelay`.
+ */
+export function forceHistoryBoundary(
+  side: HistoryIsolate = "full"
+): Annotation<"full" | "before" | "after"> {
+  return isolateHistory.of(side);
+}
+
+/**
+ * Merge history-control annotations into a `TransactionSpec`.
+ *
+ * Existing `annotations` on `spec` (single value or array) are preserved.
+ * When both `addToHistory: false` and `isolate` are set, both annotations
+ * are attached — CM6 honors `addToHistory` first, so the isolate is only
+ * meaningful when the transaction *is* recorded.
+ */
+export function withHistoryControl(
+  spec: TransactionSpec,
+  control: { addToHistory?: boolean; isolate?: HistoryIsolate }
+): TransactionSpec {
+  const extra: Annotation<unknown>[] = [];
+  if (control.addToHistory === false) {
+    extra.push(notInHistory);
+  }
+  if (control.isolate) {
+    extra.push(forceHistoryBoundary(control.isolate));
+  }
+  if (extra.length === 0) return spec;
+
+  const existing = spec.annotations;
+  const merged = existing
+    ? Array.isArray(existing)
+      ? [...existing, ...extra]
+      : [existing, ...extra]
+    : extra;
+
+  return { ...spec, annotations: merged };
+}
+
+/**
+ * Undo / redo plugin backed by CodeMirror 6 `history()`.
+ *
+ * Grouping policy:
+ * 1. Default CM6 time-based joining (`newGroupDelay`, default 500ms).
+ * 2. Callers that need a hard boundary use `forceHistoryBoundary` /
+ *    `withHistoryControl({ isolate })` on their dispatch.
+ * 3. Programmatic silent loads (`setDocument` / `replaceRange` with
+ *    `{ silent: true }`) are excluded from history by core — opening a
+ *    file must never become an undo step that erases the previous buffer.
+ */
+export function createHistoryPlugin(options: HistoryPluginOptions = {}): NexusPlugin {
+  const config: HistoryPluginOptions = {};
+  if (options.minDepth !== undefined) config.minDepth = options.minDepth;
+  if (options.newGroupDelay !== undefined) config.newGroupDelay = options.newGroupDelay;
+  if (options.joinToEvent !== undefined) config.joinToEvent = options.joinToEvent;
+
+  const hasConfig = Object.keys(config).length > 0;
+
   return {
     name: "plugin-history",
-    cmExtensions: [history(), keymap.of(historyKeymap)]
+    cmExtensions: [hasConfig ? history(config) : history(), keymap.of(historyKeymap)]
   };
 }
+
+export { isolateHistory, historyKeymap };

--- a/packages/plugin-history/test/plugin-history.test.ts
+++ b/packages/plugin-history/test/plugin-history.test.ts
@@ -1,6 +1,22 @@
+import { EditorView, ViewPlugin } from "@codemirror/view";
 import { createEditor } from "@floatboat/nexus-core";
 import { describe, expect, it } from "vitest";
-import { createHistoryPlugin } from "../src/index";
+import {
+  createHistoryPlugin,
+  forceHistoryBoundary,
+  notInHistory,
+  withHistoryControl
+} from "../src/index";
+
+function captureViewPlugin(onView: (view: EditorView) => void) {
+  return ViewPlugin.fromClass(
+    class {
+      constructor(readonly view: EditorView) {
+        onView(view);
+      }
+    }
+  );
+}
 
 describe("@floatboat/nexus-plugin-history", () => {
   it("undoes the most recent document change through codemirror key handling", () => {
@@ -60,5 +76,115 @@ describe("@floatboat/nexus-plugin-history", () => {
 
     expect(editor.getDocument()).toBe("next");
     editor.destroy();
+  });
+
+  it("accepts history grouping options without breaking undo/redo", () => {
+    const container = document.createElement("div");
+    const editor = createEditor({
+      container,
+      initialValue: "a",
+      plugins: [createHistoryPlugin({ newGroupDelay: 0, minDepth: 50 })]
+    });
+
+    editor.setDocument("b");
+    editor.setDocument("c");
+
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("b");
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("a");
+    expect(editor.redo()).toBe(true);
+    expect(editor.getDocument()).toBe("b");
+    editor.destroy();
+  });
+
+  it("notInHistory keeps a programmatic edit off the undo stack", () => {
+    const container = document.createElement("div");
+    let capturedView: EditorView | null = null;
+    const editor = createEditor({
+      container,
+      initialValue: "hello",
+      plugins: [
+        createHistoryPlugin(),
+        {
+          name: "capture-view",
+          cmExtensions: [captureViewPlugin((view) => (capturedView = view))]
+        }
+      ]
+    });
+
+    expect(capturedView).not.toBeNull();
+    const view = capturedView!;
+
+    // User-visible edit — must remain undoable.
+    view.dispatch({ changes: { from: 5, to: 5, insert: "!" } });
+    expect(editor.getDocument()).toBe("hello!");
+
+    // Host seeding that must not become its own undo step.
+    view.dispatch(
+      withHistoryControl({ changes: { from: 0, to: 1, insert: "H" } }, { addToHistory: false })
+    );
+    expect(editor.getDocument()).toBe("Hello!");
+
+    // Undo reverts the "!" insertion; the not-in-history capitalisation stays.
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("Hello");
+    expect(editor.undo()).toBe(false);
+    editor.destroy();
+  });
+
+  it("forceHistoryBoundary prevents adjacent transactions from joining", () => {
+    const container = document.createElement("div");
+    let capturedView: EditorView | null = null;
+    const editor = createEditor({
+      container,
+      initialValue: "x",
+      // Large delay would otherwise join the two edits below into one group.
+      plugins: [
+        createHistoryPlugin({ newGroupDelay: 60_000 }),
+        {
+          name: "capture-view",
+          cmExtensions: [captureViewPlugin((view) => (capturedView = view))]
+        }
+      ]
+    });
+
+    expect(capturedView).not.toBeNull();
+    const view = capturedView!;
+
+    view.dispatch({
+      changes: { from: 0, to: 1, insert: "y" },
+      userEvent: "input.type"
+    });
+    view.dispatch({
+      changes: { from: 0, to: 1, insert: "z" },
+      userEvent: "input.type",
+      annotations: forceHistoryBoundary("before")
+    });
+
+    expect(editor.getDocument()).toBe("z");
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("y");
+    expect(editor.undo()).toBe(true);
+    expect(editor.getDocument()).toBe("x");
+    editor.destroy();
+  });
+
+  it("withHistoryControl preserves pre-existing annotations", () => {
+    const marker = notInHistory;
+    const spec = withHistoryControl(
+      { changes: { from: 0, to: 0, insert: "a" }, annotations: marker },
+      { isolate: "after" }
+    );
+    const annotations = Array.isArray(spec.annotations)
+      ? spec.annotations
+      : [spec.annotations];
+    expect(annotations).toHaveLength(2);
+    expect(annotations.some((a) => a === marker)).toBe(true);
+    expect(annotations.some((a) => a != null && a.value === "after")).toBe(true);
+  });
+
+  it("exposes notInHistory as Transaction.addToHistory(false)", () => {
+    expect(notInHistory.value).toBe(false);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@codemirror/commands':
         specifier: ^6.8.1
         version: 6.10.3
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
       '@codemirror/view':
         specifier: ^6.36.1
         version: 6.41.0
@@ -977,66 +980,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}


### PR DESCRIPTION
## Summary / 摘要

Implements roadmap **#8 — Undo / redo grouping**: configurable CM6 history options, explicit group-boundary helpers, and silent `setDocument` / `replaceRange` exclusion from the undo stack.

## Motivation / 背景与动机

- Issue: n/a (open-ended contribution against `docs/ROADMAP.md`)
- Roadmap (docs/ROADMAP.md): **#8 Undo / redo grouping** (P1)
- OpenSpec change: not required (roadmap marks Needs OpenSpec = No; no new capability / breaking API)

Hosts previously had no first-class way to tune undo grouping or keep file-open / external sync out of Ctrl+Z. `plugin-history` was a bare `history()` wrapper, while silent loads only suppressed `onChange` — they still polluted the undo stack.

## Changes / 变更内容

- `packages/plugin-history`:
  - `createHistoryPlugin({ minDepth?, newGroupDelay?, joinToEvent? })`
  - Helpers: `notInHistory`, `forceHistoryBoundary()`, `withHistoryControl()`
  - Re-exports `isolateHistory` / `historyKeymap`
  - New package README + expanded unit tests
- `packages/core`:
  - Silent `setDocument` / `replaceRange` attach `Transaction.addToHistory.of(false)`
  - Docs on `EditorAPI` updated to match
  - Regression tests for silent-load undo behavior
- `docs/ROADMAP.md` (+ `.zh.md`), root README: mark #8 done / refresh package blurb

## Testing / 测试

- [x] `pnpm test` passes / 全绿 (545 tests)
- [x] Affected packages build (`pnpm build`) / `@floatboat/nexus-core` + `@floatboat/nexus-plugin-history` build
- [x] New / updated vitest cases / 新增或更新的 vitest 用例：
  - history options still undo/redo correctly
  - `notInHistory` skips the undo stack while preserving earlier user edits
  - `forceHistoryBoundary` splits groups even with a large `newGroupDelay`
  - silent `setDocument` / `replaceRange` do not create undo entries
- [ ] Manual UI check in electron-demo / electron-demo 手动验证：API-level change; demo already uses `createHistoryPlugin()` with defaults

## Compliance / 合规自检

- [x] **CLA signed** — first-time contributors will be prompted automatically by the CLA bot / 首次贡献者按 CLA 机器人提示签署
- [x] **AI disclosure**: Used AI tools for codebase navigation and CM6 history API lookup. Implementation, tests, and PR description were reviewed and validated locally (`pnpm test`, 545 passed) before submit.
      AI-assisted notes / AI 使用说明：
      AI 辅助阅读代码库与 CM6 history 文档；功能范围、bug 定位、测试设计与最终实现由本人 review 并本地验证。
- [x] **New dependencies** (if any) listed with license & rationale:
      - `@codemirror/state@^6.6.0` — MIT — required to type/export `Transaction` / `Annotation` helpers in `plugin-history` (already used transitively via CM6; now a direct dependency)
- [x] **No build artifacts** committed (`dist/`, `dist-electron/`, compiled `.js` from `.ts`) / 未提交构建产物
- [x] **No secrets** / `.env` / personal vault data committed / 无敏感信息

## Checklist / 自检清单

- [x] Title follows Conventional Commits / 标题遵循 Conventional Commits
- [x] Public API changes update package README / types — 改了公共 API 已同步 README 与类型
- [x] Touched `live-preview-table.ts` → N/A (not modified)
- [x] New capability / breaking change → OpenSpec proposal linked / N/A (additive, non-breaking; roadmap says no OpenSpec)
- [x] Change aligns with project scope (GOVERNANCE.md §4) / 改动符合 GOVERNANCE.md §4 的项目范围

## Screenshots / Recordings · 截图或录屏 (UI changes)

N/A — headless API / history semantics only.
